### PR TITLE
Add destination spec

### DIFF
--- a/specs/agents/README.md
+++ b/specs/agents/README.md
@@ -39,6 +39,7 @@ You can find details about each of these in the [APM Data Model](https://www.ela
 - Tracing
   - [Transactions](tracing-transactions.md)
   - [Spans](tracing-spans.md)
+  - [Span destination](tracing-spans-destination.md)
   - [Sampling](tracing-sampling.md)
   - [Distributed tracing](tracing-distributed-tracing.md)
   - [Tracer API](tracing-api.md)

--- a/specs/agents/tracing-instrumentation-http.md
+++ b/specs/agents/tracing-instrumentation-http.md
@@ -95,3 +95,11 @@ For both transactions and spans, if there is no HTTP status we set `outcome` fro
 
 - `failure` if an error is reported
 - `success` otherwise
+
+## Destination
+
+- `context.destination.address`: `url.host`
+- `context.destination.port`: `url.port`
+- `context.destination.service.name`: `url.port.isDefault() ? "${url.scheme}://${url.host}" : "${url.scheme}://${url.host}:${url.port}"`
+- `context.destination.service.type`: `"external"`
+- `context.destination.service.resource`: `"${url.host}:${url.port}"`

--- a/specs/agents/tracing-spans-destination.md
+++ b/specs/agents/tracing-spans-destination.md
@@ -1,5 +1,10 @@
 ## Span destination
 
+The span destination information is relevant for exit spans and helps to identify the downstream service.
+This information is used for the [service map](https://www.elastic.co/guide/en/kibana/current/service-maps.html),
+the [dependencies table](https://www.elastic.co/guide/en/kibana/current/service-overview.html#service-span-duration) in the service overview,
+and the [SIEM integration](APM SIEM integration).
+
 ### Destination service fields
 
 Spans representing an external call MUST have `context.destination.service` information.
@@ -35,7 +40,7 @@ Identifies unique destinations for each service.
 
 **Usage**
 
-Each unique resource will result in a node on the service map.
+Each unique resource will result in a node on the [service map](https://www.elastic.co/guide/en/kibana/current/service-maps.html).
 Also, APM Server will roll up metrics based on the resource.
 These metrics are currently used for the [dependencies table](https://www.elastic.co/guide/en/kibana/current/service-overview.html#service-span-duration)
 on the service overview page.

--- a/specs/agents/tracing-spans-destination.md
+++ b/specs/agents/tracing-spans-destination.md
@@ -3,7 +3,7 @@
 The span destination information is relevant for exit spans and helps to identify the downstream service.
 This information is used for the [service map](https://www.elastic.co/guide/en/kibana/current/service-maps.html),
 the [dependencies table](https://www.elastic.co/guide/en/kibana/current/service-overview.html#service-span-duration) in the service overview,
-and the [SIEM integration](APM SIEM integration).
+and the [APM SIEM integration](https://www.elastic.co/blog/elastic-apm-7-6-0-released).
 
 ### Destination service fields
 
@@ -44,7 +44,7 @@ Each unique resource will result in a node on the [service map](https://www.elas
 Also, APM Server will roll up metrics based on the resource.
 These metrics are currently used for the [dependencies table](https://www.elastic.co/guide/en/kibana/current/service-overview.html#service-span-duration)
 on the service overview page.
-There are plans to use the service desination metrics in the service map, too.
+There are plans to use the service destination metrics in the service map, too.
 
 The metrics are calculated based on the (head-based) sampled span documents that are sent to APM Server.
 That's why agents have to send the [`sample_rate`](tracing-sampling.md#effect-on-metrics)
@@ -66,7 +66,7 @@ Same cardinality otherwise.
 **Value**
 
 Generally, the value would look something like `${span.subtype}/${cluster}`, or `${span.subtype}/${queue}`.
-For HTTP, this is the address, with the port (even when it's the default port), without any scheme.
+For HTTP, this is the host and port (see the [HTTP spec](tracing-instrumentation-http.md#destination) for more details).
 The specs for the specific technologies will have more information on how to construct the value for `context.destination.service.resource`.
 
 #### `context.destination.service.type`
@@ -97,7 +97,7 @@ Examples when the effort of capturing the address and port is not justified:
 
 ES field: [`destination.address`](https://www.elastic.co/guide/en/ecs/current/ecs-destination.html#_destination_field_details)
 
-Address is the destination network address: hostname (e.g. `localhost`), FQDN (e.g. `elastic.co`), IPv4 (e.g. `127.0.0.1`) IPv6 (e.g. `::11`)
+Address is the destination network address: hostname (e.g. `localhost`), FQDN (e.g. `elastic.co`), IPv4 (e.g. `127.0.0.1`) IPv6 (e.g. `::1`)
 
 #### `context.destination.port`
 

--- a/specs/agents/tracing-spans-destination.md
+++ b/specs/agents/tracing-spans-destination.md
@@ -29,7 +29,6 @@ The original intent was to use it as a display name of a service in the service 
 
 For HTTP, use scheme, host, and non-default port (e.g. `http://elastic.co`, `http://apm.example.com:8200`).
 For anything else, use `span.subtype` (e.g. `postgresql`, `elasticsearch`).
-If cluster information is available, it should be appended `${span.subtype}/${cluster}`.
 However, individual sub-resources of a service, such as the name of a message queue, should not be added.
 
 #### `context.destination.service.resource`
@@ -65,7 +64,7 @@ Same cardinality otherwise.
 
 **Value**
 
-Generally, the value would look something like `${span.subtype}/${cluster}`, or `${span.subtype}/${queue}`.
+Usually, the value is just the `span.subtype`.
 For HTTP, this is the host and port (see the [HTTP spec](tracing-instrumentation-http.md#destination) for more details).
 The specs for the specific technologies will have more information on how to construct the value for `context.destination.service.resource`.
 

--- a/specs/agents/tracing-spans-destination.md
+++ b/specs/agents/tracing-spans-destination.md
@@ -1,0 +1,78 @@
+## Span destination
+
+Spans representing an external call MUST have `context.destination` information.
+If the span represents a call to an in-memory database, the information SHOULD still be set.
+
+Agents SHOULD have a generic component used in all tests that validates that the destination information is present for exit spans.
+Rather than opting into the validation, the testing should provide an opt-out if,
+for whatever reason, the destination information can't or shouldn't be collected for a particular exit span.
+
+### Destination service fields
+
+#### `context.destination.service.name`
+
+ES field: `span.destination.service.name`
+
+The identifier for the destination service.
+
+For HTTP, use scheme, host, and non-default port (e.g. `http://elastic.co`, `http://apm.example.com:8200`).
+For anything else, use `span.subtype` (e.g. `postgresql`, `elasticsearch`).
+
+**Usage**
+
+Currently, this field is not anywhere within the product.
+
+#### `context.destination.service.resource`
+
+ES field: `span.destination.service.resource`
+
+Identifies unique destinations for each service.
+
+**Usage**
+
+Each unique resource will result in node on the service map.
+Also, APM Server will roll up metrics based on the resource.
+These metrics are currently used for the [dependencies table](https://www.elastic.co/guide/en/kibana/current/service-overview.html#service-span-duration)
+on the service overview page.
+There are plans to use the service desination metrics in the service map, too.
+
+The metrics are calculated based on the (head-based) sampled span documents that are sent to APM Server.
+That's why agents have to send the [`sample_rate`](tracing-sampling.md#effect-on-metrics)
+attribute for transactions and spans:
+It is used by APM Server to extrapolate the service destination metrics based on the (head-based) sampled spans.
+
+**Cardinality**
+
+To avoid a huge impact on storage requirements for metrics,
+and to not "spam" the service map with lots of fine-grained nodes,
+the cardinality has to be kept low.
+However, the cardinality should, not be too low, either,
+so that different clusters, instances, or queues can be displayed separately in the service map.
+
+Generally, the value would look something like `${span.type}/${cluster}`.
+The specs for the specific technologies will have more information on how to construct the value for `context.destination.service.resource`.
+
+#### `context.destination.service.type`
+
+ES field: `span.destination.service.type`
+
+Type of the destination service, e.g. `db`, `elasticsearch`.
+Should typically be the same as `span.type`.
+Used to displaying different icons on the service map. (TODO confirm)
+
+### Destination fields
+
+These fields are used within the APM/SIEM integration.
+They don't play a role for service maps.
+
+#### `context.destination.address`
+
+ES field: [`destination.address`](https://www.elastic.co/guide/en/ecs/current/ecs-destination.html#_destination_field_details)
+
+Address is the destination network address: hostname (e.g. `localhost`), FQDN (e.g. `elastic.co`), IPv4 (e.g. `127.0.0.1`) IPv6 (e.g. `::11`)
+
+#### `context.destination.port`
+
+ES field: [`destination.port`](https://www.elastic.co/guide/en/ecs/current/ecs-destination.html#_destination_field_details)
+
+Port is the destination network port (e.g. 443)


### PR DESCRIPTION
The goal of this PR is to document the status quo. So it mainly converts https://github.com/elastic/apm/issues/180 into a proper spec. Additionally, describes the ES mapping, what the fields are used for, and discusses considerations around cardinality.

I think there's potential to simplify destination handling, which is especially needed when we want to open it up to users to set the destination in #424.
We may brainstorm some of the potential simplifications in this PR but I want to strictly separate documenting the status quo from any enhancements.

For example, as `destination.service.name` and `destination.service.type` are not used, and as there are no immediate plans (AFAIK) to use them, we might want to consider dropping them in the future.
Another thing to think about is whether we can auto-fill the destination fields based on other properties.
See also https://github.com/elastic/apm/issues/424#issuecomment-826820094