### PR TITLE
Jenkins pipeline for sending PRs to agents when changing the BDD specs

### DIFF
--- a/.ci/.jenkins-agents.yml
+++ b/.ci/.jenkins-agents.yml
@@ -1,0 +1,6 @@
+---
+agents:
+  - NAME: "python"
+    FEATURES_PATH: "tests/bdd/features"
+  - NAME: "ruby"
+    FEATURES_PATH: "features"

--- a/.ci/.jenkins-agents.yml
+++ b/.ci/.jenkins-agents.yml
@@ -1,5 +1,11 @@
 ---
 agents:
+  - NAME: "dotnet"
+    FEATURES_PATH: "test/Elastic.Apm.Feature.Tests/Features"
+  - NAME: "go"
+    FEATURES_PATH: "features"
+  - NAME: "java"
+    FEATURES_PATH: "apm-agent-core/src/test/resources/specs"
   - NAME: "python"
     FEATURES_PATH: "tests/bdd/features"
   - NAME: "ruby"

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -15,11 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import groovy.transform.Field
-
 @Library('apm@current') _
-
-@Field def results = [:]
 
 pipeline {
   agent none

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -1,0 +1,64 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import groovy.transform.Field
+
+@Library('apm@current') _
+
+@Field def results = [:]
+
+pipeline {
+  agent { label 'immutable && docker' }
+  environment {
+    REPO = 'apm'
+    BASE_DIR = "src/github.com/elastic/${env.REPO}"
+    NOTIFY_TO = credentials('notify-to')
+    JOB_GCS_BUCKET = credentials('gcs-bucket')
+    PIPELINE_LOG_LEVEL='INFO'
+  }
+  options {
+    timeout(time: 3, unit: 'HOURS')
+    buildDiscarder(logRotator(numToKeepStr: '5', artifactNumToKeepStr: '5'))
+    timestamps()
+    ansiColor('xterm')
+    disableResume()
+    durabilityHint('PERFORMANCE_OPTIMIZED')
+  }
+  stages {
+    stage('Send Pull Request with APM specs to the APM Agents'){
+      options {
+        skipDefaultCheckout()
+        warnError('Pull Requests to APM agents failed')
+      }
+      when{
+        beforeAgent true
+      }
+      steps {
+        deleteDir()
+        checkout scm
+        dir("${BASE_DIR}"){
+          sh(label: 'Test Docker containers', script: '.ci/scripts/send-pr.sh python')
+        }
+      }
+    }
+  }
+  post {
+    cleanup {
+      notifyBuildResult()
+    }
+  }
+}

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -45,7 +45,6 @@ pipeline {
       options { skipDefaultCheckout() }
       stages {
         stage('Checkout'){
-          options { skipDefaultCheckout() }
           steps {
             deleteDir()
             gitCheckout(basedir: "${BASE_DIR}",
@@ -95,16 +94,14 @@ def generateStepForAgent(Map params = [:]){
   log(level: 'INFO', text: "agent=${agent} featuresPath=${featuresPath}")
   return {
     node('linux && immutable') {
-      try {
-        deleteDir()
-        unstash 'source'
-        dir("${BASE_DIR}"){
-          sh script: '.ci/scripts/install-dependencies.sh', label: "Install dependencies"
-          sh script: """.ci/scripts/send-pr.sh "${agent}" "${featuresPath}" """, label: "Send Pull Request for apm-agent-${agent}"
-        }
-      } catch(e) {
-        error(e.toString())
-      }
+      catchError(buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
+          deleteDir()
+          unstash 'source'
+            dir("${BASE_DIR}"){
+              sh script: '.ci/scripts/install-dependencies.sh', label: "Install dependencies"
+              sh script: """.ci/scripts/send-pr.sh "${agent}" "${featuresPath}" """, label: "Send Pull Request for apm-agent-${agent}"
+            }
+          }
     }
   }
 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -96,6 +96,8 @@ def generateStepForAgent(Map params = [:]){
     node('linux && immutable') {
       catchError(buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
           deleteDir()
+          gitCmd(cmd: "config", credentialsId: '', args: '--global user.name elasticmachine')
+          gitCmd(cmd: "config", credentialsId: '', args: '--global user.email infra-root-elasticmachine@elastic.co')
           unstash 'source'
             dir("${BASE_DIR}"){
               sh script: '.ci/scripts/install-dependencies.sh', label: "Install dependencies"

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -55,7 +55,7 @@ pipeline {
             stash allowEmpty: true, name: 'source', useDefaultExcludes: false
           }
         }
-        stage('Send Pull Request with APM specs to the APM Agents'){
+        stage('Send Pull Request'){
           options {
             skipDefaultCheckout()
             warnError('Pull Requests to APM agents failed')

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -22,7 +22,7 @@ import groovy.transform.Field
 @Field def results = [:]
 
 pipeline {
-  agent { label 'immutable && docker' }
+  agent none
   environment {
     REPO = 'apm'
     BASE_DIR = "src/github.com/elastic/${env.REPO}"
@@ -40,6 +40,7 @@ pipeline {
   }
   stages {
     stage('Send Pull Request with APM specs to the APM Agents'){
+      agent { label 'immutable && docker' }
       options {
         skipDefaultCheckout()
         warnError('Pull Requests to APM agents failed')

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -107,15 +107,15 @@ def generateStepForAgent(Map params = [:]){
   return {
     node('linux && immutable') {
       catchError(buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
-          deleteDir()
-          gitCmd(cmd: "config", credentialsId: '', args: '--global user.name elasticmachine')
-          gitCmd(cmd: "config", credentialsId: '', args: '--global user.email infra-root-elasticmachine@elastic.co')
-          unstash 'source'
-            dir("${BASE_DIR}"){
-              sh script: '.ci/scripts/install-dependencies.sh', label: "Install dependencies"
-              sh script: """.ci/scripts/send-pr.sh "${agent}" "${featuresPath}" """, label: "Send Pull Request for apm-agent-${agent}"
-            }
-          }
+        deleteDir()
+        gitCmd(cmd: "config", credentialsId: '', args: '--global user.name elasticmachine')
+        gitCmd(cmd: "config", credentialsId: '', args: '--global user.email infra-root-elasticmachine@elastic.co')
+        unstash 'source'
+        dir("${BASE_DIR}"){
+          sh script: '.ci/scripts/install-dependencies.sh', label: "Install dependencies"
+          sh script: """.ci/scripts/send-pr.sh "${agent}" "${featuresPath}" """, label: "Send Pull Request for apm-agent-${agent}"
+        }
+      }
     }
   }
 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -39,17 +39,45 @@ pipeline {
     durabilityHint('PERFORMANCE_OPTIMIZED')
   }
   stages {
-    stage('Send Pull Request with APM specs to the APM Agents'){
-      agent { label 'immutable && docker' }
-      options {
-        skipDefaultCheckout()
-        warnError('Pull Requests to APM agents failed')
+    stage('Initializing'){
+      agent { label 'linux && immutable' }
+      options { skipDefaultCheckout() }
+      environment {
+        HOME = "${env.WORKSPACE}"
+        PATH = "${env.PATH}:${env.WORKSPACE}/bin:${env.WORKSPACE}/${env.BASE_DIR}/.ci/scripts"
       }
-      steps {
-        deleteDir()
-        dir("${BASE_DIR}"){
-          checkout scm
-          sh(label: 'Send Pull Request', script: '.ci/scripts/send-pr.sh python')
+      stages {
+        stage('Checkout'){
+          agent { label 'immutable && docker' }
+          options { skipDefaultCheckout() }
+          steps {
+            deleteDir()
+            dir("${BASE_DIR}"){
+              checkout scm
+              stash allowEmpty: true, name: 'source', useDefaultExcludes: false
+            }
+          }
+        }
+        stage('Send Pull Request with APM specs to the APM Agents'){
+          agent { label 'immutable && docker' }
+          options {
+            skipDefaultCheckout()
+            warnError('Pull Requests to APM agents failed')
+          }
+          steps {
+            unstash 'source'
+            dir("${BASE_DIR}"){
+              script {
+                def agents = readYaml(file: '.ci/.jenkins-agents.yml')
+                def parallelTasks = [:]
+                agents['agents'].each { agent ->
+                  parallelTasks["apm-agent-${agent.NAME}"] = generateStepForAgent(agent: "${agent.NAME}", featuresPath: "${agent.FEATURES_PATH}")
+                }
+
+                parallel(parallelTasks)
+              }
+            }
+          }
         }
       }
     }
@@ -57,6 +85,25 @@ pipeline {
   post {
     cleanup {
       notifyBuildResult()
+    }
+  }
+}
+
+def generateStepForAgent(Map params = [:]){
+  def agent = params.get('agent')
+  def featuresPath = params.get('featuresPath')
+  log(level: 'INFO', text: "agent=${agent} featuresPath=${featuresPath}")
+  return {
+    node('linux && immutable') {
+      try {
+        deleteDir()
+        dir("${BASE_DIR}"){
+          unstash 'source'
+          sh script: """.ci/scripts/send-pr.sh "${agent}" "${featuresPath}" """, label: "Send Pull Request for apm-agent-${agent}"
+        }
+      } catch(e) {
+        error(e.toString())
+      }
     }
   }
 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -39,7 +39,7 @@ pipeline {
       options { skipDefaultCheckout() }
       environment {
         HOME = "${env.WORKSPACE}"
-        PATH = "${env.PATH}:${env.WORKSPACE}/bin:${env.WORKSPACE}/${env.BASE_DIR}/.ci/scripts"
+        PATH = "${env.PATH}:${env.WORKSPACE}/bin"
       }
       stages {
         stage('Checkout'){

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -45,9 +45,6 @@ pipeline {
         skipDefaultCheckout()
         warnError('Pull Requests to APM agents failed')
       }
-      when{
-        beforeAgent true
-      }
       steps {
         deleteDir()
         checkout scm

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -53,6 +53,14 @@ pipeline {
               credentialsId: "${JOB_GIT_CREDENTIALS}"
             )
             stash allowEmpty: true, name: 'source', useDefaultExcludes: false
+            script {
+              dir("${BASE_DIR}"){
+                def regexps =[
+                  "^tests/agents/gherkin-specs/"
+                ]
+                env.GHERKIN_SPECS_UPDATED = isGitRegionMatch(patterns: regexps)
+              }
+            }
           }
         }
         stage('Send Pull Request'){
@@ -62,6 +70,10 @@ pipeline {
           }
           environment {
             DO_SEND_PR = "${params.Do_Send_PR}"
+          }
+          when {
+            beforeAgent true
+            expression { return env.GHERKIN_SPECS_UPDATED != "false" }
           }
           steps {
             unstash 'source'

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -22,9 +22,11 @@ pipeline {
   environment {
     REPO = 'apm'
     BASE_DIR = "src/github.com/elastic/${env.REPO}"
+    HOME = "${env.WORKSPACE}"
     NOTIFY_TO = credentials('notify-to')
     JOB_GCS_BUCKET = credentials('gcs-bucket')
     JOB_GIT_CREDENTIALS = "f6c7695a-671e-4f4f-a331-acdce44ff9ba"
+    PATH = "${env.PATH}:${env.WORKSPACE}/bin"
     PIPELINE_LOG_LEVEL='INFO'
   }
   options {
@@ -35,13 +37,12 @@ pipeline {
     disableResume()
     durabilityHint('PERFORMANCE_OPTIMIZED')
   }
+  parameters {
+    booleanParam(name: 'Do_Send_PR', defaultValue: false, description: 'Allows to execute this pipeline in dry run mode, without sending a PR.')
+  }
   stages {
     stage('Initializing'){
       options { skipDefaultCheckout() }
-      environment {
-        HOME = "${env.WORKSPACE}"
-        PATH = "${env.PATH}:${env.WORKSPACE}/bin"
-      }
       stages {
         stage('Checkout'){
           options { skipDefaultCheckout() }
@@ -59,6 +60,9 @@ pipeline {
           options {
             skipDefaultCheckout()
             warnError('Pull Requests to APM agents failed')
+          }
+          environment {
+            DO_SEND_PR = "${params.Do_Send_PR}"
           }
           steps {
             unstash 'source'

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -24,6 +24,7 @@ pipeline {
     BASE_DIR = "src/github.com/elastic/${env.REPO}"
     NOTIFY_TO = credentials('notify-to')
     JOB_GCS_BUCKET = credentials('gcs-bucket')
+    JOB_GIT_CREDENTIALS = "f6c7695a-671e-4f4f-a331-acdce44ff9ba"
     PIPELINE_LOG_LEVEL='INFO'
   }
   options {
@@ -46,10 +47,12 @@ pipeline {
           options { skipDefaultCheckout() }
           steps {
             deleteDir()
-            dir("${BASE_DIR}"){
-              checkout scm
-              stash allowEmpty: true, name: 'source', useDefaultExcludes: false
-            }
+            gitCheckout(basedir: "${BASE_DIR}",
+              branch: "master",
+              repo: "git@github.com:elastic/${REPO}.git",
+              credentialsId: "${JOB_GIT_CREDENTIALS}"
+            )
+            stash allowEmpty: true, name: 'source', useDefaultExcludes: false
           }
         }
         stage('Send Pull Request with APM specs to the APM Agents'){

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -93,8 +93,8 @@ def generateStepForAgent(Map params = [:]){
     node('linux && immutable') {
       try {
         deleteDir()
+        unstash 'source'
         dir("${BASE_DIR}"){
-          unstash 'source'
           sh script: '.ci/scripts/install-dependencies.sh', label: "Install dependencies"
           sh script: """.ci/scripts/send-pr.sh "${agent}" "${featuresPath}" """, label: "Send Pull Request for apm-agent-${agent}"
         }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -99,6 +99,7 @@ def generateStepForAgent(Map params = [:]){
         deleteDir()
         dir("${BASE_DIR}"){
           unstash 'source'
+          sh script: '.ci/scripts/install-dependencies.sh', label: "Install dependencies"
           sh script: """.ci/scripts/send-pr.sh "${agent}" "${featuresPath}" """, label: "Send Pull Request for apm-agent-${agent}"
         }
       } catch(e) {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -18,7 +18,7 @@
 @Library('apm@current') _
 
 pipeline {
-  agent none
+   agent { label 'linux && immutable' }
   environment {
     REPO = 'apm'
     BASE_DIR = "src/github.com/elastic/${env.REPO}"
@@ -36,7 +36,6 @@ pipeline {
   }
   stages {
     stage('Initializing'){
-      agent { label 'linux && immutable' }
       options { skipDefaultCheckout() }
       environment {
         HOME = "${env.WORKSPACE}"
@@ -44,7 +43,6 @@ pipeline {
       }
       stages {
         stage('Checkout'){
-          agent { label 'immutable && docker' }
           options { skipDefaultCheckout() }
           steps {
             deleteDir()
@@ -55,7 +53,6 @@ pipeline {
           }
         }
         stage('Send Pull Request with APM specs to the APM Agents'){
-          agent { label 'immutable && docker' }
           options {
             skipDefaultCheckout()
             warnError('Pull Requests to APM agents failed')

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -47,9 +47,9 @@ pipeline {
       }
       steps {
         deleteDir()
-        checkout scm
         dir("${BASE_DIR}"){
-          sh(label: 'Test Docker containers', script: '.ci/scripts/send-pr.sh python')
+          checkout scm
+          sh(label: 'Send Pull Request', script: '.ci/scripts/send-pr.sh python')
         }
       }
     }

--- a/.ci/scripts/install-dependencies.sh
+++ b/.ci/scripts/install-dependencies.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -uexo pipefail
+
+HOME=${HOME}
+readonly HUB_VERSION="2.14.2"
+readonly HUB_CMD="${HOME}/bin/hub"
+
+# install GitHub's hub
+curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s ${HUB_VERSION}
+mkdir -p ${HUB_CMD}
+mv bin/hub ${HUB_CMD}

--- a/.ci/scripts/install-dependencies.sh
+++ b/.ci/scripts/install-dependencies.sh
@@ -3,9 +3,9 @@
 set -uexo pipefail
 
 readonly HUB_VERSION="2.14.2"
-readonly HUB_CMD="${HOME}/bin/hub"
+readonly HUB_CMD="${HOME}/bin"
 
 # install GitHub's hub
 curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s ${HUB_VERSION}
 mkdir -p ${HUB_CMD}
-mv bin/hub ${HUB_CMD}
+mv bin/hub "${HUB_CMD}/hub"

--- a/.ci/scripts/install-dependencies.sh
+++ b/.ci/scripts/install-dependencies.sh
@@ -2,7 +2,6 @@
 
 set -uexo pipefail
 
-HOME=${HOME}
 readonly HUB_VERSION="2.14.2"
 readonly HUB_CMD="${HOME}/bin/hub"
 

--- a/.ci/scripts/send-pr.sh
+++ b/.ci/scripts/send-pr.sh
@@ -18,7 +18,7 @@ git checkout -b update-feature-files-$(date "+%Y%m%d%H%M%S")
 echo "Copying feature files to the ${APM_AGENT_REPO_NAME} repo"
 git status
 git add ${APM_AGENT_SPECS_DIR}
-git commit -m "ci: Synchronized BDD specs"
+git commit -m "test: synchronizing bdd specs"
 
 if [[ "${DO_SEND_PR}" == "true" ]]; then
     hub pull-request \ 
@@ -26,7 +26,7 @@ if [[ "${DO_SEND_PR}" == "true" ]]; then
         -b master \                           # target branch 
         --labels automation \                 # comma-separated list of tags
         --reviewer @elastic/apm-agents \      # set agents as reviewer of the PR
-        -m ":robot: Synchronizing BDD specs"  # PR message
+        -m "test: synchronizing bdd specs"  # PR message
 else 
     echo "PR sent to ${APM_AGENT_REPO_NAME}"
 fi

--- a/.ci/scripts/send-pr.sh
+++ b/.ci/scripts/send-pr.sh
@@ -6,7 +6,7 @@ readonly APM_AGENT=${1}
 readonly APM_AGENT_SPECS_DIR=${2}
 readonly APM_AGENT_REPO_NAME="apm-agent-${APM_AGENT}"
 readonly GIT_DIR=.ci/git
-readonly APM_AGENT_REPO_DIR=${GIT_DIR/${APM_AGENT_REPO_NAME}
+readonly APM_AGENT_REPO_DIR=${GIT_DIR}/${APM_AGENT_REPO_NAME}
 
 mkdir -p .ci/git
 git clone "https://github.com/elastic/${APM_AGENT_REPO_NAME}" "${APM_AGENT_REPO_DIR}"

--- a/.ci/scripts/send-pr.sh
+++ b/.ci/scripts/send-pr.sh
@@ -11,12 +11,11 @@ readonly APM_AGENT_REPO_DIR="${GIT_DIR}/${APM_AGENT_REPO_NAME}"
 git clone "https://github.com/elastic/${APM_AGENT_REPO_NAME}" "${APM_AGENT_REPO_DIR}"
 
 mkdir -p "${APM_AGENT_REPO_DIR}/${APM_AGENT_SPECS_DIR}"
+echo "Copying feature files to the ${APM_AGENT_REPO_NAME} repo"
 cp tests/agents/gherkin-specs/*.feature "${APM_AGENT_REPO_DIR}/${APM_AGENT_SPECS_DIR}"
 
 cd ${APM_AGENT_REPO_DIR}
 git checkout -b update-feature-files-$(date "+%Y%m%d%H%M%S")
-echo "Copying feature files to the ${APM_AGENT_REPO_NAME} repo"
-git status
 git add ${APM_AGENT_SPECS_DIR}
 git commit -m "test: synchronizing bdd specs"
 

--- a/.ci/scripts/send-pr.sh
+++ b/.ci/scripts/send-pr.sh
@@ -5,14 +5,16 @@ set -uexo pipefail
 readonly APM_AGENT=${1}
 readonly APM_AGENT_SPECS_DIR=${2}
 readonly APM_AGENT_REPO_NAME="apm-agent-${APM_AGENT}"
+readonly GIT_DIR=.ci/git
+readonly APM_AGENT_REPO_DIR=${GIT_DIR/${APM_AGENT_REPO_NAME}
 
 mkdir -p .ci/git
-git clone https://github.com/elastic/${APM_AGENT_REPO_NAME} .ci/git/${APM_AGENT_REPO_NAME}
+git clone "https://github.com/elastic/${APM_AGENT_REPO_NAME}" "${APM_AGENT_REPO_DIR}"
 
-mkdir -p .ci/git/${APM_AGENT_REPO_NAME}/${APM_AGENT_SPECS_DIR}
-cp tests/agents/gherkin-specs/*.feature .ci/git/${APM_AGENT_REPO_NAME}/${APM_AGENT_SPECS_DIR}
+mkdir -p "${APM_AGENT_REPO_DIR}/${APM_AGENT_SPECS_DIR}"
+cp tests/agents/gherkin-specs/*.feature "${APM_AGENT_REPO_DIR}/${APM_AGENT_SPECS_DIR}"
 
-cd .ci/git/${APM_AGENT_REPO_NAME}
+cd ${APM_AGENT_REPO_DIR}
 git checkout -b update-feature-files-$(date "+%Y%m%d%H%M%S")
 echo "Copying feature files to the ${APM_AGENT_REPO_NAME} repo"
 git status

--- a/.ci/scripts/send-pr.sh
+++ b/.ci/scripts/send-pr.sh
@@ -5,10 +5,9 @@ set -uexo pipefail
 readonly APM_AGENT=${1}
 readonly APM_AGENT_SPECS_DIR=${2}
 readonly APM_AGENT_REPO_NAME="apm-agent-${APM_AGENT}"
-readonly GIT_DIR=.ci/git
-readonly APM_AGENT_REPO_DIR=${GIT_DIR}/${APM_AGENT_REPO_NAME}
+readonly GIT_DIR=".ci/git"
+readonly APM_AGENT_REPO_DIR="${GIT_DIR}/${APM_AGENT_REPO_NAME}"
 
-mkdir -p .ci/git
 git clone "https://github.com/elastic/${APM_AGENT_REPO_NAME}" "${APM_AGENT_REPO_DIR}"
 
 mkdir -p "${APM_AGENT_REPO_DIR}/${APM_AGENT_SPECS_DIR}"

--- a/.ci/scripts/send-pr.sh
+++ b/.ci/scripts/send-pr.sh
@@ -23,7 +23,6 @@ git commit -m "test: synchronizing bdd specs"
 if [[ "${DO_SEND_PR}" == "true" ]]; then
     hub pull-request \ 
         -p \                                  # push the branch to the remote
-        -b master \                           # target branch 
         --labels automation \                 # comma-separated list of tags
         --reviewer @elastic/apm-agents \      # set agents as reviewer of the PR
         -m "test: synchronizing bdd specs"  # PR message

--- a/.ci/scripts/send-pr.sh
+++ b/.ci/scripts/send-pr.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -uexo pipefail
+
+readonly APM_AGENT=${1}
+
+echo "Sending PR to apm-$APM_AGENT-agent"

--- a/.ci/scripts/send-pr.sh
+++ b/.ci/scripts/send-pr.sh
@@ -3,5 +3,29 @@
 set -uexo pipefail
 
 readonly APM_AGENT=${1}
+readonly APM_AGENT_SPECS_DIR=${2}
+readonly APM_AGENT_REPO_NAME="apm-agent-${APM_AGENT}"
 
-echo "Sending PR to apm-$APM_AGENT-agent"
+mkdir -p .ci/git
+git clone https://github.com/elastic/${APM_AGENT_REPO_NAME} .ci/git/${APM_AGENT_REPO_NAME}
+
+mkdir -p .ci/git/${APM_AGENT_REPO_NAME}/${APM_AGENT_SPECS_DIR}
+cp tests/agents/gherkin-specs/*.feature .ci/git/${APM_AGENT_REPO_NAME}/${APM_AGENT_SPECS_DIR}
+
+cd .ci/git/${APM_AGENT_REPO_NAME}
+git checkout -b update-feature-files-$(date "+%Y%m%d%H%M%S")
+echo "Copying feature files to the ${APM_AGENT_REPO_NAME} repo"
+git status
+git add ${APM_AGENT_SPECS_DIR}
+git commit -m "ci: Synchronized BDD specs"
+
+if [[ "${DO_SEND_PR}" == "true" ]]; then
+    hub pull-request \ 
+        -p \                                  # push the branch to the remote
+        -b master \                           # target branch 
+        --labels automation \                 # comma-separated list of tags
+        --reviewer @elastic/apm-agents \      # set agents as reviewer of the PR
+        -m ":robot: Synchronizing BDD specs"  # PR message
+else 
+    echo "PR sent to ${APM_AGENT_REPO_NAME}"
+fi

--- a/.ci/scripts/send-pr.sh
+++ b/.ci/scripts/send-pr.sh
@@ -23,7 +23,7 @@ if [[ "${DO_SEND_PR}" == "true" ]]; then
     hub pull-request \ 
         -p \                                  # push the branch to the remote
         --labels automation \                 # comma-separated list of tags
-        --reviewer @elastic/apm-agents \      # set agents as reviewer of the PR
+        --reviewer @elastic/apm-agent-devs \  # set agents as reviewer of the PR
         -m "test: synchronizing bdd specs"  # PR message
 else 
     echo "PR sent to ${APM_AGENT_REPO_NAME}"


### PR DESCRIPTION
## What is this PR doing?
It adds a Jenkins pipeline executing on pushes to the master branch, with the following stages:

- Checkouts the SCM
- Uses a parallel execution to send PRs to each subscribed agent, if and only if there are changes in the gherkin files. To subscribe an agent, simply add an entry in the `.ci/.jenkins-agents.yml` file:

```yml
---
agents:
  - NAME: "python"
    FEATURES_PATH: "tests/bdd/features"
  - NAME: "ruby"
    FEATURES_PATH: "features"
```
> The name will represent the agent name (equals to the github repository: i.e. "apm-agent-**python**"), and the features path, the directory in the agent repository where the feature files are located.

- Installs HUB in the worker
- Executes a shell script per agent, this script should:
1. clone the agent repo
1. ensure the target directory exists
1. copy the feature files to the target directory
1. create a git commit with the changes
1. send a PR to the default branch of the agent repo with the changes

## Why is important?
We want to push changes to downstream repos (the agents) whenever a change on the specs is done. This way the repos are always up-to-date with the specs.

## Follow-ups
- Consider versioning the specs, so each agent follows a spec.
- Consider destructive changes in the specs (deletion): they won't be applied as we are just copying the files. We could remove the target dir first, and then apply the shared specs.