### PR TITLE
Relaxing k8s pod ID discovery regex assumption

### DIFF
--- a/docs/agents/agent-development.md
+++ b/docs/agents/agent-development.md
@@ -158,8 +158,7 @@ On Linux, the container ID and some of the Kubernetes metadata can be extracted 
  2. If the basename ends with ".scope", check for a hyphen and remove everything up to and including that. This allows us to match `.../docker-<container-id>.scope` as well as `.../<container-id>`.
 
  3. Attempt to extract the Kubernetes pod UID from the dirname by matching one of the following regular expressions:
-
-     - `(?:^/kubepods/[^/]+/pod([^/]+)/$)`
+     - `(?:^/kubepods[\\S]*/pod([^/]+)$)`
      - `(?:^/kubepods\.slice/kubepods-[^/]+\.slice/kubepods-[^/]+-pod([^/]+)\.slice/$)`
 
     The capturing group in either case is the pod UID. In the latter case, which occurs when using the systemd cgroup driver, we must unescape underscores (`_`) to hyphens (`-`) in the pod UID.


### PR DESCRIPTION
The current regex assumes exactly one path-part between `/kubepods` and `/pod<ID>` in the paths extracted from the `/proc/self/cgroup` file.

A customer reported two non-supported cases - 0 and 2 path-parts instead, as in:
- `12:pids:/kubepods/kubepods/besteffort/pod0e886e9a-3879-45f9-b44d-86ef9df03224/244a65edefdffe31685c42317c9054e71dc1193048cf9459e2a4dd35cbc1dba4`
- `10:cpuset:/kubepods/pod5eadac96-ab58-11ea-b82b-0242ac110009/7fe41c8a2d1da09420117894f11dd91f6c3a44dfeb7d125dc594bd53468861df`

I think the proposed regex (any number of parts, including 0) is safe enough from false positives.

@elastic/apm-agent-devs please upvote or downvote, and in any case be aware that we should support those eventually.