### PR TITLE
docs: unescape systemd cgroup paths

### DIFF
--- a/docs/agent-development.md
+++ b/docs/agent-development.md
@@ -157,7 +157,8 @@ On Linux, the container ID and some of the Kubernetes metadata can be extracted 
      - `(?:^/kubepods/[^/]+/pod([^/]+)/$)`
      - `(?:^/kubepods\.slice/kubepods-[^/]+\.slice/kubepods-[^/]+-pod([^/]+)\.slice/$)`
 
-    The capturing group in either case is the pod UID. If we match a pod UID then we record the hostname as the pod name since, by default, Kubernetes will set the hostname to the pod name. Finally, we record the basename as the container ID without any further checks.
+    The capturing group in either case is the pod UID. In the latter case, which occurs when using the systemd cgroup driver, we must unescape underscores (`_`) to hyphens (`-`) in the pod UID.
+    If we match a pod UID then we record the hostname as the pod name since, by default, Kubernetes will set the hostname to the pod name. Finally, we record the basename as the container ID without any further checks.
 
  4. If we did not match a Kubernetes pod UID above, then we check if the basename matches one of the following regular expressions:
 


### PR DESCRIPTION
When the systemd cgroup driver is used,
cgroup paths will have hyphens (e.g. in pod UIDs)
escaped to underscores. When we're parsing
cgroups, we must therefore unescape them.

See:
 - https://github.com/elastic/apm-agent-java/pull/920
- https://github.com/kubernetes/kubernetes/blob/6d0994fa66e34db874e4e26c86b55ba34e75d1c1/pkg/kubelet/cm/cgroup_manager_linux.go#L86