### PR TITLE
[CI] PRs with changeset context

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -195,7 +195,9 @@ def createDescription() {
     message += "* Manually forced with the CI automation job."
   }
   if (env?.SPEC_UPDATED?.equals('true')){
-    def gitLog = sh(script: "git --no-pager log ${env.GIT_PREVIOUS_SUCCESSFUL_COMMIT}...${env.BRANCH_NAME} --pretty=oneline --follow -- tests/agents || true", returnStdout: true)
+    // Compare with the TARGET_BRANCH env variable if PR otherwise the BRANCH_NAME.
+    def to = isPR() ? env.TARGET_BRANCH : env.BRANCH_NAME
+    def gitLog = sh(script: "git --no-pager log ${env.GIT_PREVIOUS_SUCCESSFUL_COMMIT}...${to} --pretty=oneline --follow -- tests/agents || true", returnStdout: true)
     message += "* Changeset \n ${gitLog}"
   }
   return message

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -196,6 +196,8 @@ def createDescription() {
   if (env?.SPEC_UPDATED?.equals('true')){
     // Compare with the target or base branch to which the change could be merged, otherwise the branch name
     def to = isPR() ? env.CHANGE_TARGET : env.BRANCH_NAME
+    sh 'git --no-pager log --pretty=oneline | true'
+    sh 'git --no-pager log ${env.GIT_PREVIOUS_SUCCESSFUL_COMMIT}...head --pretty=oneline --follow -- tests/agents || true'
     def gitLog = sh(script: "git --no-pager log ${env.GIT_PREVIOUS_SUCCESSFUL_COMMIT}...${to} --pretty=oneline --follow -- tests/agents || true", returnStdout: true)
     message += "* Changeset \n ${gitLog}"
   }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -195,13 +195,6 @@ def createPRDescription() {
     message += "* Manually forced with the CI automation job."
   }
   if (env?.SPEC_UPDATED?.equals('true')){
-    sh """
-      ls -ltra
-      git config -l
-      git log --pretty=oneline || true
-      pwd
-      git log ${env.GIT_PREVIOUS_SUCCESSFUL_COMMIT}...HEAD --pretty=oneline --follow -- tests/agents || true
-    """
     def gitLog = sh(script: "git log ${env.GIT_PREVIOUS_SUCCESSFUL_COMMIT}...HEAD --pretty=oneline --follow -- tests/agents || true", returnStdout: true)
     message += "* Changeset \n ${gitLog}"
   }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -195,8 +195,8 @@ def createDescription() {
     message += "* Manually forced with the CI automation job."
   }
   if (env?.SPEC_UPDATED?.equals('true')){
-    // Compare with the TARGET_BRANCH env variable if PR otherwise the BRANCH_NAME.
-    def to = isPR() ? env.TARGET_BRANCH : env.BRANCH_NAME
+    // Compare with the target or base branch to which the change could be merged, otherwise the branch name
+    def to = isPR() ? env.CHANGE_TARGET : env.BRANCH_NAME
     def gitLog = sh(script: "git --no-pager log ${env.GIT_PREVIOUS_SUCCESSFUL_COMMIT}...${to} --pretty=oneline --follow -- tests/agents || true", returnStdout: true)
     message += "* Changeset \n ${gitLog}"
   }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -90,6 +90,7 @@ pipeline {
             env.JSON_SPECS_UPDATED = isGitRegionMatch(
               from: "${env.GIT_PREVIOUS_SUCCESSFUL_COMMIT}",
               patterns: regexps)
+            env.SPEC_UPDATED = env.JSON_SPECS_UPDATED.equals('true') || env.GHERKIN_SPECS_UPDATED.equals('true')
           }
         }
       }
@@ -174,7 +175,19 @@ def generateStepForAgent(Map args = [:]){
             if (params.DRY_RUN_MODE || isPR()) {
               echo "DRY-RUN: ${repo}"
             } else {
-              githubCreatePullRequest(title: "test: synchronizing ${filesType} spec", labels: 'automation')
+              def message = """
+              ### What
+              APM agent specs automatic sync
+              ### Why
+              """
+              if (params.FORCE_SEND_PR) {
+                message += "* Manually forced with the CI automation job."
+              }
+              if (env?.SPEC_UPDATED?.equals('true')){
+                def gitLog = sh(script: "git --no-pager log ${env.GIT_PREVIOUS_SUCCESSFUL_COMMIT}...${env.BRANCH_NAME} --pretty=oneline --follow -- tests/agents || true", returnStdout: true)
+                message += "* Changeset \n ${gitLog}"
+              }
+              githubCreatePullRequest(title: "test: synchronizing ${filesType} spec", labels: 'automation', description: "${message}")
             }
           }
         }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -90,7 +90,7 @@ pipeline {
               from: "${env.GIT_PREVIOUS_SUCCESSFUL_COMMIT}",
               patterns: regexps)
             env.SPEC_UPDATED = env.JSON_SPECS_UPDATED.equals('true') || env.GHERKIN_SPECS_UPDATED.equals('true')
