### PR TITLE
feat: add azure app service env var mappings

### DIFF
--- a/specs/agents/metadata.md
+++ b/specs/agents/metadata.md
@@ -99,6 +99,36 @@ metadata is available.
 A sample implementation of this metadata collection is available in
 [the Python agent](https://github.com/elastic/apm-agent-python/blob/master/elasticapm/utils/cloud.py).
 
+In environments where a cloud provider's instance metadata is not
+available, agents SHOULD make a best effort to find instance metadata in
+environment/process variables. 
+
+#### Azure App Services Cloud Metadata
+
+In the _Azure App Services_ environment, Agents SHOULD
+
+- Use a value of `azure` for the `provider` field
+- Use the `WEBSITE_OWNER_NAME` environment variable for the
+  `account.name` field
+- Use the `WEBSITE_INSTANCE_ID` environment variable for the
+  `instance.id` field
+- Use the `WEBSITE_SITE_NAME` environment variable for the
+  `project.name` field
+- Manipulate the `WEBSITE_RESOURCE_GROUP` environment to derive a value
+  for the `region` field
+
+The `WEBSITE_RESOURCE_GROUP` will contain a value that looks something like this
+
+    appsvc_linux_centralus
+    default-web-eastus
+    
+Agents SHOULD split this value by non-alphanumeric delimiters and use
+the last value as the `region`.  In the above examples this would result
+in a region of `centarlus` and `eastus`.
+
+Agents MUST NOT assume these values are present, and SHOULD use the
+string `UNKNOWN` when an expected environment variable is not set.
+
 ### Global labels
 
 Events sent by the agents can have labels associated, which may be useful for custom aggregations, or document-level access control. It is possible to add "global labels" to the metadata, which are labels that will be applied to all events sent by an agent. These are only understood by APM Server 7.2 or greater.


### PR DESCRIPTION
Per: https://github.com/elastic/apm/issues/388

Azure App Services is a "Platform as a Service" feature of Microsoft Azure.  Its marketing pitch is "just write your code and don't worry about how it's deployed". Azure App Services makes no promises about the sort of services that will run the website/web-service you deploy. 

Azure's Instance Metadata Service is not available in the Azure App Services environment. Therefore, we need to rely on the environmental variables set in an Azure App Services environment to set our cloud metadata.  

This spec PR attempts to define which environmental variables we should use for which metadata fields.  

All feedback's welcome, but four specific questions we're trying to answer

1. Are these fields available in Azure App Services for your language/platform?
2. Do these field mappings make sense? Is there more we can use?
3. What delimiters does WEBSITE_RESOURCE_GROUP use for your language?
4. Is `azure` the right provider name, or do we need something distinct like `azure-app-services`

Additional Information:

Azure has [a large documentation site](https://docs.microsoft.com/en-us/azure/app-service/) for App Services that incudes quick start tutorials for [ASP.NET Core](https://docs.microsoft.com/en-us/azure/app-service/quickstart-dotnetcore), [ASP.NET app on Windows](https://docs.microsoft.com/en-us/azure/app-service/quickstart-dotnet-framework), [Node.js](https://docs.microsoft.com/en-us/azure/app-service/quickstart-nodejs), [PHP](https://docs.microsoft.com/en-us/azure/app-service/quickstart-php), [Java](https://docs.microsoft.com/en-us/azure/app-service/quickstart-java), [Python (flask)](https://docs.microsoft.com/en-us/azure/app-service/quickstart-python), and [Ruby on linux](https://docs.microsoft.com/en-us/azure/app-service/quickstart-ruby).

There's a website named [whatazurewebsiteenvironmentvariablesareavailable.azurewebsites.net](http://whatazurewebsiteenvironmentvariablesareavailable.azurewebsites.net/) that exposes the environmental variables for an azure deployment.

Some data is duplicated between the `APPSETTING_` variables, `ORYX_` variables, and `WEBSITE_` variables.  (ORYX is [a microsoft build tool](https://github.com/microsoft/Oryx))

Here are some env variables that didn't have clear analogs in our current cloud metadata but might be useful
            
    // A name for -- what? Something? Might be of interest
    "COMPUTERNAME": "lw---2C",

    // a network hostname for -- something?
    "HOSTNAME": "45---c9",

    // seems to tag this is an azure app service env, but is from the build tool
    "ORYX_ENV_TYPE": "AppService",

    // PLATFORM_VERSION environment variable shows the current App Service version.
    // https://azure.microsoft.com/en-us/updates/app-service-samesite-cookie-update/
    "PLATFORM_VERSION": "91.0.7.112",

    // A SKU indicating the Azure App Service plan level?
    "WEBSITE_SKU": "LinuxFree",

And here's an example JSON object mapping out fields to environmental variables.     

    {
        provider: 'azure',
        availability_zone: undefined
        account: {
            id: undefined,
            name: WEBSITE_OWNER_NAME, // 76--+appsvc_linux_centralus-CentralUSwebspace-Linux above
        },
        instance: {
            id: WEBSITE_INSTANCE_ID, // 252d9---931cd above
            name: undefined
        },
        machine.type: undefined,
        project: {
            id: undefined,
            name: WEBSITE_SITE_NAME  // elastic-nodejs-agent-metadata above
        },    
        region: derive from WEBSITE_RESOURCE_GROUP // centralus above, derived from `appsvc_linux_centralus`

    }

