### PR TITLE
Prefer w3c traceparent header over legacy elastic-apm-traceparent

### DIFF
--- a/specs/agents/tracing-distributed-tracing.md
+++ b/specs/agents/tracing-distributed-tracing.md
@@ -176,3 +176,4 @@ backwards-compatibility issues. New agents do not need to support this legacy
 name. Because `tracestate` was not implemented until the standard was
 finalized, no legacy names exist for this field.
 
+Agents that do support the legacy header MUST give precedence to the `traceparent` header if both are present.


### PR DESCRIPTION
@AlexanderWert:
> Whenever there is something in the middle (let's say a reverse proxy) of two services being monitored by our agent. And the proxy uses the W3C headers to create own spans (--> thus sends modified traceparent header to the downstream service), but passes our proprietary header as is. In this case the downstream service has a conflict, especially if it prefers the proprietary header over the W3C header, resulting in wrong parent child relationship.