### PR TITLE
Exit span child span handling

### DIFF
--- a/specs/agents/tracing-spans.md
+++ b/specs/agents/tracing-spans.md
@@ -88,3 +88,8 @@ For example, the HTTP `context.http.status_code` may be added to an `elasticsear
 
 Exit spans MAY have child spans that have the same `type` and `subtype`.
 For example, an HTTP exit span may have child spans with the `action` `request`, `response`, `connect`, `dns`.
+These spans MUST NOT have any destination context, so that there's no effect on destination metrics.
+
+Agents don't need to prevent the creation of exit child spans via the public API.
+Agents MAY implement internal APIs to create an exit span (such as `Span::createExitSpan`) that flags a span as an exit span (`exit=true`).
+Returning `null` from `Span::createExitSpan` when the curren span is flagged with `exit=true` can help to avoid creating nested exit spans.

--- a/specs/agents/tracing-spans.md
+++ b/specs/agents/tracing-spans.md
@@ -90,7 +90,7 @@ Exit spans MAY have child spans that have the same `type` and `subtype`.
 For example, an HTTP exit span may have child spans with the `action` `request`, `response`, `connect`, `dns`.
 These spans MUST NOT have any destination context, so that there's no effect on destination metrics.
 
-Agents don't need to prevent the creation of exit child spans via the public API.
-Agents MAY implement internal APIs to create an exit span (such as `Span::createExitSpan`) that flags a span as an exit span (`exit=true`).
-Returning `null` from `Span::createExitSpan` when the curren span is flagged with `exit=true` can help to avoid creating nested exit spans.
-The `exit` flag can also be useful in tests: if it's `true`, the `context.desitnation` information has to be populated.
+Agents MAY implement mechanisms to prevent the creation of child spans of exit spans.
+For example, agents MAY implement internal (or even public) APIs to mark a span as an exit or leaf span.
+Agents can then prevent the creation of a child span of a leaf/exit span.
+This can help to drop nested HTTP spans for instrumented calls that use HTTP as the transport layer (for example Elasticsearch).

--- a/specs/agents/tracing-spans.md
+++ b/specs/agents/tracing-spans.md
@@ -105,8 +105,11 @@ This can help to drop nested HTTP spans for instrumented calls that use HTTP as 
 
 As a general rule, when agents are tracing an exit span where the downstream service is known not to continue the trace,
 they SHOULD NOT propagate the trace context via the underlying protocol.
+
 Example: for Elasticsearch requests, which use HTTP as the transport, agents should not add `traceparent` headers to the outgoing HTTP request.
-However, when tracing an outgoing HTTP request, and it's unknown whether the downsteam service continues the trace, the trace headers should be added.
+However, when tracing a regular outgoing HTTP request (one that's not initiated by an exit span),
+and it's unknown whether the downsteam service continues the trace,
+the trace headers should be added.
 
 The reason is that spans cannot be compressed (TODO link to span compression spec once available) if the context has been propagated, as it may lead to orphaned transactions.
 That means that the `parent.id` of a transaction may refer to a span that's not available because it has been compressed (merged with another span).

--- a/specs/agents/tracing-spans.md
+++ b/specs/agents/tracing-spans.md
@@ -103,8 +103,10 @@ This can help to drop nested HTTP spans for instrumented calls that use HTTP as 
 
 #### Context propagation
 
-As a general rule, when agents are tracing an exit span, they SHOULD NOT propagate the trace context via the underlying protocol.
+As a general rule, when agents are tracing an exit span where the downstream service is known not to continue the trace,
+they SHOULD NOT propagate the trace context via the underlying protocol.
 Example: for Elasticsearch requests, which use HTTP as the transport, agents should not add `traceparent` headers to the outgoing HTTP request.
+However, when tracing an outgoing HTTP request, and it's unknown whether the downsteam service continues the trace, the trace headers should be added.
 
 The reason is that spans cannot be compressed (TODO link to span compression spec once available) if the context has been propagated, as it may lead to orphaned transactions.
 That means that the `parent.id` of a transaction may refer to a span that's not available because it has been compressed (merged with another span).

--- a/specs/agents/tracing-spans.md
+++ b/specs/agents/tracing-spans.md
@@ -78,7 +78,7 @@ such as an outgoing HTTP request or a call to a database.
 
 #### Child spans of exit spans
 
-Exit spans MUST not have child spans that have a different `type` and `subtype`.
+Exit spans MUST not have child spans that have a different `type` or `subtype`.
 For example, when capturing a span representing a query to Elasticsearch,
 there should not be an HTTP span for the same operation.
 Doing that would make [breakdown metrics](https://github.com/elastic/apm/blob/master/specs/agents/metrics.md#transaction-and-span-breakdown)

--- a/specs/agents/tracing-spans.md
+++ b/specs/agents/tracing-spans.md
@@ -93,3 +93,4 @@ These spans MUST NOT have any destination context, so that there's no effect on 
 Agents don't need to prevent the creation of exit child spans via the public API.
 Agents MAY implement internal APIs to create an exit span (such as `Span::createExitSpan`) that flags a span as an exit span (`exit=true`).
 Returning `null` from `Span::createExitSpan` when the curren span is flagged with `exit=true` can help to avoid creating nested exit spans.
+The `exit` flag can also be useful in tests: if it's `true`, the `context.desitnation` information has to be populated.

--- a/specs/agents/tracing-spans.md
+++ b/specs/agents/tracing-spans.md
@@ -70,3 +70,21 @@ To handle edge cases where many spans are captured within a single transaction, 
 ```
 
 Here's how the limit can be configured for [Node.js](https://www.elastic.co/guide/en/apm/agent/nodejs/current/agent-api.html#transaction-max-spans) and [Python](https://www.elastic.co/guide/en/apm/agent/python/current/configuration.html#config-transaction-max-spans).
+
+### Exit spans
+
+Exit spans are spans that describe a call to an external service,
+such as an outgoing HTTP request or a call to a database.
+
+Exit spans MUST not have child spans that have a different `type` and `subtype`.
+For example, when capturing a span representing a query to Elasticsearch,
+there should not be an HTTP span for the same operation.
+Doing that would make [breakdown metrics](https://github.com/elastic/apm/blob/master/specs/agents/metrics.md#transaction-and-span-breakdown)
+less meaningful,
+as most of the time would be attributed to `http` instead of `elasticsearch`.
+
+Agents MAY add information from the lower level transport to the exit span, though.
+For example, the HTTP `context.http.status_code` may be added to an `elasticsearch` span.
+
+Exit spans MAY have child spans that have the same `type` and `subtype`.
+For example, an HTTP exit span may have child spans with the `action` `request`, `response`, `connect`, `dns`.


### PR DESCRIPTION
The discussion about how to handle exit spans, and whether they can have child spans, has come up quite frequently now and currently, not all agents are handling them the same way.

I've written up a proposal on how I think we should move forward.

Once we have an agreement on how we should handle exit spans, we can schedule and prioritize the work that may have to be done in the agents to comply to that spec.