### PR TITLE
Add sanitize_field_names spec

### DIFF
--- a/specs/agents/README.md
+++ b/specs/agents/README.md
@@ -51,6 +51,7 @@ You can find details about each of these in the [APM Data Model](https://www.ela
 - [Metrics](metrics.md)
 - [Logging Correlation](log-correlation.md)
 - [Agent Configuration](configuration.md)
+- [Data sanitization](sanitization.md)
 
 # Processes
 

--- a/specs/agents/sanitization.md
+++ b/specs/agents/sanitization.md
@@ -1,0 +1,16 @@
+## Data sanitization
+
+### `sanitize_field_names` configuration
+
+Sometimes it is necessary to sanitize, i.e., remove,
+sensitive data sent to Elastic APM.
+This config accepts a list of wildcard patterns of field names which should be sanitized.
+These apply to HTTP headers (including cookies) and `application/x-www-form-urlencoded` data (POST form fields).
+The query string and the captured request body (such as `application/json` data) will not get sanitized.
+
+|                |   |
+|----------------|---|
+| Type           | `List<`[`WildcardMatcher`](../../tests/agents/json-specs/wildcard_matcher_tests.json)`>` |
+| Default        | `password, passwd, pwd, secret, *key, *token*, *session*, *credit*, *card*, authorization, set-cookie` |
+| Dynamic        | `true` |
+| Central config | `true` |


### PR DESCRIPTION
Supersedes #319 

Note that the implementation of this spec also includes adding the option to [Kibana](https://github.com/elastic/kibana/blob/master/x-pack/plugins/apm/common/agent_configuration/setting_definitions/general_settings.ts).