-            env.MESSAGE = createDescription()
+            env.PR_DESCRIPTION = createPRDescription()
           }
         }
       }
@@ -173,9 +173,9 @@ def generateStepForAgent(Map args = [:]){
           sh script: """.ci/scripts/prepare-spec-changes.sh "${repo}" "${filesType}" "${filesPath}" """, label: "Prepare ${filesType} changes for ${repo}"
           dir(".ci/${repo}") {
             if (params.DRY_RUN_MODE || isPR()) {
-              echo "DRY-RUN: ${repo} with description: '${env.MESSAGE}'"
+              echo "DRY-RUN: ${repo} with description: '${env.PR_DESCRIPTION}'"
             } else {
-              githubCreatePullRequest(title: "test: synchronizing ${filesType} spec", labels: 'automation', description: "${env.MESSAGE}")
+              githubCreatePullRequest(title: "test: synchronizing ${filesType} spec", labels: 'automation', description: "${env.PR_DESCRIPTION}")
             }
           }
         }
@@ -184,26 +184,25 @@ def generateStepForAgent(Map args = [:]){
   }
 }
 
-def createDescription() {
+def createPRDescription() {
   def message = """
   ### What
   APM agent specs automatic sync
+
   ### Why
   """
   if (params.FORCE_SEND_PR) {
     message += "* Manually forced with the CI automation job."
   }
   if (env?.SPEC_UPDATED?.equals('true')){
-    // Compare with the target or base branch to which the change could be merged, otherwise the branch name
-    def to = isPR() ? env.CHANGE_TARGET : env.BRANCH_NAME
     sh """
       ls -ltra
       git config -l
-      git log --pretty=oneline | true
+      git log --pretty=oneline || true
       pwd
-      git log ${env.GIT_PREVIOUS_SUCCESSFUL_COMMIT}...head --pretty=oneline --follow -- tests/agents || true
+      git log ${env.GIT_PREVIOUS_SUCCESSFUL_COMMIT}...HEAD --pretty=oneline --follow -- tests/agents || true
     """
-    def gitLog = sh(script: "git log ${env.GIT_PREVIOUS_SUCCESSFUL_COMMIT}...${to} --pretty=oneline --follow -- tests/agents || true", returnStdout: true)
+    def gitLog = sh(script: "git log ${env.GIT_PREVIOUS_SUCCESSFUL_COMMIT}...HEAD --pretty=oneline --follow -- tests/agents || true", returnStdout: true)
     message += "* Changeset \n ${gitLog}"
   }
   return message

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -172,21 +172,10 @@ def generateStepForAgent(Map args = [:]){
           setupAPMGitEmail(global: true)
           sh script: """.ci/scripts/prepare-spec-changes.sh "${repo}" "${filesType}" "${filesPath}" """, label: "Prepare ${filesType} changes for ${repo}"
           dir(".ci/${repo}") {
+            def message = createDescription()
             if (params.DRY_RUN_MODE || isPR()) {
-              echo "DRY-RUN: ${repo}"
+              echo "DRY-RUN: ${repo} with description: '${message}'"
             } else {
-              def message = """
-              ### What
-              APM agent specs automatic sync
-              ### Why
-              """
-              if (params.FORCE_SEND_PR) {
-                message += "* Manually forced with the CI automation job."
-              }
-              if (env?.SPEC_UPDATED?.equals('true')){
-                def gitLog = sh(script: "git --no-pager log ${env.GIT_PREVIOUS_SUCCESSFUL_COMMIT}...${env.BRANCH_NAME} --pretty=oneline --follow -- tests/agents || true", returnStdout: true)
-                message += "* Changeset \n ${gitLog}"
-              }
               githubCreatePullRequest(title: "test: synchronizing ${filesType} spec", labels: 'automation', description: "${message}")
             }
           }
@@ -194,4 +183,20 @@ def generateStepForAgent(Map args = [:]){
       }
     }
   }
+}
+
+def createDescription() {
+  def message = """
+  ### What
+  APM agent specs automatic sync
+  ### Why
+  """
+  if (params.FORCE_SEND_PR) {
+    message += "* Manually forced with the CI automation job."
+  }
+  if (env?.SPEC_UPDATED?.equals('true')){
+    def gitLog = sh(script: "git --no-pager log ${env.GIT_PREVIOUS_SUCCESSFUL_COMMIT}...${env.BRANCH_NAME} --pretty=oneline --follow -- tests/agents || true", returnStdout: true)
+    message += "* Changeset \n ${gitLog}"
+  }
+  return message
 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -90,6 +90,7 @@ pipeline {
               from: "${env.GIT_PREVIOUS_SUCCESSFUL_COMMIT}",
               patterns: regexps)
             env.SPEC_UPDATED = env.JSON_SPECS_UPDATED.equals('true') || env.GHERKIN_SPECS_UPDATED.equals('true')
+            env.MESSAGE = createDescription()
           }
         }
       }
