### PR TITLE
chore: update 404 spec link

### DIFF
--- a/specs/agents/process-new-fields.md
+++ b/specs/agents/process-new-fields.md
@@ -11,7 +11,7 @@ it would create new fields in the index and then stop using it when we standardi
 For example `context.elasticsearch.url` in the intake API becomes `elasticsearch.url` in Elasticsearch, `context.elasticsearch.error_reason` becomes `elasticsearch.error_reason` etc.
 * The proposal needs to specify which fields should be indexed.
 An APM Server person might need to assist here to determine the right data type for the indexed fields.
-* The proposal should include the suggested [JSON Schema](https://github.com/elastic/apm-server/blob/master/docs/spec/context.json) changes for all new fields.
+* The proposal should include the suggested [JSON Schema](https://github.com/elastic/apm-server/tree/master/docs/spec/v2) changes for all new fields.
 This forces alignment on the exact field names, JSON data type, length restrictions etc.
 * Make sure to check if [ECS](https://github.com/elastic/ecs) has defined appropriate fields for what you're proposing.
 * Agents should agree to the changes in a voting format (checkboxes),


### PR DESCRIPTION
This PR fixes a spec link that I noticed was 404ing.  Looking for either a rubber stamp review and/or a take on whether we need to update more of the specification to reflect recent changes to how we're representing the JSON schema for APM Server  