### PR TITLE
chore(ci): support selecting an APM Agent (or all) to send the PR with updates

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -119,9 +119,11 @@ pipeline {
             def agents = readYaml(file: '.ci/.jenkins-agents.yml')
             def parallelTasks = [:]
             agents['agents'].each { agent ->
-              def repository = 'apm-agent-' + agent.REPO
-              if (env.SELECTED_AGENT == 'All' || env.SELECTED_AGENT == repository) {
-                parallelTasks["${agent.REPO}"] = generateStepForAgent(repo: "${agent.REPO}", filesType: "gherkin", filesPath: "${agent.FEATURES_PATH}")
+              if (agent.FEATURES_PATH) {
+                def repository = 'apm-agent-' + agent.REPO
+                if (env.SELECTED_AGENT == 'All' || env.SELECTED_AGENT == repository) {
+                  parallelTasks["${agent.REPO}"] = generateStepForAgent(repo: "${agent.REPO}", filesType: "gherkin", filesPath: "${agent.FEATURES_PATH}")
+                }
               }
             }
 

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -139,7 +139,8 @@ pipeline {
       }
       environment {
         // agentMapping is defined in the shared library as a map
-        SELECTED_AGENT = agentMapping.id(params.APM_AGENTS)
+        APM_AGENTS = "${params?.APM_AGENTS}"
+        SELECTED_AGENT = agentMapping.id(env.APM_AGENTS)
       }
       when {
         beforeAgent true

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -157,7 +157,7 @@ pipeline {
             def parallelTasks = [:]
             agents['agents'].each { agent ->
               if (agent.JSON_SPECS_PATH) {
-                if (env.SELECTED_AGENT == 'all' || env.SELECTED_AGENT == agent.REPO) 
+                if (env.SELECTED_AGENT == 'all' || env.SELECTED_AGENT == agent.REPO) {
                   parallelTasks["${agent.REPO}"] = generateStepForAgent(repo: "${agent.REPO}", filesType: "json", filesPath: "${agent.JSON_SPECS_PATH}")
                 }
               }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -121,8 +121,8 @@ pipeline {
             def parallelTasks = [:]
             agents['agents'].each { agent ->
               if (agent.FEATURES_PATH) {
-                def repository = 'apm-agent-' + agent.REPO
-                if (env.SELECTED_AGENT == 'All' || env.SELECTED_AGENT == repository) {
+                def repository = 'apm-agent-' + env.SELECTED_AGENT
+                if (env.SELECTED_AGENT == 'all' || repository == agent.REPO) {
                   parallelTasks["${agent.REPO}"] = generateStepForAgent(repo: "${agent.REPO}", filesType: "gherkin", filesPath: "${agent.FEATURES_PATH}")
                 }
               }
@@ -157,7 +157,8 @@ pipeline {
             def parallelTasks = [:]
             agents['agents'].each { agent ->
               if (agent.JSON_SPECS_PATH) {
-                if (env.SELECTED_AGENT == 'all' || env.SELECTED_AGENT == agent.REPO) {
+                def repository = 'apm-agent-' + env.SELECTED_AGENT
+                if (env.SELECTED_AGENT == 'all' || repository == agent.REPO) {
                   parallelTasks["${agent.REPO}"] = generateStepForAgent(repo: "${agent.REPO}", filesType: "json", filesPath: "${agent.JSON_SPECS_PATH}")
                 }
               }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -157,8 +157,7 @@ pipeline {
             def parallelTasks = [:]
             agents['agents'].each { agent ->
               if (agent.JSON_SPECS_PATH) {
-                def repository = 'apm-agent-' + agent.REPO
-                if (env.SELECTED_AGENT == 'All' || env.SELECTED_AGENT == repository) {
+                if (env.SELECTED_AGENT == 'all' || env.SELECTED_AGENT == agent.REPO) 
                   parallelTasks["${agent.REPO}"] = generateStepForAgent(repo: "${agent.REPO}", filesType: "json", filesPath: "${agent.JSON_SPECS_PATH}")
                 }
               }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -121,8 +121,7 @@ pipeline {
             def parallelTasks = [:]
             agents['agents'].each { agent ->
               if (agent.FEATURES_PATH) {
-                def repository = 'apm-agent-' + env.SELECTED_AGENT
-                if (env.SELECTED_AGENT == 'all' || repository == agent.REPO) {
+                if (env.SELECTED_AGENT == 'all' || "apm-agent-${env.SELECTED_AGENT}" == agent.REPO) {
                   parallelTasks["${agent.REPO}"] = generateStepForAgent(repo: "${agent.REPO}", filesType: "gherkin", filesPath: "${agent.FEATURES_PATH}")
                 }
               }
@@ -158,8 +157,7 @@ pipeline {
             def parallelTasks = [:]
             agents['agents'].each { agent ->
               if (agent.JSON_SPECS_PATH) {
-                def repository = 'apm-agent-' + env.SELECTED_AGENT
-                if (env.SELECTED_AGENT == 'all' || repository == agent.REPO) {
+                if (env.SELECTED_AGENT == 'all' || "apm-agent-${env.SELECTED_AGENT}" == agent.REPO) {
                   parallelTasks["${agent.REPO}"] = generateStepForAgent(repo: "${agent.REPO}", filesType: "json", filesPath: "${agent.JSON_SPECS_PATH}")
                 }
               }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -109,7 +109,8 @@ pipeline {
       }
       environment {
         // agentMapping is defined in the shared library as a map
-        SELECTED_AGENT = agentMapping.id(params.APM_AGENTS)
+        APM_AGENTS = "${params?.APM_AGENTS}"
+        SELECTED_AGENT = agentMapping.id(env.APM_AGENTS)
       }
       steps {
         deleteDir()

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -43,6 +43,7 @@ pipeline {
   parameters {
     booleanParam(name: 'DRY_RUN_MODE', defaultValue: false, description: 'If true, allows to execute this pipeline in dry run mode, without sending a PR.')
     booleanParam(name: 'FORCE_SEND_PR', defaultValue: false, description: 'If true, will force sending a PR, although it could be affected by the value off the DRY_RUN parameter: if the latter is true, a message will be printed in the console.')
+    choice(name: 'APM_AGENTS', choices: ['All','.NET', 'Go', 'Java', 'Node.js', 'PHP', 'Python', 'Ruby', 'RUM'], description: 'Name of the APM Agent you want to update its specs.')
   }
   stages {
     stage('Checkout'){
@@ -106,6 +107,10 @@ pipeline {
           expression { return params.FORCE_SEND_PR }
         }
       }
+      environment {
+        // agentMapping is defined in the shared library as a map
+        SELECTED_AGENT = agentMapping.id(params.APM_AGENTS)
+      }
       steps {
         deleteDir()
         unstash 'source'
@@ -114,7 +119,10 @@ pipeline {
             def agents = readYaml(file: '.ci/.jenkins-agents.yml')
             def parallelTasks = [:]
             agents['agents'].each { agent ->
-              parallelTasks["${agent.REPO}"] = generateStepForAgent(repo: "${agent.REPO}", filesType: "gherkin", filesPath: "${agent.FEATURES_PATH}")
+              def repository = 'apm-agent-' + agent.REPO
+              if (env.SELECTED_AGENT == 'All' || env.SELECTED_AGENT == repository) {
+                parallelTasks["${agent.REPO}"] = generateStepForAgent(repo: "${agent.REPO}", filesType: "gherkin", filesPath: "${agent.FEATURES_PATH}")
+              }
             }
 
             parallel(parallelTasks)
@@ -125,6 +133,10 @@ pipeline {
     stage('Send Pull Request for JSON specs'){
       options {
         warnError('Pull Requests to APM agents failed')
+      }
+      environment {
+        // agentMapping is defined in the shared library as a map
+        SELECTED_AGENT = agentMapping.id(params.APM_AGENTS)
       }
       when {
         beforeAgent true
@@ -142,7 +154,10 @@ pipeline {
             def parallelTasks = [:]
             agents['agents'].each { agent ->
               if (agent.JSON_SPECS_PATH) {
-                parallelTasks["${agent.REPO}"] = generateStepForAgent(repo: "${agent.REPO}", filesType: "json", filesPath: "${agent.JSON_SPECS_PATH}")
+                def repository = 'apm-agent-' + agent.REPO
+                if (env.SELECTED_AGENT == 'All' || env.SELECTED_AGENT == repository) {
+                  parallelTasks["${agent.REPO}"] = generateStepForAgent(repo: "${agent.REPO}", filesType: "json", filesPath: "${agent.JSON_SPECS_PATH}")
+                }
               }
             }
 


### PR DESCRIPTION
## What does this PR do?
It adds a selector in the Jenkins UI when manually triggering the build. This selector will use the internals of the APM Shared pipeline library to get the APM Agent repository name, which will be compared to what is defined at `.jenkins-agents.yml`.

If the selected item is `All` (default) or the name of the agent, it will be added to the parallel execution.

Another improvement is that we are checking if the agent is defining a `FEATURES_PATH` in the aforementioned descriptor. (i.e. the NodeJS agent).

## Why is it important?
It will allow adding new agents without sending PRs to the rest of them, causing noise.

The change evaluating the FEATURES_PATH variable will support not adding an agent not including it.

## Screenshots
After triggering a DRY_RUN build for this PR, for the NodeJS agent, it only adds the node-js agent to the parallel branch for JSON specs, but not for the BDD specs (as it's not defined there).

<img width="1402" alt="Screenshot 2020-11-16 at 17 06 18" src="https://user-images.githubusercontent.com/951580/99277429-18866680-282e-11eb-98b5-d5a2b0270c9f.png">
