### PR TITLE
chore(jenkins): fix regex

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -52,7 +52,7 @@ pipeline {
         script {
           dir("${BASE_DIR}"){
             def regexps =[
-              "^tests/agents/gherkin-specs/"
+              "^tests/agents/gherkin-specs/.*"
             ]
             env.GHERKIN_SPECS_UPDATED = isGitRegionMatch(
               from: "${env.GIT_PREVIOUS_SUCCESSFUL_COMMIT}",

--- a/tests/agents/gherkin-specs/api_key.feature
+++ b/tests/agents/gherkin-specs/api_key.feature
@@ -11,7 +11,7 @@ Feature: API Key
     And a secret_token is set to 'secr3tT0ken' in the config
     Then the Authorization header is 'ApiKey MjlXNEJasdfDt'
 
-  Scenario: A configured secret token is sent if no api key is configured
+  Scenario: A configured secret token is sent if no API key is configured
     Given an agent
     When a secret_token is set to 'secr3tT0ken' in the config
     And an api key is not set in the config


### PR DESCRIPTION
## What is this PR doing?
It uses groovish-style for defining the regex that catches the changes.

It also modifies the feature file, uppercasing API in the scenarios (which does not affect the implementation steps in the agents). This will trigger the PRs to downstream repos

## Why is it important?
The skipped step should not be skipped on gherkin modifications