### PR TITLE
Clarifies Behavior of SANITIZE_FIELD_NAMES

### DIFF
--- a/specs/agents/sanitization.md
+++ b/specs/agents/sanitization.md
@@ -50,7 +50,7 @@ headers, and form fields in an `application/x-www-form-urlencoded` request
 body.  No fields (including `set-cookie` headers) are exempt from this.
 
 The query string and other captured request bodies (such as `application/json`)
-MUST NOT be sanitized.
+SHOULD NOT be sanitized.
 
 Agents MAY choose to further sanitize fields based on the _value_ of a
 particular field, including the keys and values stored in a cookie header.

--- a/specs/agents/sanitization.md
+++ b/specs/agents/sanitization.md
@@ -53,6 +53,6 @@ The query string and other captured request bodies (such as `application/json`)
 MUST NOT be sanitized.
 
 Agents MAY choose to further sanitize fields based on the _value_ of a
-particular field, including the keys and values store in a cookie header.
+particular field, including the keys and values stored in a cookie header.
 Agents SHOULD consider sanitization based on values to be a seperate
 feature with its own configuration.

--- a/specs/agents/sanitization.md
+++ b/specs/agents/sanitization.md
@@ -54,3 +54,5 @@ MUST NOT be sanitized.
 
 Agents MAY choose to further sanitize fields based on the _value_ of a
 particular field, including the keys and values store in a cookie header.
+Agents SHOULD consider sanitization based on values to be a seperate
+feature with its own configuration.

--- a/specs/agents/sanitization.md
+++ b/specs/agents/sanitization.md
@@ -47,7 +47,4 @@ body.  No fields (including `set-cookie` headers) are exempt from this.
 The query string and other captured request bodies (such as `application/json`)
 SHOULD NOT be sanitized.
 
-Agents MAY choose to further sanitize fields based on the _value_ of a
-particular field, including the keys and values stored in a cookie header.
-Agents SHOULD consider sanitization based on values to be a seperate
-feature with its own configuration.
+Agents SHOULD NOT sanitize fields based on the _value_ of a particular field.

--- a/specs/agents/sanitization.md
+++ b/specs/agents/sanitization.md
@@ -39,7 +39,7 @@ default values.
 ## Sanitizing Values
 
 If a payload field's name (a header key, a form key) matches a configured
-wildcard, that field's _value_ MUST be removed/redacted and the key itself
+wildcard, that field's _value_ MUST be redacted and the key itself
 MUST still be reported in the agent payload. Agents MAY chose the string
 they use to replace the value so long as it's consistent and does not reveal
 the value it has replaced. Some example replacement strings

--- a/specs/agents/sanitization.md
+++ b/specs/agents/sanitization.md
@@ -20,7 +20,7 @@ how an agent will sanitize data.
 | Dynamic        | `true` |
 | Central config | `true` |
 
-## Configuration
+#### Configuration
 
 Agents MUST provide a minimum default configuration of
 

--- a/specs/agents/sanitization.md
+++ b/specs/agents/sanitization.md
@@ -46,7 +46,7 @@ the value it has replaced. Some example replacement strings
 include `REDACTED`, `**********`, `-----------`, etc.
 
 Fields that MUST be sanitized are the HTTP Request headers, HTTP Response
-headers, and form fields in a `application/x-www-form-urlencoded` request
+headers, and form fields in an `application/x-www-form-urlencoded` request
 body.  No fields (including `set-cookie` headers) are exempt from this.
 
 The query string and other captured request bodies (such as `application/json`)

