### PR TITLE
Transform vote checkboxes into table

### DIFF
--- a/.github/ISSUE_TEMPLATE/agents-poll.md
+++ b/.github/ISSUE_TEMPLATE/agents-poll.md
@@ -10,10 +10,12 @@ labels: agents, poll
 
 ## Vote
 
-* [ ] .NET 
-* [ ] Go 
-* [ ] Java
-* [ ] Node.js
-* [ ] Python
-* [ ] Ruby 
-* [ ] RUM
+| Yes | No | `¯\(ツ)/¯` | N/A |        |
+|-----|----|------------|-----|--------|
+|     |    |            |     | .NET   |
+|     |    |            |     | Go     |
+|     |    |            |     | Java   |
+|     |    |            |     | Node.js|
+|     |    |            |     | Python |
+|     |    |            |     | Ruby   |
+|     |    |            |     | RUM    |


### PR DESCRIPTION
This makes it clearer if there is input missing, an agent explicitly voted "no",
they have no strong opinion or if the issue is not applicable to a specific agent.

You vote by putting an `x` in the table. Unfortunately, checkboxes in tables don't work.