### PR TITLE
chore: add an intermediate stage to check for changes

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -53,6 +53,27 @@ pipeline {
           repo: "git@github.com:elastic/${REPO}.git",
           credentialsId: "${JOB_GIT_CREDENTIALS}"
         )
+        stash allowEmpty: true, name: 'source', useDefaultExcludes: false
+      }
+    }
+    // This stage will populate the environment, and will only be executed under any of the
+    // following conditions:
+    // 1. we run the pipeline NOT in DRY_RUN_MODE, because we want to send real PRs
+    // 2. we run the pipeline forcing sending real PRs, because we want so
+    // Because the rest of the following stages will need these variables to check for changes,
+    // skipping this stage would not take effect in them, as they are covered by the 
+    // FORCE_SEND_PR check.
+    stage('Check for spec changes'){
+      when {
+        beforeAgent true
+        anyOf {
+          expression { return env.DRY_RUN_MODE == "false" }
+          expression { return params.FORCE_SEND_PR }
+        }
+      }
+      steps {
+        deleteDir()
+        unstash 'source'
         script {
           dir("${BASE_DIR}"){
             def regexps =[
@@ -73,7 +94,6 @@ pipeline {
               patterns: regexps)
           }
         }
-        stash allowEmpty: true, name: 'source', useDefaultExcludes: false
       }
     }
     stage('Send Pull Request for BDD specs'){


### PR DESCRIPTION
## What is this PR doing?
It adds an intermediate stage to calculate the git changes inside it, decoupling this from the checkout stage.

This stage will populate the environment, and will only be executed under any of the following conditions:
1. we run the pipeline NOT in DRY_RUN_MODE, because we want to send real PRs
2. we run the pipeline forcing sending real PRs, because we want so

Because the rest of the following stages will need these variables to check for changes, skipping this stage would not take effect in them, as they are covered by the FORCE_SEND_PR check.

## Why is it important?
This will allow us to run the pipeline in DRY_RUN mode and not forcing sending real PRs, and getting a green build, which is needed by the IS_GIT_REGION_MATCH pipeline step.

As we are using env.GIT_PREVIOUS_SUCCESSFUL_COMMIT, we will be reading it from the previous green build, and this won't be possible on new jobs. Because we renamed the job on the CI instance, to cover the JSON specs too (from update-gherkin to update-specs) we are suffering this: we cannot get a previous green build.