### PR TITLE
Proposal to improve gherkin API key spec

### DIFF
--- a/tests/agents/gherkin-specs/api_key.feature
+++ b/tests/agents/gherkin-specs/api_key.feature
@@ -7,12 +7,12 @@ Feature: Api Key
 
   Scenario: A configured api key takes precedence over a secret token
     Given an agent
-    When an api key is set in the config
-    And a secret_token is set in the config
-    Then the api key is sent in the Authorization header
+    When an api key is set to 'MjlXNEJasdfDt' in the config
+    And a secret_token is set to 'secr3tT0ken' in the config
+    Then the Authorization header is 'ApiKey MjlXNEJasdfDt'
 
   Scenario: A configured secret token is sent if no api key is configured
     Given an agent
-    When a secret_token is set in the config
+    When a secret_token is set to 'secr3tT0ken' in the config
     And an api key is not set in the config
-    Then the secret token is sent in the Authorization header
+    Then the Authorization header is 'Bearer secr3tT0ken'


### PR DESCRIPTION
- provide explicit values for `secret_token` and `api_key`
- single `Then` statement for expected result

This is a minor improvement on the spec, but makes test implementation less verbose and with less assumptions, for example the expected behavior regarding `secret_token` current behavior is not really specified.

This should only impact test implementation, not production code.