### PR TITLE
Add traceparent spec

### DIFF
--- a/specs/agents/error-tracking.md
+++ b/specs/agents/error-tracking.md
@@ -7,7 +7,11 @@ The agent support reporting exceptions/errors. Errors may come in one of two for
 
 Agents should include exception handling in the instrumentation they provide, such that exceptions are reported to the APM Server automatically, without intervention. In addition, hooks into logging libraries may be provided such that logged errors are also sent to the APM Server.
 
-Errors may or may not occur within the context of a transaction or span. If they do, then they will be associated with them by recording the trace ID and transaction or span ID. This enables the APM UI to annotate traces with errors.
+Error objects will also include the `trace_id` (optional), an `id` (which in
+the case of errors is 128 bits, encoded as 32 hexadecimal digits), a
+`transaction_id`, and a `parent_id` (which is the `id` of the transaction or
+span that caused the error). If an error occurs outside of the context of a
+transaction or span, these fields may be missing.
 
 ### Impact on the `outcome`
 

--- a/specs/agents/tracing-distributed-tracing.md
+++ b/specs/agents/tracing-distributed-tracing.md
@@ -153,16 +153,16 @@ make sure we are fully aligned, all agents are implementing the specification de
 [this commit](https://github.com/w3c/trace-context-binary/blob/571cafae56360d99c1f233e7df7d0009b44201fe/spec/20-binary-format.md).
 
 Binary fields should only be used where strings are not allowed, such as in
-Kafka record headers. The field names should still be `traceparent` and
+Kafka record headers. The field names should be `elasticapmtraceparent` (due
+to the lack of finalization for the binary trace context spec) and
 `tracestate`.
 
 
-### Legacy HTTP Headers/Binary Fields
+### Legacy HTTP Header Name
 
-Some agents support the legacy header name `elastic-apm-traceparent` and the
-binary field name `elasticapmtraceparent`. These names were used while the W3C
-standard was being finalized, to avoid any backwards-compatibility issues. New
-agents do not need to support these legacy names. Because `tracestate` was
-not implemented until the standard was finalized, no legacy names exist for
-this field.
+Some agents support the legacy header name `elastic-apm-traceparent`. This name
+was used while the W3C standard was being finalized, to avoid any
+backwards-compatibility issues. New agents do not need to support this legacy
+name. Because `tracestate` was not implemented until the standard was
+finalized, no legacy names exist for this field.
 

--- a/specs/agents/tracing-distributed-tracing.md
+++ b/specs/agents/tracing-distributed-tracing.md
@@ -40,7 +40,7 @@ whole distributed trace and stays constant throughout a given trace.
 
 #### Transaction/Span ID, and Parent ID
 
-Each transaction object will store the global `trace_id`. If the transaction
+Each transaction and span object will store the global `trace_id`. If the transaction
 is started without an incoming `traceparent` header, then the `trace_id`
 should be generated.
 
@@ -78,8 +78,9 @@ The `sampled` flag is the least significant bit (right-most) and denotes that
 the caller may have recorded trace data. If this flag is unset (`0` in the
 least significant bit), the agent should not sample the transaction. If this
 flag is set (`1` in the least significant bit), the agent should sample the
-transaction. See the [sampling](tracing-sampling.md) specification for more
-details.
+transaction. The agent may ignore this flag if sampling a transaction would
+conflict with another config option, e.g. rate limit.See the
+[sampling](tracing-sampling.md) specification for more details.
 
 
 ### `tracestate`

--- a/specs/agents/tracing-distributed-tracing.md
+++ b/specs/agents/tracing-distributed-tracing.md
@@ -1,13 +1,13 @@
-### Distributed Tracing
+## Distributed Tracing
 
 We implement the [W3C standards](https://www.w3.org/TR/trace-context-1/) for
 `traceparent` and `tracestate`, both for HTTP headers and binary fields.
 
 
-#### `trace_id`, `parent_id`, and `traceparent`
+### `trace_id`, `parent_id`, and `traceparent`
 
-Our `trace_id`, `parent_id`, and `traceparent` HTTP header all follow the
-standard established by the
+Our `trace_id`, `parent_id`, and the combined `traceparent` HTTP header follow
+the standard established by the
 [W3C Trace-Context Spec](https://github.com/w3c/trace-context/blob/master/spec/20-http_request_header_format.md#traceparent-header).
 
 The `traceparent` header is composed of four parts:
@@ -20,25 +20,25 @@ The `traceparent` header is composed of four parts:
 Example:
 
 ```
-elastic-apm-traceparent: 00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01
-(_____________________)  () (______________________________) (______________) ()
-            v            v                 v                        v         v
-      Header name       Version        Trace-Id                Span-Id     Flags
+traceparent: 00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01
+             () (______________________________) (______________) ()
+             v                 v                        v         v
+           Version         Trace-Id                 Span-Id     Flags
 ```
 
 
-##### Version
+#### Version
 
-The `version` is 1 byte representing an 8-bit unsigned integer. Currently,
-the `version` will always be `00`.
+The `version` is 1 byte (2 hexadecimal digits) representing an 8-bit unsigned
+integer. Currently, the `version` will always be `00`.
 
-##### Trace ID
+#### Trace ID
 
 A Trace ID is globally unique, and consists of 128 random bits (like a UUID).
 Its string representation is 32 hexadecimal digits.  This is the ID for the
 whole distributed trace and stays constant throughout a given trace.
 
-##### Transaction/Span ID, and Parent ID
+#### Transaction/Span ID, and Parent ID
 
 Each transaction object will store the global `trace_id`. If the transaction
 is started without an incoming `traceparent` header, then the `trace_id`
@@ -65,14 +65,14 @@ the case of errors is 128 bits, encoded as 32 hexadecimal digits), a
 span that caused the error).
 
 
-##### Flags
+#### Flags
 
 The W3C traceparent header specifies 8 bits for flags. Currently, only a single
 flag (`sampled`) is defined, with the rest reserved for later use. These flags
 are recommendations given by the by the caller rather than strict rules to
 follow.
 
-###### Sampled
+##### Sampled
 
 The `sampled` flag is the least significant bit (right-most) and denotes that
 the caller may have recorded trace data. If this flag is unset (`0` in the
@@ -82,7 +82,7 @@ transaction. See the [sampling](tracing-sampling.md) specification for more
 details.
 
 
-#### `tracestate`
+### `tracestate`
 
 For our own `es` `tracestate` entry we will introduce a `key:value` formatted list of attributes.
 This is used to propagate the sampling rate downstream, for example.
@@ -97,7 +97,7 @@ For example:
     tracestate: es=s:0.1,othervendor=<opaque>
 
 
-##### Validation and length limits
+#### Validation and length limits
 
 The [`tracestate`](https://www.w3.org/TR/trace-context/#tracestate-header)
 specification lists a number of validation rules.
@@ -131,7 +131,7 @@ would also cause unexpected behavior. In any case, this situation should be
 rare and we feel comfortable ignoring the validation rules in this case.
 
 
-#### HTTP Headers
+### HTTP Headers
 
 Every outgoing request should be intercepted and modified to include both the
 `traceparent` and `tracestate` headers, described above.
@@ -145,7 +145,7 @@ representing the outgoing request. If (and only if) that span is not sampled,
 the `span-id` may instead be the `id` of the current transaction.
 
 
-#### Binary Fields
+### Binary Fields
 
 Our implementation relies on the [W3C Binary Trace
 Context](https://w3c.github.io/trace-context-binary/) standard.  In order to
@@ -157,7 +157,7 @@ Kafka record headers. The field names should still be `traceparent` and
 `tracestate`.
 
 
-#### Legacy HTTP Headers/Binary Fields
+### Legacy HTTP Headers/Binary Fields
 
 Some agents support the legacy header name `elastic-apm-traceparent` and the
 binary field name `elasticapmtraceparent`. These names were used while the W3C

--- a/specs/agents/tracing-distributed-tracing.md
+++ b/specs/agents/tracing-distributed-tracing.md
@@ -23,7 +23,7 @@ Example:
 traceparent: 00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01
              () (______________________________) (______________) ()
              v                 v                        v         v
-           Version         Trace-Id                 Span-Id     Flags
+           Version         Trace-Id                 Parent-Id    Flags
 ```
 
 
@@ -48,11 +48,15 @@ Each transaction and span object will have an `id`. This is generated for each
 transaction and span, and is 64 random bits (with a string representation of
 16 hexadecimal digits).
 
-Each transaction and span object will have a `parent_id`, except for the
-very first transaction in the distributed trace. The `parent_id` will be the
-`id` of the parent transaction/span. For new transactions with an incoming
-`traceparent` header, the `span-id` piece of the `traceparent` should be
-used as the `parent_id`.
+Each transaction and span object will have a `parent_id`, except for the very
+first transaction in the distributed trace. Some agents allow the user to
+ensure a parent ID is present on a transaction via an API call. In this case,
+if the transaction doesn't have a `parent_id` the agent will generate a new ID
+and set it as the `parent_id` for the transaction.
+
+The `parent_id` will be the `id` of the parent transaction/span. For new
+transactions with an incoming `traceparent` header, the `parent-id` piece of
+the `traceparent` should be used as the `parent_id`.
 
 In addition to the above rules, spans will also have a `transaction_id`,
 which is the `id` of the current transaction. While not necessary for
@@ -62,7 +66,8 @@ queries.
 Error objects will also include the `trace_id` (optional), an `id` (which in
 the case of errors is 128 bits, encoded as 32 hexadecimal digits), a
 `transaction_id`, and a `parent_id` (which is the `id` of the transaction or
-span that caused the error).
+span that caused the error). If an error occurs outside of the context of a
+transaction or span, these fields may be missing.
 
 
 #### Flags

--- a/specs/agents/tracing-distributed-tracing.md
+++ b/specs/agents/tracing-distributed-tracing.md
@@ -145,6 +145,10 @@ The `span-id` part of the `traceparent` header should be the `id` of the span
 representing the outgoing request. If (and only if) that span is not sampled,
 the `span-id` may instead be the `id` of the current transaction.
 
+HTTP/text format should be used for headers wherever possible. Only in cases
+where binary fields are necessary (such as in Kafka record headers) should
+binary fields be used. (See below for binary fields)
+
 
 ### Binary Fields
 

--- a/specs/agents/tracing-distributed-tracing.md
+++ b/specs/agents/tracing-distributed-tracing.md
@@ -4,7 +4,85 @@ We implement the [W3C standards](https://www.w3.org/TR/trace-context-1/) for
 `traceparent` and `tracestate`, both for HTTP headers and binary fields.
 
 
-#### Tracestate
+#### `trace_id`, `parent_id`, and `traceparent`
+
+Our `trace_id`, `parent_id`, and `traceparent` HTTP header all follow the
+standard established by the
+[W3C Trace-Context Spec](https://github.com/w3c/trace-context/blob/master/spec/20-http_request_header_format.md#traceparent-header).
+
+The `traceparent` header is composed of four parts:
+
+ * `version`
+ * `trace-id`
+ * `parent-id`
+ * `trace-flags`
+
+Example:
+
+```
+elastic-apm-traceparent: 00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01
+(_____________________)  () (______________________________) (______________) ()
+            v            v                 v                        v         v
+      Header name       Version        Trace-Id                Span-Id     Flags
+```
+
+
+##### Version
+
+The `version` is 1 byte representing an 8-bit unsigned integer. Currently,
+the `version` will always be `00`.
+
+##### Trace ID
+
+A Trace ID is globally unique, and consists of 128 random bits (like a UUID).
+Its string representation is 32 hexadecimal digits.  This is the ID for the
+whole distributed trace and stays constant throughout a given trace.
+
+##### Transaction/Span ID, and Parent ID
+
+Each transaction object will store the global `trace_id`. If the transaction
+is started without an incoming `traceparent` header, then the `trace_id`
+should be generated.
+
+Each transaction and span object will have an `id`. This is generated for each
+transaction and span, and is 64 random bits (with a string representation of
+16 hexadecimal digits).
+
+Each transaction and span object will have a `parent_id`, except for the
+very first transaction in the distributed trace. The `parent_id` will be the
+`id` of the parent transaction/span. For new transactions with an incoming
+`traceparent` header, the `span-id` piece of the `traceparent` should be
+used as the `parent_id`.
+
+In addition to the above rules, spans will also have a `transaction_id`,
+which is the `id` of the current transaction. While not necessary for
+distributed tracing, this inclusion allows for simpler and more performant UI
+queries.
+
+Error objects will also include the `trace_id` (optional), an `id` (which in
+the case of errors is 128 bits, encoded as 32 hexadecimal digits), a
+`transaction_id`, and a `parent_id` (which is the `id` of the transaction or
+span that caused the error).
+
+
+##### Flags
+
+The W3C traceparent header specifies 8 bits for flags. Currently, only a single
+flag (`sampled`) is defined, with the rest reserved for later use. These flags
+are recommendations given by the by the caller rather than strict rules to
+follow.
+
+###### Sampled
+
+The `sampled` flag is the least significant bit (right-most) and denotes that
+the caller may have recorded trace data. If this flag is unset (`0` in the
+least significant bit), the agent should not sample the transaction. If this
+flag is set (`1` in the least significant bit), the agent should sample the
+transaction. See the [sampling](tracing-sampling.md) specification for more
+details.
+
+
+#### `tracestate`
 
 For our own `es` `tracestate` entry we will introduce a `key:value` formatted list of attributes.
 This is used to propagate the sampling rate downstream, for example.
@@ -53,6 +131,20 @@ would also cause unexpected behavior. In any case, this situation should be
 rare and we feel comfortable ignoring the validation rules in this case.
 
 
+#### HTTP Headers
+
+Every outgoing request should be intercepted and modified to include both the
+`traceparent` and `tracestate` headers, described above.
+
+If an incoming request contains either of the `traceparent` or `tracestate`
+headers, they should be propagated throughout the transaction and mutated as
+specified above before being set on outgoing requests.
+
+The `span-id` part of the `traceparent` header should be the `id` of the span
+representing the outgoing request. If (and only if) that span is not sampled,
+the `span-id` may instead be the `id` of the current transaction.
+
+
 #### Binary Fields
 
 Our implementation relies on the [W3C Binary Trace
@@ -61,7 +153,8 @@ make sure we are fully aligned, all agents are implementing the specification de
 [this commit](https://github.com/w3c/trace-context-binary/blob/571cafae56360d99c1f233e7df7d0009b44201fe/spec/20-binary-format.md).
 
 Binary fields should only be used where strings are not allowed, such as in
-Kafka record headers.
+Kafka record headers. The field names should still be `traceparent` and
+`tracestate`.
 
 
 #### Legacy HTTP Headers/Binary Fields
@@ -70,6 +163,6 @@ Some agents support the legacy header name `elastic-apm-traceparent` and the
 binary field name `elasticapmtraceparent`. These names were used while the W3C
 standard was being finalized, to avoid any backwards-compatibility issues. New
 agents do not need to support these legacy names. Because `tracestate` was
-not implemented until the standar was finalized, no legacy names exist for
+not implemented until the standard was finalized, no legacy names exist for
 this field.
 

--- a/specs/agents/tracing-spans.md
+++ b/specs/agents/tracing-spans.md
@@ -2,6 +2,16 @@
 
 The agent should also have a sense of the most common libraries for these and instrument them without any further setup from the app developers.
 
+#### Span ID fields
+
+Each span object will have an `id`. This is generated for each transaction and
+span, and is 64 random bits (with a string representation of 16 hexadecimal
+digits).
+
+Spans will also have a `transaction_id`, which is the `id` of the current
+transaction. While not necessary for distributed tracing, this inclusion allows
+for simpler and more performant UI queries.
+
 #### Span outcome
 
 The `outcome` property denotes whether the span represents a success or a failure.


### PR DESCRIPTION
Previously this spec lived in a google doc and a bunch of other issues. While chatting about trace context with @astorm I realized we should have our `traceparent` spec in the same location as `tracestate` spec.

I tried to distill the contents of the doc down to the essentials.

The only change I made to the `traceparent` spec is to specify that support for the legacy header name was no longer required.

I also made a few small changes around `tracestate` -- specifically the validation rules. I also reorganized the doc a bit and clarified the use of binary fields.