@@ -168,14 +169,13 @@ def generateStepForAgent(Map args = [:]){
         deleteDir()
         unstash 'source'
         dir("${BASE_DIR}"){
-          def message = createDescription()
           setupAPMGitEmail(global: true)
           sh script: """.ci/scripts/prepare-spec-changes.sh "${repo}" "${filesType}" "${filesPath}" """, label: "Prepare ${filesType} changes for ${repo}"
           dir(".ci/${repo}") {
             if (params.DRY_RUN_MODE || isPR()) {
-              echo "DRY-RUN: ${repo} with description: '${message}'"
+              echo "DRY-RUN: ${repo} with description: '${env.MESSAGE}'"
             } else {
-              githubCreatePullRequest(title: "test: synchronizing ${filesType} spec", labels: 'automation', description: "${message}")
+              githubCreatePullRequest(title: "test: synchronizing ${filesType} spec", labels: 'automation', description: "${env.MESSAGE}")
             }
           }
         }
@@ -197,11 +197,13 @@ def createDescription() {
     // Compare with the target or base branch to which the change could be merged, otherwise the branch name
     def to = isPR() ? env.CHANGE_TARGET : env.BRANCH_NAME
     sh """
-      git --no-pager log --pretty=oneline | true
+      ls -ltra
+      git config -l
+      git log --pretty=oneline | true
       pwd
-      git --no-pager log ${env.GIT_PREVIOUS_SUCCESSFUL_COMMIT}...head --pretty=oneline --follow -- tests/agents || true
+      git log ${env.GIT_PREVIOUS_SUCCESSFUL_COMMIT}...head --pretty=oneline --follow -- tests/agents || true
     """
-    def gitLog = sh(script: "git --no-pager log ${env.GIT_PREVIOUS_SUCCESSFUL_COMMIT}...${to} --pretty=oneline --follow -- tests/agents || true", returnStdout: true)
+    def gitLog = sh(script: "git log ${env.GIT_PREVIOUS_SUCCESSFUL_COMMIT}...${to} --pretty=oneline --follow -- tests/agents || true", returnStdout: true)
     message += "* Changeset \n ${gitLog}"
   }
   return message

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -195,8 +195,12 @@ def createPRDescription() {
     message += "* Manually forced with the CI automation job."
   }
   if (env?.SPEC_UPDATED?.equals('true')){
-    def gitLog = sh(script: "git log ${env.GIT_PREVIOUS_SUCCESSFUL_COMMIT}...HEAD --pretty=oneline --follow -- tests/agents || true", returnStdout: true)
-    message += "* Changeset \n ${gitLog}"
+    def gitLog = sh(script: """
+      git log --pretty=format:'  * https://github.com/${env.ORG_NAME}/${env.REPO_NAME}/%h %s' \
+          ${env.GIT_PREVIOUS_SUCCESSFUL_COMMIT}...HEAD \
+          --follow -- tests/agents \
+      | sed 's/#\\([0-9]\\+\\)/https:\\/\\/github.com\\/${env.ORG_NAME}\\/${env.REPO_NAME}\\/pull\\1/g' || true""", returnStdout: true)
+    message += "* Changeset\n${gitLog}"
   }
   return message
 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -192,15 +192,15 @@ def createPRDescription() {
   ### Why
   """
   if (params.FORCE_SEND_PR) {
-    message += "* Manually forced with the CI automation job."
+    message += "*Manually forced with the CI automation job.*"
   }
   if (env?.SPEC_UPDATED?.equals('true')){
     def gitLog = sh(script: """
-      git log --pretty=format:'  * https://github.com/${env.ORG_NAME}/${env.REPO_NAME}/%h %s' \
+      git log --pretty=format:'* https://github.com/${env.ORG_NAME}/${env.REPO_NAME}/commit/%h %s' \
           ${env.GIT_PREVIOUS_SUCCESSFUL_COMMIT}...HEAD \
           --follow -- tests/agents \
-      | sed 's/#\\([0-9]\\+\\)/https:\\/\\/github.com\\/${env.ORG_NAME}\\/${env.REPO_NAME}\\/pull\\1/g' || true""", returnStdout: true)
-    message += "* Changeset\n${gitLog}"
+      | sed 's/#\\([0-9]\\+\\)/https:\\/\\/github.com\\/${env.ORG_NAME}\\/${env.REPO_NAME}\\/pull\\/\\1/g' || true""", returnStdout: true)
+    message += "*Changeset*\n${gitLog}"
   }
   return message
 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -168,10 +168,10 @@ def generateStepForAgent(Map args = [:]){
         deleteDir()
         unstash 'source'
         dir("${BASE_DIR}"){
+          def message = createDescription()
           setupAPMGitEmail(global: true)
           sh script: """.ci/scripts/prepare-spec-changes.sh "${repo}" "${filesType}" "${filesPath}" """, label: "Prepare ${filesType} changes for ${repo}"
           dir(".ci/${repo}") {
-            def message = createDescription()
             if (params.DRY_RUN_MODE || isPR()) {
               echo "DRY-RUN: ${repo} with description: '${message}'"
             } else {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -49,7 +49,6 @@ pipeline {
       steps {
         deleteDir()
         gitCheckout(basedir: "${BASE_DIR}",
-          branch: "master",
           repo: "git@github.com:elastic/${REPO}.git",
           credentialsId: "${JOB_GIT_CREDENTIALS}"
         )

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -196,8 +196,11 @@ def createDescription() {
   if (env?.SPEC_UPDATED?.equals('true')){
     // Compare with the target or base branch to which the change could be merged, otherwise the branch name
     def to = isPR() ? env.CHANGE_TARGET : env.BRANCH_NAME
-    sh 'git --no-pager log --pretty=oneline | true'
-    sh 'git --no-pager log ${env.GIT_PREVIOUS_SUCCESSFUL_COMMIT}...head --pretty=oneline --follow -- tests/agents || true'
+    sh """
+      git --no-pager log --pretty=oneline | true
+      pwd
+      git --no-pager log ${env.GIT_PREVIOUS_SUCCESSFUL_COMMIT}...head --pretty=oneline --follow -- tests/agents || true
+    """
     def gitLog = sh(script: "git --no-pager log ${env.GIT_PREVIOUS_SUCCESSFUL_COMMIT}...${to} --pretty=oneline --follow -- tests/agents || true", returnStdout: true)
     message += "* Changeset \n ${gitLog}"
   }


### PR DESCRIPTION
## What

When creating PRs automatically for changes in the `tests/agents` folder then add the git log with the context or when they were launched manually too.

__NOTE__: In the CI is required to use `HEAD`

## Issues

Closes https://github.com/elastic/observability-robots/issues/231

## Tests

### CLI

```cucumber
Given https://github.com/elastic/apm/commit/e5f315e5ba1a941d9132a05da7620c4eb9efcb81 that was caused by https://github.com/elastic/apm/pull/245 
When compare with the `master` branch (https://github.com/elastic/apm/compare/e5f315e5ba1a941d9132a05da7620c4eb9efcb81...master)
and tests/agents folder
Then 0c78d54ebc748c6593c475fb97f1e2adec0977db and 25067c471fb794177d8272655817d8318b90b51f should be shown
```

```bash
$ docker run --rm -ti -v $(PWD):/app -w /app  ubuntu /bin/bash
$ apt-get update && apt-get install -y git
$ git --no-pager \
         log e5f315e5ba1a941d9132a05da7620c4eb9efcb81...master \
          --pretty=format:"https://github.com/elastic/apm/commit/%h %s" \
         --follow \
         -- tests/agents \
     | sed 's/#\([0-9]\+\)/https:\/\/github.com\/elastic\/apm\/pull\/\1/g'
https://github.com/elastic/apm/commit/0c78d54 Add SQL parsing performance examples (https://github.com/elastic/apm/pull/186)
https://github.com/elastic/apm/commit/25067c4 Add wildcard matcher tests (https://github.com/elastic/apm/pull/313)
```

### CI with DRY_RUN and FORCE

- The [build](https://apm-ci.elastic.co/blue/organizations/jenkins/apm-shared%2Fapm-update-specs-mbp/detail/PR-341/3/pipeline/) caused [this](https://apm-ci.elastic.co/blue/organizations/jenkins/apm-shared%2Fapm-update-specs-mbp/detail/PR-341/3/pipeline/105), see the below screenshot

![image](https://user-images.githubusercontent.com/2871786/93760966-e4634080-fc04-11ea-9613-d013c1df6ef3.png)

### CI with changes

- dfbd969 caused the build [#17](https://apm-ci.elastic.co/blue/organizations/jenkins/apm-shared%2Fapm-update-specs-mbp/detail/PR-341/17/pipeline)

![image](https://user-images.githubusercontent.com/2871786/93787310-3b2e4180-fc28-11ea-8601-410416747fe8.png)

See [logs here](https://apm-ci.elastic.co/blue/organizations/jenkins/apm-shared%2Fapm-update-specs-mbp/detail/PR-341/17/pipeline/121)