### PR TITLE
fix: Use proper variables

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -92,7 +92,7 @@ pipeline {
             def agents = readYaml(file: '.ci/.jenkins-agents.yml')
             def parallelTasks = [:]
             agents['agents'].each { agent ->
-              parallelTasks["apm-agent-${agent.NAME}"] = generateStepForAgent(repo: "${agent.REPO}", filesType: "gherkin", filesPath: "${agent.FEATURES_PATH}")
+              parallelTasks["${agent.REPO}"] = generateStepForAgent(repo: "${agent.REPO}", filesType: "gherkin", filesPath: "${agent.FEATURES_PATH}")
             }
 
             parallel(parallelTasks)
@@ -120,7 +120,7 @@ pipeline {
             def parallelTasks = [:]
             agents['agents'].each { agent ->
               if (agent.JSON_SPECS_PATH) {
-                parallelTasks["apm-agent-${agent.NAME}"] = generateStepForAgent(repo: "${agent.REPO}", filesType: "json", filesPath: "${agent.JSON_SPECS_PATH}")
+                parallelTasks["${agent.REPO}"] = generateStepForAgent(repo: "${agent.REPO}", filesType: "json", filesPath: "${agent.JSON_SPECS_PATH}")
               }
             }
 

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -80,7 +80,7 @@ pipeline {
       when {
         beforeAgent true
         anyOf {
-          expression { return env.GHERKIN_SPECS_UPDATED }
+          expression { return env.GHERKIN_SPECS_UPDATED == "true" }
           expression { return params.FORCE_SEND_PR }
         }
       }
@@ -107,7 +107,7 @@ pipeline {
       when {
         beforeAgent true
         anyOf {
-          expression { return env.JSON_SPECS_UPDATED }
+          expression { return env.JSON_SPECS_UPDATED == "true" }
           expression { return params.FORCE_SEND_PR }
         }
       }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -119,7 +119,7 @@ pipeline {
             def agents = readYaml(file: '.ci/.jenkins-agents.yml')
             def parallelTasks = [:]
             agents['agents'].each { agent ->
-              if (${agent.JSON_SPECS_PATH}) {
+              if (agent.JSON_SPECS_PATH) {
                 parallelTasks["apm-agent-${agent.NAME}"] = generateStepForAgent(repo: "${agent.REPO}", filesType: "json", filesPath: "${agent.JSON_SPECS_PATH}")
               }
             }


### PR DESCRIPTION
## What does this PR do?
It fixes three things:

1. the key used to map the agent was changed a few months ago, we are now using the proper key
1. we interpolated a variable inside a script block, which is not needed
1. treat env vars as strings and boolean params as boolean (See https://issues.jenkins-ci.org/browse/JENKINS-46552)

## Why is this important?
The pipeline is operative again

## Related issues
- Caused by #317