### PR TITLE
chore: add debug logs for git config

### DIFF
--- a/.ci/scripts/prepare-spec-changes.sh
+++ b/.ci/scripts/prepare-spec-changes.sh
@@ -19,6 +19,8 @@ echo "Copying ${EXTENSION} files to the ${APM_AGENT_REPO_NAME} repo"
 cp tests/agents/${SPECS_TYPE}-specs/*.${EXTENSION} "${APM_AGENT_REPO_DIR}/${APM_AGENT_SPECS_DIR}"
 
 cd "${APM_AGENT_REPO_DIR}"
+git config user.email
 git checkout -b "update-spec-files-$(date "+%Y%m%d%H%M%S")"
 git add "${APM_AGENT_SPECS_DIR}"
 git commit -m "test: synchronizing ${SPECS_TYPE} specs"
+git --no-pager log -1


### PR DESCRIPTION
## What does this PR do?
It adds two debug traces when running git commands:

- the configured email for the git user
- the git log for the last commit

## Why is it important?
We are trying to determine why the user is not a valid CLA user, because the email we set in the shared library is correct (checked with infra)