### PR TITLE
Fixing cloud metadata spec link

### DIFF
--- a/specs/agents/metadata.md
+++ b/specs/agents/metadata.md
@@ -74,9 +74,7 @@ For official Elastic agents, the agent name should just be the name of the langu
 is collected from local cloud provider metadata services:
 
 - availability_zone
-- account
-  - id
-  - name
+- account.id
 - instance
   - id
   - name

--- a/specs/agents/metadata.md
+++ b/specs/agents/metadata.md
@@ -70,7 +70,7 @@ For official Elastic agents, the agent name should just be the name of the langu
 
 ### Cloud Provider Metadata
 
-[Cloud provider metadata](https://github.com/elastic/apm-server/blob/master/docs/spec/v2/metadata.json#L5-L129)
+[Cloud provider metadata](https://github.com/elastic/apm-server/blob/master/docs/spec/v2/metadata.json)
 is collected from local cloud provider metadata services:
 
 - availability_zone

--- a/specs/agents/metadata.md
+++ b/specs/agents/metadata.md
@@ -70,7 +70,7 @@ For official Elastic agents, the agent name should just be the name of the langu
 
 ### Cloud Provider Metadata
 
-[Cloud provider metadata](https://github.com/elastic/apm-server/blob/master/docs/spec/cloud.json)
+[Cloud provider metadata](https://github.com/elastic/apm-server/blob/master/docs/spec/v2/metadata.json#L5-L129)
 is collected from local cloud provider metadata services:
 
 - availability_zone


### PR DESCRIPTION
In addition, it doesn't seem that `account.name` is actually collected in any of the currently supported cloud providers. Should it be removed?