### PR TITLE
Add config to omit specific fields

### DIFF
--- a/specs/agents/sanitization.md
+++ b/specs/agents/sanitization.md
@@ -21,19 +21,20 @@ A list of captured field names to omit. This list is applied to all fields that 
 
 Every matching field will be omitted except required fields. In case of required field, this config is ignored.
 
-#### Omitting Values
-
-If a field's name matches a configured
-wildcard, that field's _value_ MUST be omitted and the key itself
-MAY still be reported in the agent payload.
-
-#### Example: 
-
-`omit_captured_fields=user.*` omits all `transaction.context.user` fields and `omit_captured_fields=user.ema*l` only omits `transaction.context.user.email`.
-
 |                |   |
 |----------------|---|
 | Type           | `List<`[`WildcardMatcher`](../../tests/agents/json-specs/wildcard_matcher_tests.json)`>` |
 | Default        | empty list |
 | Dynamic        | `true` |
 | Central config | `true` |
+
+
+#### Omitting Values
+
+If a non-required field's name matches a configured
+wildcard, that field's _value_ MUST be omitted and the key itself
+MAY still be reported in the agent payload.
+
+#### Example
+
+`omit_captured_fields=user.*` omits all `transaction.context.user` fields and `omit_captured_fields=user.ema*l` only omits `transaction.context.user.email`.

--- a/specs/agents/sanitization.md
+++ b/specs/agents/sanitization.md
@@ -14,3 +14,21 @@ The query string and the captured request body (such as `application/json` data)
 | Default        | `password, passwd, pwd, secret, *key, *token*, *session*, *credit*, *card*, authorization, set-cookie` |
 | Dynamic        | `true` |
 | Central config | `true` |
+
+### `omit_captured_fields`
+
+A list of captured field names to omit. This list is applied to all fields that the agent captures and if a field name is matching then the field will be omitted.
+
+Every matching field will be omitted except required fields. In case of required field, this config is ignored.
+
+Example: 
+
+`omit_captured_fields =user.*` omits all `transaction.context.user` fields and `omit_captured_fields =user.ema*l` only omits `transaction.context.user.email`.
+
+
+|                |   |
+|----------------|---|
+| Type           | `List<`[`WildcardMatcher`](../../tests/agents/json-specs/wildcard_matcher_tests.json)`>` |
+| Default        | empty string |
+| Dynamic        | `true` |
+| Central config | `true` |

--- a/specs/agents/sanitization.md
+++ b/specs/agents/sanitization.md
@@ -21,14 +21,19 @@ A list of captured field names to omit. This list is applied to all fields that 
 
 Every matching field will be omitted except required fields. In case of required field, this config is ignored.
 
-Example: 
+#### Omitting Values
 
-`omit_captured_fields =user.*` omits all `transaction.context.user` fields and `omit_captured_fields =user.ema*l` only omits `transaction.context.user.email`.
+If a field's name matches a configured
+wildcard, that field's _value_ MUST be omitted and the key itself
+MAY still be reported in the agent payload.
 
+#### Example: 
+
+`omit_captured_fields=user.*` omits all `transaction.context.user` fields and `omit_captured_fields=user.ema*l` only omits `transaction.context.user.email`.
 
 |                |   |
 |----------------|---|
 | Type           | `List<`[`WildcardMatcher`](../../tests/agents/json-specs/wildcard_matcher_tests.json)`>` |
-| Default        | empty string |
+| Default        | empty list |
 | Dynamic        | `true` |
 | Central config | `true` |


### PR DESCRIPTION
The idea is to add a config to disabling capturing specific data. Follow up from https://github.com/elastic/apm/issues/272. 

Often we get requests to "disable X" where X is usually a specific field or multiple related fields (e.g. disable user capturing, disable capturing IP addresses, disable capturing query string, etc.). With this setting we'd give users the ability to provide a list of wildcards as a config and the agent would omit every matching field (except required ones).

### Why not `sanitize_field_names`? 
`sanitize_field_names` matches against captured data (like the value of HTTP headers). The problem this config would solve is omitting specific _captured_ fields. So the values of this setting would be matched against the intake API field names (or elasticsearch field names alternatively (see open questions)). Specifically if we'd only have `sanitize_field_names` then the wildcards from that config would be matched against incoming data like HTTP headers, form-encoded request body, etc. and then also against APM field names which is conceptually different.

I feel that merging the two would cause confusion and it's worth exploring if a dedicated setting would be easier to understand from a user's point of view.


### Alternative solutions
- We could merge this with `sanitize_field_names`. As mentioned above, in my opinion that config is a very different concept and it'd be confusing for users.
- Add config to disable specific things (e.g. `disable_user_capturing`). [We already had ideas](https://github.com/elastic/apm/issues/272#issuecomment-730436432) to disable capturing other things. If we implement those with a specific setting per feature, it could explode into lots of settings per feature.
- Just tell users to use filters in APM agent: not all agents offer the concept of filters, plus it requires code change, so not very compatible with the zero code change injection approach.
- APM Server processors: data still potentially leaves the process/machine and it's also more work than just providing a list in a config.

### Open questions

- [ ] What field names do we match against?
	- Intake API field name: Easy to implement, but unknown to the user. Luckily by using wildcards users can make it work (just use `*user.`, it'll match the intake field name `context.user`, even if it's stored as top level `user` since APM server stores that data ecs style).
	- Real field names in elasticsearch: Easy for the users, but hard to keep it in-sync with the agent.
	- Maybe use ecs field names? 
- [ ] Should we omit values or should we set it to something like `[REDACTED]`? If we set it to something specific, we need to define it for each data type.
