### PR TITLE
Add log_level spec

### DIFF
--- a/specs/agents/README.md
+++ b/specs/agents/README.md
@@ -51,6 +51,7 @@ You can find details about each of these in the [APM Data Model](https://www.ela
 - [Metrics](metrics.md)
 - [Logging Correlation](log-correlation.md)
 - [Agent Configuration](configuration.md)
+- [Agent logging](logging.md)
 
 # Processes
 

--- a/specs/agents/logging.md
+++ b/specs/agents/logging.md
@@ -1,0 +1,36 @@
+## Agent logging
+
+### `log_level` configuration
+
+Sets the logging level for the agent.
+
+This option is case-insensitive.
+
+|                |   |
+|----------------|---|
+| Valid options  | `trace`, `debug`, `info`, `warning`, `error`, `critical`, `off` |
+| Default        | `info` |
+| Dynamic        | `true` |
+| Central config | `true` |
+
+### Mapping to native log levels
+
+As not all logging frameworks used by the different agents can natively work with these levels.
+Thus, agents will need to translate them.
+
+Some examples:
+If the logging framework used by an agent doesn't have `trace`,
+it would map it to the same level as `debug`.
+If the underlying logging framework doesn't support `critical`,
+agents can treat that as a synonym for `error`.
+
+The `off` level is a switch to completely turn off logging.
+
+### Backwards compatibility
+
+Most agents have already implemented `log_level`,
+accepting a different set of levels.
+Those agents should still accept their "native" log levels to preserve backwards compatibility.
+However, in central config,
+there will only be a dropdown with the that are consistent across agents.
+Also, the documentation should not mention the old log levels going forward.

--- a/specs/agents/logging.md
+++ b/specs/agents/logging.md
@@ -9,20 +9,20 @@ This option is case-insensitive.
 |                |   |
 |----------------|---|
 | Valid options  | `trace`, `debug`, `info`, `warning`, `error`, `critical`, `off` |
-| Default        | `info` |
+| Default        | `warning` |
 | Dynamic        | `true` |
 | Central config | `true` |
 
 ### Mapping to native log levels
 
 As not all logging frameworks used by the different agents can natively work with these levels.
-Thus, agents will need to translate them.
+Thus, agents will need to translate them, using their best judgment for the mapping.
 
 Some examples:
 If the logging framework used by an agent doesn't have `trace`,
 it would map it to the same level as `debug`.
 If the underlying logging framework doesn't support `critical`,
-agents can treat that as a synonym for `error`.
+agents can treat that as a synonym for `error` or `fatal`.
 
 The `off` level is a switch to completely turn off logging.
 

--- a/specs/agents/logging.md
+++ b/specs/agents/logging.md
@@ -9,9 +9,13 @@ This option is case-insensitive.
 |                |   |
 |----------------|---|
 | Valid options  | `trace`, `debug`, `info`, `warning`, `error`, `critical`, `off` |
-| Default        | `warning` |
+| Default        | `info` (soft default) |
 | Dynamic        | `true` |
 | Central config | `true` |
+
+Note that this default is not enforced among all agents.
+If an agent development team thinks that a different default should be used
+(such as `warning`), that is acceptable.
 
 ### Mapping to native log levels
 


### PR DESCRIPTION
Supersedes #321

Note that the implementation of this spec also includes adding the option to [Kibana](https://github.com/elastic/kibana/blob/master/x-pack/plugins/apm/common/agent_configuration/setting_definitions/general_settings.ts).