### PR TITLE
fix: use apm user machine

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -28,6 +28,7 @@ pipeline {
     JOB_GIT_CREDENTIALS = "f6c7695a-671e-4f4f-a331-acdce44ff9ba"
     PATH = "${env.PATH}:${env.WORKSPACE}/bin"
     PIPELINE_LOG_LEVEL='INFO'
+    GIT_USER_MACHINE='apmmachine'
   }
   options {
     timeout(time: 3, unit: 'HOURS')
@@ -106,8 +107,8 @@ def generateStepForAgent(Map params = [:]){
     node('linux && immutable') {
       catchError(buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
         deleteDir()
-        sh(label: "Git config User", script: "git config --global user.name elasticmachine")
-        sh(label: "Git config Email", script: "git config --global user.email infra-root-elasticmachine@elastic.co")
+        sh(label: "Git config User", script: "git config --global user.name ${GIT_USER_MACHINE}")
+        sh(label: "Git config Email", script: "git config --global user.email infra-root-${GIT_USER_MACHINE}@elastic.co")
         unstash 'source'
         dir("${BASE_DIR}"){
           retry(3){

--- a/.ci/scripts/send-pr.sh
+++ b/.ci/scripts/send-pr.sh
@@ -21,7 +21,7 @@ git add ${APM_AGENT_SPECS_DIR}
 git commit -m "test: synchronizing bdd specs"
 
 if [[ "${DO_SEND_PR}" == "true" ]]; then
-    hub pull-request -p --labels automation --reviewer @elastic/apm-agent-devs -m "test: synchronizing bdd specs"
+    hub pull-request -p --labels automation -m "test: synchronizing bdd specs"
 else 
     echo "PR sent to ${APM_AGENT_REPO_NAME}"
 fi

--- a/tests/agents/gherkin-specs/api_key.feature
+++ b/tests/agents/gherkin-specs/api_key.feature
@@ -1,17 +1,17 @@
-Feature: API Key
+Feature: API Key.
 
-  Scenario: A configured API key is sent in the Authorization header
+  Scenario: A configured API key is sent in the Authorization header.
     Given an agent
     When an api key is set to 'RTNxMjlXNEJt' in the config
     Then the Authorization header is 'ApiKey RTNxMjlXNEJt'
 
-  Scenario: A configured API key takes precedence over a secret token
+  Scenario: A configured API key takes precedence over a secret token.
     Given an agent
     When an api key is set to 'MjlXNEJasdfDt' in the config
     And a secret_token is set to 'secr3tT0ken' in the config
     Then the Authorization header is 'ApiKey MjlXNEJasdfDt'
 
-  Scenario: A configured secret token is sent if no API key is configured
+  Scenario: A configured secret token is sent if no API key is configured.
     Given an agent
     When a secret_token is set to 'secr3tT0ken' in the config
     And an api key is not set in the config


### PR DESCRIPTION
## Why is it important?
Otherwise the generated commits won't use same user (elasticmachine) than the one sending the PR (apmmachine)

We are using apmmachine to maintain lower usage of the Github quotas

Finally, we removed the auto-assignment to the agents team, to avoid multiple notifications when a PR on a repo is opened