### PR TITLE
Added section to metrics spec on shutdown behavior.

### DIFF
--- a/specs/agents/metrics.md
+++ b/specs/agents/metrics.md
@@ -55,3 +55,8 @@ When capturing runtime metrics, keep in mind the end use-case: how will they be 
 ### Transaction and span breakdown
 
 Agents should record "breakdown metrics", which is a summarisation of how much time is spent per span type/subtype in each transaction group. This is described in detail in the [Breakdown Graphs](https://docs.google.com/document/d/1-_LuC9zhmva0VvLgtI0KcHuLzNztPHbcM0ZdlcPUl64#heading=h.ondan294nbpt) document, so we do not repeat it here.
+
+## Shutdown behavior
+
+Agents should make an effort to flush any metrics before shutting down.
+If this cannot be achieved with shutdown hooks provided by the language/runtime, the agent should provide a public API that the user can call to flush any remaining data.


### PR DESCRIPTION
Due to the somewhat lengthy default metrics collection interval of 30s,
it is quite possible to lose significant amounts of metrics data if
no effort is made to flush them before shutdown.

See https://github.com/elastic/apm-agent-java/pull/1658 for the implementation
in the Java agent.