### PR TITLE
Add test case for CQL line comment

### DIFF
--- a/tests/agents/json-specs/sql_token_examples.json
+++ b/tests/agents/json-specs/sql_token_examples.json
@@ -117,6 +117,20 @@
     ]
   },
   {
+    "name": "CQL line comment",
+    "input": "/* /*nested*/ */ // SELECT /*",
+    "tokens": [
+      {
+        "kind": "COMMENT",
+        "text": "/* /*nested*/ */"
+      },
+      {
+        "kind": "COMMENT",
+        "text": "// SELECT /*"
+      }
+    ]
+  },
+  {
     "name": "string-literal",
     "input": "'abc '' def\\''",
     "tokens": [


### PR DESCRIPTION
CQL line comments (`//`) are currently not supported in QL Scanners that are derived from the Go agent's reference implementation.
This adds a test case for it.

Example Java implementation:
```patch
@@ -123,6 +131,10 @@ public Token scan() {
            case '/':
                if (isNextChar('*')) {
                     // /* comment */
                     next();
                     return scanBracketedComment();
+                } else if (isNextChar('/')) {
+                    // // line comment (ex. Cassandra QL)
+                    next();
+                    return scanSimpleComment();
                 }
                 return Token.OTHER;
```
