### PR TITLE
chore: improve download scripts

### DIFF
--- a/scripts/download_gherkin_features.bat
+++ b/scripts/download_gherkin_features.bat
@@ -3,7 +3,8 @@
 SET TMP_FOLDER=.\tests\tempFeatures
 SET "FOLDER=%1"
 IF "%FOLDER%"=="" SET /P "FOLDER=.\tests\bdd\features"
-SET APM_BRANCH=master
+SET "APM_BRANCH=%2%"
+IF "%APM_BRANCH%"=="" SET /P "APM_BRANCH=master"
 
 mkdir %TMP_FOLDER%
 curl -s https://codeload.github.com/elastic/apm/zip/%APM_BRANCH% -o %TMP_FOLDER%\features.zip

--- a/scripts/download_gherkin_features.sh
+++ b/scripts/download_gherkin_features.sh
@@ -8,9 +8,9 @@ download_gherkin()
     for run in 1 2 3 4 5
     do
         if [ -x "$(command -v gtar)" ]; then
-            curl --silent --fail https://codeload.github.com/elastic/apm/tar.gz/${2} | gtar xzvf - --directory=${1} --strip-components=4 "*/tests/agents/gherkin-specs*"
+            curl --silent --fail https://codeload.github.com/elastic/apm/tar.gz/${2} | gtar xzvf - --wildcards --directory=${1} --strip-components=4 "*/tests/agents/gherkin-specs*"
         else
-            curl --silent --fail https://codeload.github.com/elastic/apm/tar.gz/${2} | tar xzvf - --directory=${1} --strip-components=4 "*tests/agents/gherkin-specs*"
+            curl --silent --fail https://codeload.github.com/elastic/apm/tar.gz/${2} | tar xzvf - --wildcards --directory=${1} --strip-components=4 "*tests/agents/gherkin-specs*"
         fi
         result=$?
         if [ $result -eq 0 ]; then break; fi

--- a/scripts/download_gherkin_features.sh
+++ b/scripts/download_gherkin_features.sh
@@ -4,13 +4,18 @@ set -ex
 
 download_gherkin()
 {
+    wildcardFlag="--wildcards"
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        wildcardFlag=""
+    fi
+
     rm -rf ${1} && mkdir -p ${1}
     for run in 1 2 3 4 5
     do
         if [ -x "$(command -v gtar)" ]; then
-            curl --silent --fail https://codeload.github.com/elastic/apm/tar.gz/${2} | gtar xzvf - --wildcards --directory=${1} --strip-components=4 "*/tests/agents/gherkin-specs*"
+            curl --silent --fail https://codeload.github.com/elastic/apm/tar.gz/${2} | gtar xzvf - ${wildcardFlag} --directory=${1} --strip-components=4 "*/tests/agents/gherkin-specs*"
         else
-            curl --silent --fail https://codeload.github.com/elastic/apm/tar.gz/${2} | tar xzvf - --wildcards --directory=${1} --strip-components=4 "*tests/agents/gherkin-specs*"
+            curl --silent --fail https://codeload.github.com/elastic/apm/tar.gz/${2} | tar xzvf - ${wildcardFlag} --directory=${1} --strip-components=4 "*tests/agents/gherkin-specs*"
         fi
         result=$?
         if [ $result -eq 0 ]; then break; fi

--- a/scripts/download_gherkin_features.sh
+++ b/scripts/download_gherkin_features.sh
@@ -24,7 +24,8 @@ download_gherkin()
 # parent directory
 basedir=$(dirname "$0")/..
 targetdir="${1:-"bdd/features"}"
+branch="${2:-"master"}"
 
-download_gherkin ${basedir}/${targetdir} master
+download_gherkin ${basedir}/${targetdir} ${branch}
 
 echo "Done."

--- a/scripts/download_gherkin_features.sh
+++ b/scripts/download_gherkin_features.sh
@@ -22,7 +22,7 @@ download_gherkin()
 }
 
 # parent directory
-basedir=$(dirname "$0")/..
+basedir=$(dirname "$0")
 targetdir="${1:-"bdd/features"}"
 branch="${2:-"master"}"
 


### PR DESCRIPTION
## What is this PR doing?
It does not move up in the filesystem from the location of the caller of this script, adding the branch as an input variable, with "master" as default value.

It also adds back the `wildcards` TAR flag, but only for linux.

## Why is it important?
We want to avoid moving to a non-exist path, i.e. inside a Docker container.