### PR TITLE
Consider aborted request outcome as unknown

### DIFF
--- a/specs/agents/tracing-instrumentation-http.md
+++ b/specs/agents/tracing-instrumentation-http.md
@@ -46,4 +46,5 @@ For outbound HTTP request spans we capture the following http-specific span cont
   The captured URL should have the userinfo (username and password), if any, redacted.
 - `http.status_code` (the response status code) \
   The span's `outcome` should be set to `"success"` if the status code is lower than 400 and to `"failure"` otherwise. 
+  If the request is aborted the `outcome` should be set to `unknown`.
 


### PR DESCRIPTION
The outcome of aborted outgoing http requests should be considered `unknown`. In the future we might consider adding a separate outcome for aborted requests. 