### PR TITLE
chore: use GITHUB_TOKEN when cloning the repo

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -114,8 +114,7 @@ def generateStepForAgent(Map params = [:]){
             sleep randomNumber(min: 5, max: 10)
             sh script: '.ci/scripts/install-dependencies.sh', label: "Install dependencies"
           }
-          def token = getGithubToken()
-          withEnvMask(vars: [[var: "GITHUB_TOKEN", password: token]]){
+          withCredentials([string(credentialsId: '2a9602aa-ab9f-4e52-baf3-b71ca88469c7', variable: 'GITHUB_TOKEN')]){
             sh script: """.ci/scripts/send-pr.sh "${agent}" "${featuresPath}" "${env.DO_SEND_PR}" """, label: "Send Pull Request for apm-agent-${agent}"
           }
         }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -114,7 +114,10 @@ def generateStepForAgent(Map params = [:]){
             sleep randomNumber(min: 5, max: 10)
             sh script: '.ci/scripts/install-dependencies.sh', label: "Install dependencies"
           }
-          sh script: """.ci/scripts/send-pr.sh "${agent}" "${featuresPath}" "${env.DO_SEND_PR}" """, label: "Send Pull Request for apm-agent-${agent}"
+          def token = getGithubToken()
+          withEnvMask(vars: [[var: "GITHUB_TOKEN", password: token]]){
+            sh script: """.ci/scripts/send-pr.sh "${agent}" "${featuresPath}" "${env.DO_SEND_PR}" """, label: "Send Pull Request for apm-agent-${agent}"
+          }
         }
       }
     }

--- a/.ci/scripts/send-pr.sh
+++ b/.ci/scripts/send-pr.sh
@@ -8,9 +8,8 @@ readonly DO_SEND_PR=${3:-"true"}
 readonly APM_AGENT_REPO_NAME="apm-agent-${APM_AGENT}"
 readonly GIT_DIR=".ci/git"
 readonly APM_AGENT_REPO_DIR="${GIT_DIR}/${APM_AGENT_REPO_NAME}"
-readonly GITHUB_token="${GITHUB_TOKEN:?"missing GITHUB_TOKEN"}"
 
-git clone "https://${GITHUB_token}@github.com/elastic/${APM_AGENT_REPO_NAME}" "${APM_AGENT_REPO_DIR}"
+git clone "https://${GITHUB_TOKEN}@github.com/elastic/${APM_AGENT_REPO_NAME}" "${APM_AGENT_REPO_DIR}"
 
 mkdir -p "${APM_AGENT_REPO_DIR}/${APM_AGENT_SPECS_DIR}"
 echo "Copying feature files to the ${APM_AGENT_REPO_NAME} repo"

--- a/.ci/scripts/send-pr.sh
+++ b/.ci/scripts/send-pr.sh
@@ -8,8 +8,9 @@ readonly DO_SEND_PR=${3:-"true"}
 readonly APM_AGENT_REPO_NAME="apm-agent-${APM_AGENT}"
 readonly GIT_DIR=".ci/git"
 readonly APM_AGENT_REPO_DIR="${GIT_DIR}/${APM_AGENT_REPO_NAME}"
+readonly GITHUB_token="${GITHUB_TOKEN:?"missing GITHUB_TOKEN"}"
 
-git clone "https://github.com/elastic/${APM_AGENT_REPO_NAME}" "${APM_AGENT_REPO_DIR}"
+git clone "https://${GITHUB_token}@github.com/elastic/${APM_AGENT_REPO_NAME}" "${APM_AGENT_REPO_DIR}"
 
 mkdir -p "${APM_AGENT_REPO_DIR}/${APM_AGENT_SPECS_DIR}"
 echo "Copying feature files to the ${APM_AGENT_REPO_NAME} repo"
@@ -21,11 +22,7 @@ git add ${APM_AGENT_SPECS_DIR}
 git commit -m "test: synchronizing bdd specs"
 
 if [[ "${DO_SEND_PR}" == "true" ]]; then
-    hub pull-request \ 
-        -p \                                  # push the branch to the remote
-        --labels automation \                 # comma-separated list of tags
-        --reviewer @elastic/apm-agent-devs \  # set agents as reviewer of the PR
-        -m "test: synchronizing bdd specs"  # PR message
+    hub pull-request -p --labels automation --reviewer @elastic/apm-agent-devs -m "test: synchronizing bdd specs"
 else 
     echo "PR sent to ${APM_AGENT_REPO_NAME}"
 fi

--- a/tests/agents/gherkin-specs/api_key.feature
+++ b/tests/agents/gherkin-specs/api_key.feature
@@ -1,4 +1,4 @@
-Feature: API Key.
+Feature: API Key
 
   Scenario: A configured API key is sent in the Authorization header
     Given an agent


### PR DESCRIPTION
## What it this PR doing?
It wraps the script execution with the GITHUB_TOKEN masked variable, which is obtained from the pipeline library, using it to clone the repo.

## Why is it important?
Setting up the variable allows HUB to perform git operations without prompting for Github's user/password.