### PR TITLE
fix: rename variable to avoid overriding Jenkins params

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -137,10 +137,10 @@ pipeline {
   }
 }
 
-def generateStepForAgent(Map params = [:]){
-  def repo = params.containsKey('repo') ? params.get('repo') : error('generateStepForAgent: repo argument is required')
-  def filesType = params.containsKey('filesType') ? params.get('filesType') : error('generateStepForAgent: filesType argument is required. Valid values: [gherkin | json]')
-  def filesPath = params.containsKey('filesPath') ? params.get('filesPath') : error('generateStepForAgent: filesPath argument is required')
+def generateStepForAgent(Map args = [:]){
+  def repo = args.containsKey('repo') ? args.get('repo') : error('generateStepForAgent: repo argument is required')
+  def filesType = args.containsKey('filesType') ? args.get('filesType') : error('generateStepForAgent: filesType argument is required. Valid values: [gherkin | json]')
+  def filesPath = args.containsKey('filesPath') ? args.get('filesPath') : error('generateStepForAgent: filesPath argument is required')
   return {
     node('linux && immutable') {
       catchError(buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {


### PR DESCRIPTION
## What does this PR do?
It renames the input variable for the method to avoid overridding the Jenkins parameters.

## Why is it important?
It caused the build to skip the DRY_RUN evaluation, always sending PRs even if the DRY_RUN parameter was checked.