### PR TITLE
chore: update fields based on schema

### DIFF
--- a/specs/agents/metadata.md
+++ b/specs/agents/metadata.md
@@ -74,7 +74,9 @@ For official Elastic agents, the agent name should just be the name of the langu
 is collected from local cloud provider metadata services:
 
 - availability_zone
-- account.id
+- account
+  - id
+  - name
 - instance
   - id
   - name
@@ -82,7 +84,7 @@ is collected from local cloud provider metadata services:
 - project
   - id
   - name
-- provider
+- provider (**required**)
 - region
 
 This metadata collection is controlled by a configuration value,


### PR DESCRIPTION
Small PR to reflect the current schema fields (adds `account.name`, notes that provider is the only required field).

This came out of our implementing this work in the Node.js agent