### PR TITLE
chore: exclude stages for PRs

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -58,7 +58,6 @@ pipeline {
     }
     // This stage will populate the environment, and will only be executed under any of the
     // following conditions:
-    // 0. we run the pipeline for a branch, not a PR
     // 1. we run the pipeline NOT in DRY_RUN_MODE, because we want to send real PRs
     // 2. we run the pipeline forcing sending real PRs, because we want so
     // Because the rest of the following stages will need these variables to check for changes,
@@ -67,12 +66,9 @@ pipeline {
     stage('Check for spec changes'){
       when {
         beforeAgent true
-        allOf {
-          not { changeRequest() }
-          anyOf {
-            expression { return env.DRY_RUN_MODE == "false" }
-            expression { return params.FORCE_SEND_PR }
-          }
+        anyOf {
+          expression { return env.DRY_RUN_MODE == "false" }
+          expression { return params.FORCE_SEND_PR }
         }
       }
       steps {
@@ -106,12 +102,9 @@ pipeline {
       }
       when {
         beforeAgent true
-        allOf {
-          not { changeRequest() }
-          anyOf {
-            expression { return env.GHERKIN_SPECS_UPDATED == "true" }
-            expression { return params.FORCE_SEND_PR }
-          }
+        anyOf {
+          expression { return env.GHERKIN_SPECS_UPDATED == "true" }
+          expression { return params.FORCE_SEND_PR }
         }
       }
       steps {
@@ -183,7 +176,7 @@ def generateStepForAgent(Map args = [:]){
           setupAPMGitEmail(global: true)
           sh script: """.ci/scripts/prepare-spec-changes.sh "${repo}" "${filesType}" "${filesPath}" """, label: "Prepare ${filesType} changes for ${repo}"
           dir(".ci/${repo}") {
-            if (params.DRY_RUN_MODE) {
+            if (params.DRY_RUN_MODE || isPR()) {
               echo "DRY-RUN: ${repo}"
             } else {
               githubCreatePullRequest(title: "test: synchronizing ${filesType} spec", labels: 'automation')

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -129,12 +129,9 @@ pipeline {
       }
       when {
         beforeAgent true
-        allOf {
-          not { changeRequest() }
-          anyOf {
-            expression { return env.JSON_SPECS_UPDATED == "true" }
-            expression { return params.FORCE_SEND_PR }
-          }
+        anyOf {
+          expression { return env.JSON_SPECS_UPDATED == "true" }
+          expression { return params.FORCE_SEND_PR }
         }
       }
       steps {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -58,6 +58,7 @@ pipeline {
     }
     // This stage will populate the environment, and will only be executed under any of the
     // following conditions:
+    // 0. we run the pipeline for a branch, not a PR
     // 1. we run the pipeline NOT in DRY_RUN_MODE, because we want to send real PRs
     // 2. we run the pipeline forcing sending real PRs, because we want so
     // Because the rest of the following stages will need these variables to check for changes,
@@ -66,9 +67,12 @@ pipeline {
     stage('Check for spec changes'){
       when {
         beforeAgent true
-        anyOf {
-          expression { return env.DRY_RUN_MODE == "false" }
-          expression { return params.FORCE_SEND_PR }
+        allOf {
+          not { changeRequest }
+          anyOf {
+            expression { return env.DRY_RUN_MODE == "false" }
+            expression { return params.FORCE_SEND_PR }
+          }
         }
       }
       steps {
@@ -102,9 +106,12 @@ pipeline {
       }
       when {
         beforeAgent true
-        anyOf {
-          expression { return env.GHERKIN_SPECS_UPDATED == "true" }
-          expression { return params.FORCE_SEND_PR }
+        allOf {
+          not { changeRequest }
+          anyOf {
+            expression { return env.GHERKIN_SPECS_UPDATED == "true" }
+            expression { return params.FORCE_SEND_PR }
+          }
         }
       }
       steps {
@@ -129,9 +136,12 @@ pipeline {
       }
       when {
         beforeAgent true
-        anyOf {
-          expression { return env.JSON_SPECS_UPDATED == "true" }
-          expression { return params.FORCE_SEND_PR }
+        allOf {
+          not { changeRequest }
+          anyOf {
+            expression { return env.JSON_SPECS_UPDATED == "true" }
+            expression { return params.FORCE_SEND_PR }
+          }
         }
       }
       steps {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -68,7 +68,7 @@ pipeline {
       when {
         beforeAgent true
         allOf {
-          not { changeRequest }
+          not { changeRequest() }
           anyOf {
             expression { return env.DRY_RUN_MODE == "false" }
             expression { return params.FORCE_SEND_PR }
@@ -107,7 +107,7 @@ pipeline {
       when {
         beforeAgent true
         allOf {
-          not { changeRequest }
+          not { changeRequest() }
           anyOf {
             expression { return env.GHERKIN_SPECS_UPDATED == "true" }
             expression { return params.FORCE_SEND_PR }
@@ -137,7 +137,7 @@ pipeline {
       when {
         beforeAgent true
         allOf {
-          not { changeRequest }
+          not { changeRequest() }
           anyOf {
             expression { return env.JSON_SPECS_UPDATED == "true" }
             expression { return params.FORCE_SEND_PR }


### PR DESCRIPTION
## What does this PR do?
It excludes PRs from checking the spec files to send a PR to the enrolled agents. To achieve it, we are adding a condition at the pipeline level, checking that the current build is not a PR. This condition will be evaluated at the exact moment of sending the PR: if it's a PR or DRY_RUN is enabled, a message will be printed. Otherwise (not a PR AND not DRY_RUN), a PR to the agents will be send.

## Why is it important?
We want to avoid PRs to send real PRs to the agents, which could cause unnecessary noise in the downstream repos.