### PR TITLE
Adding Messaging spec and aligning header levels

### DIFF
--- a/specs/agents/README.md
+++ b/specs/agents/README.md
@@ -45,6 +45,7 @@ You can find details about each of these in the [APM Data Model](https://www.ela
   - Instrumentation
       - [Databases](tracing-instrumentation-db.md)
       - [HTTP](tracing-instrumentation-http.md)
+      - [Messaging systems](tracing-instrumentation-messaging.md)
       - [gRPC](tracing-instrumentation-grpc.md)
       - [GraphQL](tracing-instrumentation-graphql.md)
 - [Error/exception tracking](error-tracking.md)

--- a/specs/agents/tracing-api.md
+++ b/specs/agents/tracing-api.md
@@ -1,4 +1,4 @@
-### Tracer APIs
+## Tracer APIs
 
 All agents must provide an API to enable developers to instrument their applications manually, in addition to any automatic instrumentation. Agents document their APIs in the elastic.co docs:
 

--- a/specs/agents/tracing-instrumentation-db.md
+++ b/specs/agents/tracing-instrumentation-db.md
@@ -1,4 +1,4 @@
-#### Database spans
+## Database spans
 
 We capture spans for various types of database/data-stores operations, such as SQL queries, Elasticsearch queries, Redis commands, etc. We follow some of the same conventions defined by OpenTracing for capturing database-specific span context, including:
 
@@ -15,7 +15,7 @@ For MongoDB, this can be set to the command encoded as MongoDB Extended JSON.
 
 For Elasticsearch search-type queries, the request body may be recorded. Alternatively, if a query is specified in HTTP query parameters, that may be used instead. If the body is gzip-encoded, the body should be decoded first.
 
-##### Database span names
+### Database span names
 
 For SQL operations we perform a limited parsing the statement, and extract the operation name and outer-most table involved (if any). See more details here: https://docs.google.com/document/d/1sblkAP1NHqk4MtloUta7tXjDuI_l64sT2ZQ_UFHuytA.
 
@@ -26,7 +26,7 @@ For MongoDB, the span name should be the command name in the context of its coll
 For Elasticsearch, the span name should be `Elasticsearch: <method> <path>`, e.g.
 `Elasticsearch: GET /index/_search`.
 
-##### Database span type/subtype
+### Database span type/subtype
 
 For database spans, the type should be `db` and subtype should be the database name. Agents should standardise on the following span subtypes:
 

--- a/specs/agents/tracing-instrumentation-graphql.md
+++ b/specs/agents/tracing-instrumentation-graphql.md
@@ -1,8 +1,8 @@
-# GraphQL transactions and spans
+## GraphQL transactions and spans
 
 **NB:** This document is not guaranteed to be final.
 
-## Problems with our current approach
+### Problems with our current approach
 
 Grouping transactions by HTTP method and path fits perfectly for REST-style APIs and the like.
 
@@ -46,13 +46,13 @@ Content-Type: application/json
 
 **Sidenote:** The Node.js agent already supports GraphQL. This document is written with that in mind but not necessarily with its implementation as a target result.
 
-## Transactions
+### Transactions
 
-### Prefix
+#### Prefix
 
 To distinguish GraphQL transactions from others we prefix them with `GraphQL:`.
 
-### Operation Name
+#### Operation Name
 
 It is common (and [recommended](https://graphql.org/learn/queries/#operation-name)) to provide an _Operation Name_ for queries. Here for example `UserWithComments`:
 
@@ -76,13 +76,13 @@ Transaction name examples:
 - `GraphQL: UserWithComments`
 - `GraphQL: UpdateUser`
 
-#### Sidenote: Multiple endpoints
+##### Sidenote: Multiple endpoints
 
 The Node.js implementation adds the request path to the GraphQL span names.
 
 We do not find serving multiple endpoints and using them with the same Operation Names likely enough to add it to this document.
 
-### Anonymous queries
+#### Anonymous queries
 
 An Operation Name isn't required. When one isn't provided it's hard for us to tell apart the queries.
 
@@ -121,7 +121,7 @@ To further help and nudge developers to use Operation Names for their queries, a
 Transaction name examples:
 - `GraphQL: [unnamed]`
 
-### Batching/Multiplexing queries
+#### Batching/Multiplexing queries
 
 Some clients and servers allow batching/multiplexing queries (see for example [apollo-link-batch-http](https://www.apollographql.com/docs/link/links/batch-http/#gatsby-focus-wrapper) or [dataloader](https://github.com/graphql/dataloader#batching)) allowing multiple queries to be run from the same HTTP request.
 
@@ -135,7 +135,7 @@ To avoid very long transaction names, if a request has more than five queries, w
 Transaction name examples:
 - `GraphQL: [more-than-five-queries]`
 
-## Spans
+### Spans
 
 The life cycle of responding to a GraphQL query is mostly split in two parts. First, the quer(y/ies) are read, parsed and analyzed. Second, they are executed.
 

--- a/specs/agents/tracing-instrumentation-grpc.md
+++ b/specs/agents/tracing-instrumentation-grpc.md
@@ -1,26 +1,26 @@
-# gRPC support in agents
+## gRPC support in agents
 
-## Header
+### Header
 
-### Value format
+#### Value format
 The value format of the header is text, as other vendors use text and there's no advantage to using a binary encoding. See technical details about the gRPC header [here](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#requests).
 
-### Key Names
+#### Key Names
 The header key names are `elastic-apm-traceparent` (for backwards compatibility with older agents) and `traceparent`.
 
-## Instrumented calls
+### Instrumented calls
 Server and Client Unary request/response calls are instrumented. Support for other calls may be added later (i.e. client/server streaming, bidirectional streaming).
 
-## Transaction/Span context schemas
+### Transaction/Span context schemas
 
-### Transaction context
+#### Transaction context
 
 * **name**: \<method\>, ex: `/helloworld.Greeter/SayHello`
 * **type**: `request`
 * **trace_context**: \<trace-context\>
 * **result**: [\<a-valid-result-value\>](https://github.com/grpc/grpc/blob/master/doc/statuscodes.md#status-codes-and-their-use-in-grpc), ex: `OK`
 
-### Span context
+#### Span context
 
 Note that the destination fields are optional as some gRPC libraries don't expose host and port information.
 See [apm#180](https://github.com/elastic/apm/issues/180) and [apm#115](https://github.com/elastic/apm/issues/115) for details on `destination` fields.

--- a/specs/agents/tracing-instrumentation-http.md
+++ b/specs/agents/tracing-instrumentation-http.md
@@ -1,4 +1,4 @@
-#### HTTP Transactions
+## HTTP Transactions
 
 Agents should instrument HTTP request routers/handlers, starting a new transaction for each incoming HTTP request. When the request ends, the transaction should be ended, recording its duration.
 
@@ -35,7 +35,7 @@ Request and response headers, cookies, and form bodies should be sanitised (i.e.
 
 Agents may may include additional patterns if there are common conventions specific to language frameworks.
 
-##### `transaction_ignore_urls` configuration
+### `transaction_ignore_urls` configuration
 
 Used to restrict requests to certain URLs from being instrumented.
 
@@ -61,7 +61,7 @@ All errors that are captured during a request to an ignored URL are still sent t
 | Dynamic        | `true` |
 | Central config | `true` |
 
-#### HTTP client spans
+## HTTP client spans
 
 We capture spans for outbound HTTP requests. These should have a type of `external`, and subtype of `http`. The span name should have the format `<method> <host>`.
 

--- a/specs/agents/tracing-instrumentation-messaging.md
+++ b/specs/agents/tracing-instrumentation-messaging.md
@@ -29,7 +29,7 @@ polling spans, where we want to capture such as well).
 - Spans: 
   - `span.type`: `messaging` 
   - `span.subtype`: the name of the framework - e.g. `jms`, `kafka`, `rabbitmq` 
-  - `span.action`: `send` or `receive`
+  - `span.action`: `send`, `receive` or `poll`
   
 ### Naming
 

--- a/specs/agents/tracing-instrumentation-messaging.md
+++ b/specs/agents/tracing-instrumentation-messaging.md
@@ -1,0 +1,79 @@
+## Messaging Systems
+
+The instrumentation of messaging systems includes:
+- Transaction creation on message reception, either as a child of the message-sending span, if the sending action is traced (meaning 
+distributed tracing support), or as root
+- Span creation for message sending action
+- Span creation on message *polling that occurs within a traced transaction*
+
+### Passive vs. Active message reception
+
+Message send/publish events can only be captured as spans if occurring within a traced transaction.
+Message consumption can be divided into two types: passive, where you would implement a listener that is called once a message is available, 
+and active, where the queue/topic is being polled (blocking or non-blocking). 
+
+Passive consumption typically results in a `messaging` transaction and is pretty straightforward to trace - start at entry and end at exit. 
+
+Message polling can be done within a traced transaction, in which case it should result in a messaging span, or it can be the initiating 
+event for a message handling flow. Capturing polling spans is also mostly straightforward. 
+For polling-based transactions, our goal is to capture the message handling flow, which typically *starts after the polling action exits*, 
+returning a message. This may be tricky if the handling flow is not implemented within a well defined API. Use other agent implementation
+as reference.
+The agent should not create a transaction based on polling APIs if the polling action did not result with a message (as opposed to 
+polling spans, where we want to capture such as well).
+
+### Typing
+
+- Transactions: 
+  - `transaction.type`: `messaging`
+- Spans: 
+  - `span.type`: `messaging` 
+  - `span.subtype`: the name of the framework - e.g. `jms`, `kafka`, `rabbitmq` 
+  - `span.action`: `send` or `receive`
+  
+### Naming
+
+Transaction and span names may* follow this pattern: `<MSG-FRAMEWORK> SEND/RECEIVE to/from <QUEUE-NAME>`.
+Examples:
+- `JMS SEND to MyQueue`
+- `RabbitMQ RECEIVE from MyExchange`**
+
+\* Java agent's instrumentation for Kafka does not follow this pattern at the moment.
+
+\** In RabbitMQ, queues are only relevant in the receiver side, so the exchange name is used instead. Agents may add an opt-in config to 
+append the routing key to the name as well, for example: `RabbitMQ RECEIVE from MyExchange\58D7EA987`.
+
+### Context fields
+
+- **`context.message.queue.name`**: optional for `messaging` spans and transactions. Indexed as keyword. Wherever the broker terminology 
+uses "topic", this field will contain the topic name.
+- **`context.message.body`**: similar to HTTP requests' `context.request.body`- only fill in messaging-related **transactions** (ie 
+incoming messages creating a transaction) and not for outgoing messaging spans. 
+   - Capture only when `ELASTIC_APM_CAPTURE_BODY` config is set to `true`.
+   - Only capture UTF-8 encoded message bodies.
+   - Limit size to 10000 characters. If longer than this size, trim to 9999 and append with ellipsis
+- **`context.message.headers`**: similar to HTTP requests' `context.request.headers`- only fill in messaging-related **transactions**.
+   - Capture only when `ELASTIC_APM_CAPTURE_HEADERS` config is set to `true`.
+   - Sanitize headers with keys configured through `ELASTIC_APM_SANITIZE_FIELD_NAMES`.
+   - Intake: key-value pairs, same like `context.request.headers`.
+- **`context.message.age.ms`** (optional): a numeric field indicating the message's age in milliseconds. Relevant for transactions and 
+`receive` spans that receive valid messages. There is no accurate definition as to how this is calculated. If the messaging framework 
+provides a timestamp for the message- agents may use it. Otherwise, the sending agent can add a timestamp _indicated as milliseconds since 
+epoch UTC_ to the message's metadata to be retrieved by the receiving agent. If a timestamp is not available- agents should omit this field. 
+Clock skews between agents are ignored, unless the calculated age (receive-timestamp minus send-timestamp) is negative, in which case the 
+agent should report 0 for this field.
+- **`context.message.routing-key`** (optional): use only where relevant. Currently only RabbitMQ.
+
+### `ELASTIC_APM_IGNORE_MESSAGE_QUEUES` configuration
+
+Used to filter out specific messaging queues/topics from being traced.
+
+This property should be set to a list containing one or more strings. When set, sends-to and receives-from the specified 
+queues/topic will be ignored.
+
+|                |   |
+|----------------|---|
+| Type           | `List<`[`WildcardMatcher`](../../tests/agents/json-specs/wildcard_matcher_tests.json)`>` |
+| Default        | empty |
+| Dynamic        | `true` |
+| Central config | `false` |

--- a/specs/agents/tracing-instrumentation-messaging.md
+++ b/specs/agents/tracing-instrumentation-messaging.md
@@ -87,7 +87,7 @@ incoming messages creating a transaction) and not for outgoing messaging spans.
 - **`context.destination.port`**: optional. Not available in some cases. Only set if the actual connection is available.
 - **`context.destination.service.name`**: mandatory. Use the framework name in lowercase, e.g. `kafka`, `rabbitmq`.
 - **`context.destination.service.resource`**: mandatory. Use the framework name in lowercase. Wherever the queue/topic/exchange name is
- available, append it with a leading `/`, for example: `kafka/myTopic`, `rabbitmq/myExchange`, `rabbitmq`.
+ available, append it with a leading `/`, for example: `kafka/myTopic`, `rabbitmq/myExchange`, `jms`.
 - **`context.destination.service.type`**: mandatory. Use `messaging`.
 
 ### `ignore_message_queues` configuration

--- a/specs/agents/tracing-instrumentation-messaging.md
+++ b/specs/agents/tracing-instrumentation-messaging.md
@@ -102,4 +102,4 @@ queues/topics/exchanges will be ignored.
 | Type           | `List<`[`WildcardMatcher`](../../tests/agents/json-specs/wildcard_matcher_tests.json)`>` |
 | Default        | empty |
 | Dynamic        | `true` |
-| Central config | `false` |
+| Central config | `true` |

--- a/specs/agents/tracing-instrumentation-messaging.md
+++ b/specs/agents/tracing-instrumentation-messaging.md
@@ -33,10 +33,11 @@ polling spans, where we want to capture such as well).
   
 ### Naming
 
-Transaction and span names may* follow this pattern: `<MSG-FRAMEWORK> SEND/RECEIVE to/from <QUEUE-NAME>`.
+Transaction and span names may* follow this pattern: `<MSG-FRAMEWORK> SEND/RECEIVE/POLL to/from <QUEUE-NAME>`.
 Examples:
 - `JMS SEND to MyQueue`
-- `RabbitMQ RECEIVE from MyExchange`**
+- `RabbitMQ RECEIVE from MyQueue`**
+- `RabbitMQ POLL from MyExchange`**
 
 Agents may deviate from this pattern, as long as they ensure a proper cardinality is maintained, that is- neither too low nor too high. 
 For example, agents may choose to name all transactions/spans reading-from/sending-to temporary queues equally. 

--- a/specs/agents/tracing-instrumentation-messaging.md
+++ b/specs/agents/tracing-instrumentation-messaging.md
@@ -38,6 +38,10 @@ Examples:
 - `JMS SEND to MyQueue`
 - `RabbitMQ RECEIVE from MyExchange`**
 
+Agents may deviate from this pattern, as long as they ensure a proper cardinality is maintained, that is- neither too low nor too high. 
+For example, agents may choose to name all transactions/spans reading-from/sending-to temporary queues equally. 
+On the other end, agents may choose to append a cardinality-increasing factor to the name, like the routing key in RabbitMQ.
+
 \* Java agent's instrumentation for Kafka does not follow this pattern at the moment.
 
 \** In RabbitMQ, queues are only relevant in the receiver side, so the exchange name is used instead. Agents may add an opt-in config to 

--- a/specs/agents/tracing-sampling.md
+++ b/specs/agents/tracing-sampling.md
@@ -1,4 +1,4 @@
-#### Transaction sampling
+## Transaction sampling
 
 To reduce processing and storage overhead, transactions may be sampled by agents.
 Sampling here refers to "head-based sampling".
@@ -7,7 +7,7 @@ Head-based sampling is where a sampling decision is made at the root of the dist
 before the details or outcome of the trace are known,
 and propagated throughout the trace.
 
-##### `transaction_sample_rate` configuration
+### `transaction_sample_rate` configuration
 
 By default, all transactions will be sampled.
 Agents can be configured to sample probabilistically,
@@ -41,7 +41,7 @@ This is to ensure we are consistent when [propagating](#propagation) the samplin
 | Dynamic        | `true`  |
 | Central config | `true`  |
 
-##### Effect on metrics
+### Effect on metrics
 
 At the time of making a sampling decision,
 the sampling rate must be recorded so that it can be associated with every transaction and span in the trace.
@@ -81,7 +81,7 @@ This is required for backwards compatibility with agents that do not send a samp
 The server will only calculate span metrics for newer agents that include `sample_rate` in spans,
 as otherwise the representative counts will be incorrect for sampling rates less than 1.
 
-##### Non-sampled transactions
+### Non-sampled transactions
 
 Currently _all_ transactions are captured by Elastic APM agents.
 Sampling controls how much data is captured for transactions:
@@ -93,7 +93,7 @@ No spans should be captured.
 
 In the future we may introduce options to agents to stop sending non-sampled transactions altogether.
 
-##### Propagation
+### Propagation
 
 As mentioned above, the sampling decision must be propagated throughout the trace.
 We adhere to the W3C Trace-Context spec for this, propagating the decision through trace-flags: https://www.w3.org/TR/trace-context/#sampled-flag

--- a/specs/agents/tracing-spans.md
+++ b/specs/agents/tracing-spans.md
@@ -1,8 +1,8 @@
-### Spans
+## Spans
 
 The agent should also have a sense of the most common libraries for these and instrument them without any further setup from the app developers.
 
-#### Span ID fields
+### Span ID fields
 
 Each span object will have an `id`. This is generated for each transaction and
 span, and is 64 random bits (with a string representation of 16 hexadecimal
@@ -12,7 +12,7 @@ Spans will also have a `transaction_id`, which is the `id` of the current
 transaction. While not necessary for distributed tracing, this inclusion allows
 for simpler and more performant UI queries.
 
-#### Span outcome
+### Span outcome
 
 The `outcome` property denotes whether the span represents a success or a failure.
 It supports the same values as `transaction.outcome`.
@@ -29,17 +29,17 @@ the error rate of service B is 100% from service A's perspective.
 However, as service B doesn't receive any requests, the error rate is 0% from service B's perspective.
 The `span.outcome` also allows reasoning about error rates of external services.
 
-#### Outcome API
+### Outcome API
 
 Agents should expose an API to manually override the outcome.
 This value must always take precedence over the automatically determined value.
 The documentation should clarify that spans with `unknown` outcomes are ignored in the error rate calculation.
 
-#### Span stack traces
+### Span stack traces
 
 Spans may have an associated stack trace, in order to locate the associated source code that caused the span to occur. If there are many spans being collected this can cause a significant amount of overhead in the application, due to the capture, rendering, and transmission of potentially large stack traces. It is possible to limit the recording of span stack traces to only spans that are slower than a specified duration, using the config variable `ELASTIC_APM_SPAN_FRAMES_MIN_DURATION`.
 
-#### Span count
+### Span count
 
 When a span is started a counter should be incremented on its transaction, in order to later identify the _expected_ number of spans. In this way we can identify data loss, e.g. because events have been dropped, or because of instrumentation errors.
 

--- a/specs/agents/tracing-transactions.md
+++ b/specs/agents/tracing-transactions.md
@@ -1,4 +1,4 @@
-### Transactions
+## Transactions
 
 Transactions are a special kind of span.
 They represent the entry into a service.
@@ -6,7 +6,7 @@ They are sometimes also referred to as local roots or entry spans.
 
 Transactions are created either by the built-in auto-instrumentation or an agent or the [tracer API](tracing-api.md).
 
-#### Transaction outcome
+### Transaction outcome
 
 The `outcome` property denotes whether the transaction represents a success or a failure from the perspective of the entity that produced the event.
 The APM Server converts this to the [`event.outcome`](https://www.elastic.co/guide/en/ecs/current/ecs-allowed-values-event-outcome.html) field.
@@ -23,7 +23,7 @@ If an agent doesn't report the `outcome` (or reports `null`), the APM Server wil
 
 What counts as a failed or successful request depends on the protocol and does not depend on whether there are error documents associated with a transaction.
 
-##### Error rate
+#### Error rate
 
 The error rate of a transaction group is based on the `outcome` of its transactions.
 
@@ -40,7 +40,7 @@ or when looking at RUM data (as page load transactions have an `unknown` outcome
 Also note that this only reflects the error rate as perceived from the application itself.
 The error rate perceived from its clients is greater or equal to that.
 
-##### Outcome API
+#### Outcome API
 
 Agents should expose an API to manually override the outcome.
 This value must always take precedence over the automatically determined value.


### PR DESCRIPTION
Adding a spec for the instrumentation of messaging systems.
Currently this spec is only implemented by the Java agent, but will become relevant to other agents when adding support for RabbitMQ, Kafka or other systems.

The spec is based on the discussions from https://github.com/elastic/apm/issues/143