### PR TITLE
docs: enrich message description for parameter

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
   }
   parameters {
     booleanParam(name: 'DRY_RUN_MODE', defaultValue: false, description: 'If true, allows to execute this pipeline in dry run mode, without sending a PR.')
-    booleanParam(name: 'FORCE_SEND_PR', defaultValue: false, description: 'If true, will force sending a PR.')
+    booleanParam(name: 'FORCE_SEND_PR', defaultValue: false, description: 'If true, will force sending a PR, although it could be affected by the value off the DRY_RUN parameter: if the later is true, a message will be printed in the console.')
   }
   stages {
     stage('Checkout'){

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
   }
   parameters {
     booleanParam(name: 'DRY_RUN_MODE', defaultValue: false, description: 'If true, allows to execute this pipeline in dry run mode, without sending a PR.')
-    booleanParam(name: 'FORCE_SEND_PR', defaultValue: false, description: 'If true, will force sending a PR, although it could be affected by the value off the DRY_RUN parameter: if the later is true, a message will be printed in the console.')
+    booleanParam(name: 'FORCE_SEND_PR', defaultValue: false, description: 'If true, will force sending a PR, although it could be affected by the value off the DRY_RUN parameter: if the latter is true, a message will be printed in the console.')
   }
   stages {
     stage('Checkout'){


### PR DESCRIPTION
## What is this PR doing?
It adds more descriptive information for the boolean param `FORCE_SEND_PR`, which allows to send PRs on manual triggers.

## Why is it important?
After a few discussions, we realised the previous message was not clear enough to provide the best experience triggering manual builds.

## Use cases

- A build with changes in the spec files will send PRs for the enrolled agents
- A build with NO changes in the spec files will not send PRs for the enrolled agents
- It must be possible to send PRs even if there are no changes in the spec files, controlled by an input parameter (true|false)
- It must be possible to print a descriptive message instead of sending a real PR

After this reasoning, we think we should not change the existing `FORCE_SEND_PR` param, or maybe rename it to something like `DO_SEND_PR`. What could bring confusion was executing the job in combination with the `DRY_RUN` param: if both are enabled, a message will be printed even if there are no changes in the spec files. So we are enforcing the message that the DRY_RUN param will take precedence over the force one when manualy triggering a build.