### PR TITLE
[CI] compare with the calculated SHA commit

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -81,7 +81,7 @@ pipeline {
             ]
             env.GHERKIN_SPECS_UPDATED = isGitRegionMatch(
               from: "${env.GIT_PREVIOUS_SUCCESSFUL_COMMIT}",
-              to: "${env.GIT_COMMIT}",
+              to: "${env.GIT_BASE_COMMIT}",
               patterns: regexps)
 
             // regexp for JSON specs
@@ -90,7 +90,7 @@ pipeline {
             ]
             env.JSON_SPECS_UPDATED = isGitRegionMatch(
               from: "${env.GIT_PREVIOUS_SUCCESSFUL_COMMIT}",
-              to: "${env.GIT_COMMIT}",
+              to: "${env.GIT_BASE_COMMIT}",
               patterns: regexps)
           }
         }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -81,7 +81,6 @@ pipeline {
             ]
             env.GHERKIN_SPECS_UPDATED = isGitRegionMatch(
               from: "${env.GIT_PREVIOUS_SUCCESSFUL_COMMIT}",
-              to: "${env.GIT_BASE_COMMIT}",
               patterns: regexps)
 
             // regexp for JSON specs
@@ -90,7 +89,6 @@ pipeline {
             ]
             env.JSON_SPECS_UPDATED = isGitRegionMatch(
               from: "${env.GIT_PREVIOUS_SUCCESSFUL_COMMIT}",
-              to: "${env.GIT_BASE_COMMIT}",
               patterns: regexps)
           }
         }


### PR DESCRIPTION
Otherwise we can see some errors like:

```
09:58:21  + git diff --name-only 56d18114fc033189fd9ea05309d088ef8eadca00...061d4bc14c337e5716b0bb92ee5a3c19dd250937
09:58:21  fatal: Invalid symmetric difference expression 56d18114fc033189fd9ea05309d088ef8eadca00...061d4bc14c337e5716b0bb92ee5a3c19dd250937
```

56d18114fc033189fd9ea05309d088ef8eadca00 is the sha commit from https://github.com/elastic/apm/pull/333/commits/56d18114fc033189fd9ea05309d088ef8eadca00

but 061d4bc14c337e5716b0bb92ee5a3c19dd250937 is the sha commit generated by the default checkout , but no the gitCheckout


```
09:57:59  Merging remotes/origin/master commit d32077ad5bcc847ddc9b4f9d3f13f04624a6decc into PR head commit 73bc50083f36841ce7a1ab746688284728552337
09:57:59  Merge succeeded, producing 061d4bc14c337e5716b0bb92ee5a3c19dd250937
09:57:59  Checking out Revision 061d4bc14c337e5716b0bb92ee5a3c19dd250937 (PR-333)
```