### PR TITLE
Document common apm.getServiceName() API

### DIFF
--- a/specs/agents/README.md
+++ b/specs/agents/README.md
@@ -54,6 +54,7 @@ You can find details about each of these in the [APM Data Model](https://www.ela
 - [Agent Configuration](configuration.md)
 - [Agent logging](logging.md)
 - [Data sanitization](sanitization.md)
+- [Common Public APIs](common-public-apis.md)
 
 # Processes
 

--- a/specs/agents/common-public-apis.md
+++ b/specs/agents/common-public-apis.md
@@ -1,0 +1,31 @@
+## Common Public APIs
+
+This document describes APM Agent Public APIs that are or should be common
+between the separate language implementations; and that are not defined in
+a separate document such as the [Tracing API](./tracing-api.md).
+
+In the following APIs, the string "apm" is used to refer to the top-level
+namespace or primary singleton API object provided by the APM agent:
+
+- Node.js: the singleton [Agent instance](https://www.elastic.co/guide/en/apm/agent/nodejs/current/agent-api.html)
+- Go: the [Tracer](https://www.elastic.co/guide/en/apm/agent/go/current/api.html#tracer-api) instance
+- Java: the [`co.elastic.apm.api.ElasticApm` class](https://www.elastic.co/guide/en/apm/agent/java/current/public-api.html)
+- .NET: the [`Elastic.Apm.Agent` class](https://www.elastic.co/guide/en/apm/agent/dotnet/current/public-api.html)
+- Python: the [`elasticapm` package](https://www.elastic.co/guide/en/apm/agent/python/current/api.html)
+- Ruby: the [`ElasticAPM` module](https://www.elastic.co/guide/en/apm/agent/ruby/current/api.html)
+- RUM JS: the singleton [Agent instance](https://www.elastic.co/guide/en/apm/agent/js-base/current/agent-api.html)
+
+
+### `apm.getServiceName() -> String`
+
+Alternative spellings as makes sense for each Agent: `.get_service_name()`,
+`.GetServiceName()`.
+
+This API returns the service name, which may have been explicitly configured
+or automatically discovered.
+
+Use cases:
+
+- [ecs-loggers](https://github.com/elastic/ecs-logging) may use this to fill in
+  the "service.name" and "event.dataset" ECS logging fields.
+


### PR DESCRIPTION
For ecs-logging implementations to populate the ["service.name" and "event.dataset" fields](https://github.com/elastic/ecs-logging/blob/7fc00daf3da87e749b0053c592eca61a38afc6ce/spec/spec.json#L62-L86) they will need some way to get the service name from the detected APM Agent. I'm proposing a `apm.getServiceName() -> String` API for that, at least for the Node.js Agent.

I didn't see a current doc in apm.git/specs/agents/ that might appropriately hold this. I'm happy to take advice/opinions that documenting commonalities in the APM Agent APIs isn't time well spent.

The ecs-logging case for `getServiceName()` affects the Agent languages with ecs-loggers: https://github.com/elastic/ecs-logging#loggers  In particular this does *not* include the RUM agent.

### updating

Has a use case for a `apm.getServiceName()`:

- Node.js: yes
- Go: ?
- Java: no (instruments logging from APM side)
- .NET: ?
- Python: no (instruments logging from APM side)
- Ruby: ?
- PHP: ?
- RUM JS: N/A