### PR TITLE
Unify fetching the BDD feature files in one single repository

### DIFF
--- a/scripts/download_gherkin_features.bat
+++ b/scripts/download_gherkin_features.bat
@@ -1,0 +1,12 @@
+: Adding gherkin feature download for windows
+@echo off
+SET TMP_FOLDER=.\tests\tempFeatures
+SET FOLDER=.\tests\bdd\features
+SET APM_BRANCH=master
+
+mkdir %TMP_FOLDER%
+curl -s https://codeload.github.com/elastic/apm/zip/%APM_BRANCH% -o %TMP_FOLDER%\features.zip
+7z x %TMP_FOLDER%\features.zip -o%TMP_FOLDER% *.feature -y -r
+mkdir %FOLDER%
+xcopy %TMP_FOLDER%\apm-master\tests\agents\gherkin-specs\* %FOLDER% /Y /S /Q
+del %TMP_FOLDER%\ /F /Q /S 1>nul

--- a/scripts/download_gherkin_features.bat
+++ b/scripts/download_gherkin_features.bat
@@ -1,7 +1,8 @@
 : Adding gherkin feature download for windows
 @echo off
 SET TMP_FOLDER=.\tests\tempFeatures
-SET FOLDER=.\tests\bdd\features
+SET "FOLDER=%1"
+IF "%FOLDER%"=="" SET /P "FOLDER=.\tests\bdd\features"
 SET APM_BRANCH=master
 
 mkdir %TMP_FOLDER%

--- a/scripts/download_gherkin_features.sh
+++ b/scripts/download_gherkin_features.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -ex
+
+download_gherkin()
+{
+    rm -rf ${1} && mkdir -p ${1}
+    for run in 1 2 3 4 5
+    do
+        if [ -x "$(command -v gtar)" ]; then
+            curl --silent --fail https://codeload.github.com/elastic/apm/tar.gz/${2} | gtar xzvf - --wildcards --directory=${1} --strip-components=4 "*/tests/agents/gherkin-specs*"
+        else
+            curl --silent --fail https://codeload.github.com/elastic/apm/tar.gz/${2} | tar xzvf - --wildcards --directory=${1} --strip-components=4 "*tests/agents/gherkin-specs*"
+        fi
+        result=$?
+        if [ $result -eq 0 ]; then break; fi
+        sleep 1
+    done
+
+    if [ $result -ne 0 ]; then exit $result; fi
+
+}
+
+# parent directory
+basedir=$(dirname "$0")/..
+
+
+download_gherkin ${basedir}/bdd/features master
+
+echo "Done."

--- a/scripts/download_gherkin_features.sh
+++ b/scripts/download_gherkin_features.sh
@@ -8,9 +8,9 @@ download_gherkin()
     for run in 1 2 3 4 5
     do
         if [ -x "$(command -v gtar)" ]; then
-            curl --silent --fail https://codeload.github.com/elastic/apm/tar.gz/${2} | gtar xzvf - --wildcards --directory=${1} --strip-components=4 "*/tests/agents/gherkin-specs*"
+            curl --silent --fail https://codeload.github.com/elastic/apm/tar.gz/${2} | gtar xzvf - --directory=${1} --strip-components=4 "*/tests/agents/gherkin-specs*"
         else
-            curl --silent --fail https://codeload.github.com/elastic/apm/tar.gz/${2} | tar xzvf - --wildcards --directory=${1} --strip-components=4 "*tests/agents/gherkin-specs*"
+            curl --silent --fail https://codeload.github.com/elastic/apm/tar.gz/${2} | tar xzvf - --directory=${1} --strip-components=4 "*tests/agents/gherkin-specs*"
         fi
         result=$?
         if [ $result -eq 0 ]; then break; fi

--- a/scripts/download_gherkin_features.sh
+++ b/scripts/download_gherkin_features.sh
@@ -23,8 +23,8 @@ download_gherkin()
 
 # parent directory
 basedir=$(dirname "$0")/..
+targetdir="${1:-"bdd/features"}"
 
-
-download_gherkin ${basedir}/bdd/features master
+download_gherkin ${basedir}/${targetdir} master
 
 echo "Done."


### PR DESCRIPTION
## What does this PR do?
It copies the scripts already present in the Python agent repo for [Linux](https://github.com/elastic/apm-agent-python/blob/master/tests/scripts/download_gherkin_features.sh) and [Windows](https://github.com/elastic/apm-agent-python/blob/master/tests/scripts/download_gherkin_features.bat)

Besides that, we added support to change the directory where to put the downloaded files.

## Why is it important?
We want to unify the way we fetch these files, so each APM agent would download it in a common and shared way.

## Follow-ups
- Remove original scripts from Python agent
- In each APM Agent repo: add a simple script that fetches the new scripts (cross-platform: i.e. with curl/wget), executing them to extract the feature files