### PR TITLE
chore: schedule sync job every monday and friday

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -37,6 +37,9 @@ pipeline {
     disableResume()
     durabilityHint('PERFORMANCE_OPTIMIZED')
   }
+  triggers {
+    cron('H H(4-5) * * 1,5')
+  }
   parameters {
     booleanParam(name: 'DRY_RUN_MODE', defaultValue: false, description: 'If true, allows to execute this pipeline in dry run mode, without sending a PR.')
     booleanParam(name: 'FORCE_SEND_PR', defaultValue: false, description: 'If true, will force sending a PR.')


### PR DESCRIPTION
## What does this PR do?
It schedules the sync job every monday and friday

## Why is it important?
We do not want to manually trigger the job. For manual triggers we enabled two input parameters in the past:

- DRY_RUN: it does not send the PR, printing a message instead
- FORCE_SEND_PR: it does not check if there weren't changes in the spec files