### PR TITLE
Proposal for transaction_ignore_user_agents configuration

### DIFF
--- a/specs/agents/tracing-instrumentation-http.md
+++ b/specs/agents/tracing-instrumentation-http.md
@@ -63,10 +63,10 @@ All errors that are captured during a request to an ignored URL are still sent t
 
 ### `transaction_ignore_user_agents` configuration
 
-Used to restrict requests from certain User-Agents from being instrumented.
+Used to restrict requests made by certain User-Agents from being instrumented.
 
 This property should be set to a list containing one or more strings.
-When an incoming HTTP request is detected, the `User-Agent` request headers will be tested against each element in this list.
+When an incoming HTTP request is detected, the `User-Agent` request headers will be tested against each element in this list and if a match is found, no trace will be captured for this request.
 
 NOTE: 
 All errors that are captured during a request made by an ignored user agent are still sent to the APM Server regardless of this setting.

--- a/specs/agents/tracing-instrumentation-http.md
+++ b/specs/agents/tracing-instrumentation-http.md
@@ -61,6 +61,23 @@ All errors that are captured during a request to an ignored URL are still sent t
 | Dynamic        | `true` |
 | Central config | `true` |
 
+### `transaction_ignore_user_agents` configuration
+
+Used to restrict requests from certain User-Agents from being instrumented.
+
+This property should be set to a list containing one or more strings.
+When an incoming HTTP request is detected, the `User-Agent` request headers will be tested against each element in this list.
+
+NOTE: 
+All errors that are captured during a request made by an ignored user agent are still sent to the APM Server regardless of this setting.
+
+|                |   |
+|----------------|---|
+| Type           | `List<`[`WildcardMatcher`](../../tests/agents/json-specs/wildcard_matcher_tests.json)`>` |
+| Default        | `<none>` |
+| Dynamic        | `true` |
+| Central config | `true` |
+
 ## HTTP client spans
 
 We capture spans for outbound HTTP requests. These should have a type of `external`, and subtype of `http`. The span name should have the format `<method> <host>`.

--- a/specs/agents/tracing-instrumentation-http.md
+++ b/specs/agents/tracing-instrumentation-http.md
@@ -51,9 +51,6 @@ http://localhost/home/index
 http://whatever.com/home/index?value1=123
 ```
 
-NOTE: 
-All errors that are captured during a request to an ignored URL are still sent to the APM Server regardless of this setting.
-
 |                |   |
 |----------------|---|
 | Type           | `List<`[`WildcardMatcher`](../../tests/agents/json-specs/wildcard_matcher_tests.json)`>` |
@@ -67,9 +64,6 @@ Used to restrict requests made by certain User-Agents from being instrumented.
 
 This property should be set to a list containing one or more strings.
 When an incoming HTTP request is detected, the `User-Agent` request headers will be tested against each element in this list and if a match is found, no trace will be captured for this request.
-
-NOTE: 
-All errors that are captured during a request made by an ignored user agent are still sent to the APM Server regardless of this setting.
 
 |                |   |
 |----------------|---|


### PR DESCRIPTION
Following the discussion in https://github.com/elastic/apm/issues/395, @trentm [proposed](https://github.com/elastic/apm-agent-nodejs/issues/1950) two options for resolving the discrepancy in the `ignore_user_agents` config. 
We opted to start fresh with a new config option - `transaction_ignore_user_agents` that will be aligned across agents.