### PR TITLE
ci: add JSON_SPECS_PATH paths for nodejs to .ci/.jenkins-agents.yml

### DIFF
--- a/.ci/.jenkins-agents.yml
+++ b/.ci/.jenkins-agents.yml
@@ -18,4 +18,4 @@ agents:
     FEATURES_PATH: "features"
     JSON_SPECS_PATH: "spec/fixtures"
   - REPO: "apm-agent-nodejs"
-    JSON_SPECS_PATH: "tests/fixtures/json-specs"
+    JSON_SPECS_PATH: "test/fixtures/json-specs"

--- a/.ci/.jenkins-agents.yml
+++ b/.ci/.jenkins-agents.yml
@@ -17,3 +17,5 @@ agents:
   - REPO: "apm-agent-ruby"
     FEATURES_PATH: "features"
     JSON_SPECS_PATH: "spec/fixtures"
+  - REPO: "apm-agent-nodejs"
+    JSON_SPECS_PATH: "tests/fixtures/json-specs"


### PR DESCRIPTION
Moves https://github.com/elastic/apm-agent-nodejs/issues/1872 forward

Presumes `tests/fixtures/json-specs` does not need to exist in the repo that files will be PRd/synced to. 