### PR TITLE
feat(ci): support sending a PR to each agent when JSON specs are modified

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -79,7 +79,7 @@ pipeline {
             def agents = readYaml(file: '.ci/.jenkins-agents.yml')
             def parallelTasks = [:]
             agents['agents'].each { agent ->
-              parallelTasks["apm-agent-${agent.NAME}"] = generateStepForAgent(repo: "${agent.REPO}", filesType: "bdd", filesPath: "${agent.FEATURES_PATH}")
+              parallelTasks["apm-agent-${agent.NAME}"] = generateStepForAgent(repo: "${agent.REPO}", filesType: "gherkin", filesPath: "${agent.FEATURES_PATH}")
             }
 
             parallel(parallelTasks)
@@ -97,7 +97,7 @@ pipeline {
 
 def generateStepForAgent(Map params = [:]){
   def repo = params.containsKey('repo') ? params.get('repo') : error('generateStepForAgent: repo argument is required')
-  def filesType = params.containsKey('filesType') ? params.get('filesType') : error('generateStepForAgent: filesType argument is required. Valid values: [bdd]')
+  def filesType = params.containsKey('filesType') ? params.get('filesType') : error('generateStepForAgent: filesType argument is required. Valid values: [gherkin]')
   def filesPath = params.containsKey('filesPath') ? params.get('filesPath') : error('generateStepForAgent: filesPath argument is required')
   return {
     node('linux && immutable') {
@@ -106,7 +106,7 @@ def generateStepForAgent(Map params = [:]){
         unstash 'source'
         dir("${BASE_DIR}"){
           setupAPMGitEmail(global: true)
-          sh script: """.ci/scripts/prepare-spec-changes.sh "${repo}" "${filesPath}" """, label: "Prepare changes for ${repo}"
+          sh script: """.ci/scripts/prepare-spec-changes.sh "${repo}" "${filesType}" "${filesPath}" """, label: "Prepare changes for ${repo}"
           dir(".ci/${repo}") {
             if (params.DRY_RUN_MODE) {
               echo "DRY-RUN: ${repo}"

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -79,7 +79,7 @@ pipeline {
             def agents = readYaml(file: '.ci/.jenkins-agents.yml')
             def parallelTasks = [:]
             agents['agents'].each { agent ->
-              parallelTasks["apm-agent-${agent.NAME}"] = generateStepForAgent(repo: "${agent.REPO}", featuresPath: "${agent.FEATURES_PATH}")
+              parallelTasks["apm-agent-${agent.NAME}"] = generateStepForAgent(repo: "${agent.REPO}", filesPath: "${agent.FEATURES_PATH}")
             }
 
             parallel(parallelTasks)
@@ -97,7 +97,7 @@ pipeline {
 
 def generateStepForAgent(Map params = [:]){
   def repo = params.containsKey('repo') ? params.get('repo') : error('generateStepForAgent: repo argument is required')
-  def featuresPath = params.containsKey('featuresPath') ? params.get('featuresPath') : error('generateStepForAgent: featuresPath argument is required')
+  def filesPath = params.containsKey('filesPath') ? params.get('filesPath') : error('generateStepForAgent: filesPath argument is required')
   return {
     node('linux && immutable') {
       catchError(buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
@@ -105,7 +105,7 @@ def generateStepForAgent(Map params = [:]){
         unstash 'source'
         dir("${BASE_DIR}"){
           setupAPMGitEmail(global: true)
-          sh script: """.ci/scripts/prepare-spec-changes.sh "${repo}" "${featuresPath}" """, label: "Prepare changes for ${repo}"
+          sh script: """.ci/scripts/prepare-spec-changes.sh "${repo}" "${filesPath}" """, label: "Prepare changes for ${repo}"
           dir(".ci/${repo}") {
             if (params.DRY_RUN_MODE) {
               echo "DRY-RUN: ${repo}"

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -58,6 +58,15 @@ pipeline {
               from: "${env.GIT_PREVIOUS_SUCCESSFUL_COMMIT}",
               to: "${env.GIT_COMMIT}",
               patterns: regexps)
+
+            // regexp for JSON specs
+            regexps =[
+              "^tests/agents/json-specs/.*"
+            ]
+            env.JSON_SPECS_UPDATED = isGitRegionMatch(
+              from: "${env.GIT_PREVIOUS_SUCCESSFUL_COMMIT}",
+              to: "${env.GIT_COMMIT}",
+              patterns: regexps)
           }
         }
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
@@ -87,6 +96,30 @@ pipeline {
         }
       }
     }
+    stage('Send Pull Request for JSON specs'){
+      options {
+        warnError('Pull Requests to APM agents failed')
+      }
+      when {
+        beforeAgent true
+        expression { return env.JSON_SPECS_UPDATED != "false" }
+      }
+      steps {
+        deleteDir()
+        unstash 'source'
+        dir("${BASE_DIR}"){
+          script {
+            def agents = readYaml(file: '.ci/.jenkins-agents.yml')
+            def parallelTasks = [:]
+            agents['agents'].each { agent ->
+              parallelTasks["apm-agent-${agent.NAME}"] = generateStepForAgent(repo: "${agent.REPO}", filesType: "json", filesPath: "${agent.JSON_SPECS_PATH}")
+            }
+
+            parallel(parallelTasks)
+          }
+        }
+      }
+    }
   }
   post {
     cleanup {
@@ -106,7 +139,7 @@ def generateStepForAgent(Map params = [:]){
         unstash 'source'
         dir("${BASE_DIR}"){
           setupAPMGitEmail(global: true)
-          sh script: """.ci/scripts/prepare-spec-changes.sh "${repo}" "${filesType}" "${filesPath}" """, label: "Prepare changes for ${repo}"
+          sh script: """.ci/scripts/prepare-spec-changes.sh "${repo}" "${filesType}" "${filesPath}" """, label: "Prepare ${filesType} changes for ${repo}"
           dir(".ci/${repo}") {
             if (params.DRY_RUN_MODE) {
               echo "DRY-RUN: ${repo}"

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -130,7 +130,7 @@ pipeline {
 
 def generateStepForAgent(Map params = [:]){
   def repo = params.containsKey('repo') ? params.get('repo') : error('generateStepForAgent: repo argument is required')
-  def filesType = params.containsKey('filesType') ? params.get('filesType') : error('generateStepForAgent: filesType argument is required. Valid values: [gherkin]')
+  def filesType = params.containsKey('filesType') ? params.get('filesType') : error('generateStepForAgent: filesType argument is required. Valid values: [gherkin | json]')
   def filesPath = params.containsKey('filesPath') ? params.get('filesPath') : error('generateStepForAgent: filesPath argument is required')
   return {
     node('linux && immutable') {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -80,7 +80,7 @@ pipeline {
       when {
         beforeAgent true
         anyOf {
-          expression { return env.GHERKIN_SPECS_UPDATED != "false" }
+          expression { return env.GHERKIN_SPECS_UPDATED }
           expression { return params.FORCE_SEND_PR }
         }
       }
@@ -107,7 +107,7 @@ pipeline {
       when {
         beforeAgent true
         anyOf {
-          expression { return env.JSON_SPECS_UPDATED != "false" }
+          expression { return env.JSON_SPECS_UPDATED }
           expression { return params.FORCE_SEND_PR }
         }
       }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -119,7 +119,9 @@ pipeline {
             def agents = readYaml(file: '.ci/.jenkins-agents.yml')
             def parallelTasks = [:]
             agents['agents'].each { agent ->
-              parallelTasks["apm-agent-${agent.NAME}"] = generateStepForAgent(repo: "${agent.REPO}", filesType: "json", filesPath: "${agent.JSON_SPECS_PATH}")
+              if (${agent.JSON_SPECS_PATH}) {
+                parallelTasks["apm-agent-${agent.NAME}"] = generateStepForAgent(repo: "${agent.REPO}", filesType: "json", filesPath: "${agent.JSON_SPECS_PATH}")
+              }
             }
 
             parallel(parallelTasks)

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -39,6 +39,7 @@ pipeline {
   }
   parameters {
     booleanParam(name: 'DRY_RUN_MODE', defaultValue: false, description: 'If true, allows to execute this pipeline in dry run mode, without sending a PR.')
+    booleanParam(name: 'FORCE_SEND_PR', defaultValue: false, description: 'If true, will force sending a PR.')
   }
   stages {
     stage('Checkout'){
@@ -78,7 +79,10 @@ pipeline {
       }
       when {
         beforeAgent true
-        expression { return env.GHERKIN_SPECS_UPDATED != "false" }
+        anyOf {
+          expression { return env.GHERKIN_SPECS_UPDATED != "false" }
+          expression { return params.FORCE_SEND_PR == "true" }
+        }
       }
       steps {
         deleteDir()
@@ -102,7 +106,10 @@ pipeline {
       }
       when {
         beforeAgent true
-        expression { return env.JSON_SPECS_UPDATED != "false" }
+        anyOf {
+          expression { return env.JSON_SPECS_UPDATED != "false" }
+          expression { return params.FORCE_SEND_PR == "true" }
+        }
       }
       steps {
         deleteDir()

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -81,7 +81,7 @@ pipeline {
         beforeAgent true
         anyOf {
           expression { return env.GHERKIN_SPECS_UPDATED != "false" }
-          expression { return params.FORCE_SEND_PR == "true" }
+          expression { return params.FORCE_SEND_PR }
         }
       }
       steps {
@@ -108,7 +108,7 @@ pipeline {
         beforeAgent true
         anyOf {
           expression { return env.JSON_SPECS_UPDATED != "false" }
-          expression { return params.FORCE_SEND_PR == "true" }
+          expression { return params.FORCE_SEND_PR }
         }
       }
       steps {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -79,7 +79,7 @@ pipeline {
             def agents = readYaml(file: '.ci/.jenkins-agents.yml')
             def parallelTasks = [:]
             agents['agents'].each { agent ->
-              parallelTasks["apm-agent-${agent.NAME}"] = generateStepForAgent(repo: "${agent.REPO}", filesPath: "${agent.FEATURES_PATH}")
+              parallelTasks["apm-agent-${agent.NAME}"] = generateStepForAgent(repo: "${agent.REPO}", filesType: "bdd", filesPath: "${agent.FEATURES_PATH}")
             }
 
             parallel(parallelTasks)
@@ -97,6 +97,7 @@ pipeline {
 
 def generateStepForAgent(Map params = [:]){
   def repo = params.containsKey('repo') ? params.get('repo') : error('generateStepForAgent: repo argument is required')
+  def filesType = params.containsKey('filesType') ? params.get('filesType') : error('generateStepForAgent: filesType argument is required. Valid values: [bdd]')
   def filesPath = params.containsKey('filesPath') ? params.get('filesPath') : error('generateStepForAgent: filesPath argument is required')
   return {
     node('linux && immutable') {
@@ -110,7 +111,7 @@ def generateStepForAgent(Map params = [:]){
             if (params.DRY_RUN_MODE) {
               echo "DRY-RUN: ${repo}"
             } else {
-              githubCreatePullRequest(title: 'test: synchronizing bdd spec', labels: 'automation')
+              githubCreatePullRequest(title: "test: synchronizing ${filesType} spec", labels: 'automation')
             }
           }
         }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -63,7 +63,7 @@ pipeline {
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
       }
     }
-    stage('Send Pull Request'){
+    stage('Send Pull Request for BDD specs'){
       options {
         warnError('Pull Requests to APM agents failed')
       }

--- a/.ci/scripts/prepare-spec-changes.sh
+++ b/.ci/scripts/prepare-spec-changes.sh
@@ -15,7 +15,7 @@ fi
 git clone "https://github.com/elastic/${APM_AGENT_REPO_NAME}" "${APM_AGENT_REPO_DIR}"
 
 mkdir -p "${APM_AGENT_REPO_DIR}/${APM_AGENT_SPECS_DIR}"
-echo "Copying spec files to the ${APM_AGENT_REPO_NAME} repo"
+echo "Copying ${EXTENSION} files to the ${APM_AGENT_REPO_NAME} repo"
 cp tests/agents/${SPECS_TYPE}-specs/*.${EXTENSION} "${APM_AGENT_REPO_DIR}/${APM_AGENT_SPECS_DIR}"
 
 cd "${APM_AGENT_REPO_DIR}"

--- a/.ci/scripts/prepare-spec-changes.sh
+++ b/.ci/scripts/prepare-spec-changes.sh
@@ -3,16 +3,19 @@
 set -uexo pipefail
 
 readonly APM_AGENT_REPO_NAME=${1}
-readonly APM_AGENT_SPECS_DIR=${2}
+readonly SPECS_TYPE=${2} # gherkin
+readonly APM_AGENT_SPECS_DIR=${3}
 readonly APM_AGENT_REPO_DIR=".ci/${APM_AGENT_REPO_NAME}"
+
+EXTENSION="feature"
 
 git clone "https://github.com/elastic/${APM_AGENT_REPO_NAME}" "${APM_AGENT_REPO_DIR}"
 
 mkdir -p "${APM_AGENT_REPO_DIR}/${APM_AGENT_SPECS_DIR}"
-echo "Copying feature files to the ${APM_AGENT_REPO_NAME} repo"
-cp tests/agents/gherkin-specs/*.feature "${APM_AGENT_REPO_DIR}/${APM_AGENT_SPECS_DIR}"
+echo "Copying spec files to the ${APM_AGENT_REPO_NAME} repo"
+cp tests/agents/${SPECS_TYPE}-specs/*.${EXTENSION} "${APM_AGENT_REPO_DIR}/${APM_AGENT_SPECS_DIR}"
 
 cd "${APM_AGENT_REPO_DIR}"
-git checkout -b "update-feature-files-$(date "+%Y%m%d%H%M%S")"
+git checkout -b "update-spec-files-$(date "+%Y%m%d%H%M%S")"
 git add "${APM_AGENT_SPECS_DIR}"
-git commit -m "test: synchronizing bdd specs"
+git commit -m "test: synchronizing ${SPECS_TYPE} specs"

--- a/.ci/scripts/prepare-spec-changes.sh
+++ b/.ci/scripts/prepare-spec-changes.sh
@@ -3,11 +3,14 @@
 set -uexo pipefail
 
 readonly APM_AGENT_REPO_NAME=${1}
-readonly SPECS_TYPE=${2} # gherkin
+readonly SPECS_TYPE=${2} # json or gherkin
 readonly APM_AGENT_SPECS_DIR=${3}
 readonly APM_AGENT_REPO_DIR=".ci/${APM_AGENT_REPO_NAME}"
 
 EXTENSION="feature"
+if [[ "${SPECS_TYPE}" == "json" ]]; then
+    EXTENSION="json"
+fi
 
 git clone "https://github.com/elastic/${APM_AGENT_REPO_NAME}" "${APM_AGENT_REPO_DIR}"
 


### PR DESCRIPTION
## What does this PR do?
It uses the existing automation for the Gherkin specs, making it a bit more abstract so that it's possible to reuse the scripts for both gherkin and json specs modifications.

Then, we add a new stage to the pipeline detecting changes on the JSON spec files, triggering the automation (and the PR to the agents) on modifications on the JSON spec files.

## Why is it important?
Consistency across agents

## Author's checklist
- [x] Executed the automation locally

## How to test this
It's possible to verify that a commit is created in the downstream repositories (the agents). Please use the following script, running block by block by agent.

```shell
## Java Gherkin
./.ci/scripts/prepare-spec-changes.sh apm-agent-java gherkin apm-agent-core/src/test/resources/specs
cd .ci/apm-agent-java
git log
cd ../..
rm -fr .ci/apm-agent-java

## Java JSON
mkdir -p tests/agents/json-specs
touch tests/agents/json-specs/foo.json
./.ci/scripts/prepare-spec-changes.sh apm-agent-java json apm-agent-core/src/test/resources/json-specs
cd .ci/apm-agent-java
git log
cd ../..
rm -fr .ci/apm-agent-java
rm -fr tests/agents/json-specs

## .Net
./.ci/scripts/prepare-spec-changes.sh apm-agent-dotnet gherkin "test/Elastic.Apm.Feature.Tests/Features"
cd .ci/apm-agent-dotnet
git log
cd ../..
rm -fr .ci/apm-agent-dotnet

## Go
./.ci/scripts/prepare-spec-changes.sh apm-agent-go gherkin features
cd ../apm-agent-go
git log
cd ../..
rm -fr .ci/apm-agent-go

## Python
./.ci/scripts/prepare-spec-changes.sh apm-agent-python gherkin tests/bdd/features
cd ../apm-agent-python
git log
cd ../..
rm -fr .ci/apm-agent-python

## Ruby
./.ci/scripts/prepare-spec-changes.sh apm-agent-ruby gherkin features
cd ../apm-agent-ruby
git log
cd ../..
rm -fr .ci/apm-agent-ruby
```

## Related issues
- Related to https://github.com/elastic/apm/pull/313, so please do not merge until that one is merged

## Follow-ups
I noticed there are agents with the gherkin files outdated. Should we force a PR to all?

Besides that, not all agents have the gherkin specs (PHP, Node). Is it on purpose?