--- a/specs/agents/sanitization.md
+++ b/specs/agents/sanitization.md
@@ -1,12 +1,17 @@
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in this document are to
+be interpreted as described in
+[RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
+
 ## Data sanitization
 
 ### `sanitize_field_names` configuration
 
 Sometimes it is necessary to sanitize, i.e., remove,
 sensitive data sent to Elastic APM.
-This config accepts a list of wildcard patterns of field names which should be sanitized.
-These apply to HTTP headers (including cookies) and `application/x-www-form-urlencoded` data (POST form fields).
-The query string and the captured request body (such as `application/json` data) will not get sanitized.
+
+This config accepts a list of wildcard patterns of field names which should be
+sanitized.
 
 |                |   |
 |----------------|---|
@@ -14,3 +19,38 @@ The query string and the captured request body (such as `application/json` data)
 | Default        | `password, passwd, pwd, secret, *key, *token*, *session*, *credit*, *card*, authorization, set-cookie` |
 | Dynamic        | `true` |
 | Central config | `true` |
+
+## Configuration
+
+Agents MUST provide a minimum default configuration of
+
+    [ 'password', 'passwd', 'pwd', 'secret', '*key', '*token*', '*session*',
+      '*credit*','*card*', 'authorization', 'set-cookie']
+
+for the `sanitize_field_names` configuration value.  Agent's MAY include the
+following extra fields in their default configuration to avoid breaking changes
+
+    ['pw','pass','connect.sid']
+
+If an end-user configures different values, these values MUST **replace** the
+above values. An end-user's configured values MUST NOT be merged with these
+default values.
+
+## Sanitizing Values
+
+If a payload field's name (a header key, a form key) matches a configured
+wildcard, that field's _value_ MUST be removed/redacted and the key itself
+MUST still be reported in the agent payload. Agents MAY chose the string
+they use to replace the value so long as it's consistent and does not reveal
+the value it has replaced. Some example replacement strings
+include `REDACTED`, `**********`, `-----------`, etc.
+
+Fields that MUST be sanitized are the HTTP Request headers, HTTP Response
+headers, and form fields in a `application/x-www-form-urlencoded` request
+body.  No fields (including `set-cookie` headers) are exempt from this.
+
+The query string and other captured request bodies (such as `application/json`)
+MUST NOT be sanitized.
+
+Agents MAY choose to further sanitize fields based on the _value_ of a
+particular field, including the keys and values store in a cookie header.

--- a/specs/agents/sanitization.md
+++ b/specs/agents/sanitization.md
@@ -32,10 +32,6 @@ following extra fields in their default configuration to avoid breaking changes
 
     ['pw','pass','connect.sid']
 
-If an end-user configures different values, these values MUST **replace** the
-above values. An end-user's configured values MUST NOT be merged with these
-default values.
-
 ## Sanitizing Values
 
 If a payload field's name (a header key, a form key) matches a configured

--- a/specs/agents/sanitization.md
+++ b/specs/agents/sanitization.md
@@ -10,8 +10,8 @@ be interpreted as described in
 Sometimes it is necessary to sanitize, i.e., remove,
 sensitive data sent to Elastic APM.
 
-This config accepts a list of wildcard patterns of field names which should be
-sanitized.
+This config accepts a list of wildcard patterns of field names which control
+how an agent will sanitize data.
 
 |                |   |
 |----------------|---|

--- a/specs/agents/sanitization.md
+++ b/specs/agents/sanitization.md
@@ -40,7 +40,7 @@ default values.
 
 If a payload field's name (a header key, a form key) matches a configured
 wildcard, that field's _value_ MUST be redacted and the key itself
-MUST still be reported in the agent payload. Agents MAY chose the string
+MUST still be reported in the agent payload. Agents MAY choose the string
 they use to replace the value so long as it's consistent and does not reveal
 the value it has replaced. Some example replacement strings
 include `REDACTED`, `**********`, `-----------`, etc.

--- a/specs/agents/sanitization.md
+++ b/specs/agents/sanitization.md
@@ -38,8 +38,7 @@ If a payload field's name (a header key, a form key) matches a configured
 wildcard, that field's _value_ MUST be redacted and the key itself
 MUST still be reported in the agent payload. Agents MAY choose the string
 they use to replace the value so long as it's consistent and does not reveal
-the value it has replaced. Some example replacement strings
-include `REDACTED`, `**********`, `-----------`, etc.
+the value it has replaced. The replacement string SHOULD be `[REDACTED]`.
 
 Fields that MUST be sanitized are the HTTP Request headers, HTTP Response
 headers, and form fields in an `application/x-www-form-urlencoded` request


### PR DESCRIPTION
While we (Node Agent) were working on the `SANITIZE_FIELD_NAMES` feature we discovered some ambiguities in the spec -- likely due to there not being a Node Agent team when this spec was agreed on :)   

This PR attempts to resolve those ambiguities and is intended as the _start_ of a  conversation, not the end of one. Our intention is to better understand how all Agents are doing things.

- [ ] After landing, update [remote config description](https://github.com/elastic/kibana/blob/7.x/x-pack/plugins/apm/common/agent_configuration/setting_definitions/general_settings.ts#L227) 