### PR TITLE
Clarifications to S3 tracing spec

### DIFF
--- a/specs/agents/tracing-instrumentation-db.md
+++ b/specs/agents/tracing-instrumentation-db.md
@@ -11,7 +11,7 @@
 
 ## Database and Datastore spans
 
-We capture spans for various types of database/data-stores operations, such as SQL queries, Elasticsearch queries, is commands, etc. 
+We capture spans for various types of database/data-stores operations, such as SQL queries, Elasticsearch queries, is commands, etc.
 Database and datastore spans **must not have child spans that have a different `type` or `subtype`** within the same transaction (see [span-spec](tracing-spans.md)).
 
 The following fields are relevant for database and datastore spans. Where possible, agents should provide information for as many as possible of these fields. The semantics of and concrete values for these fields may vary between different technologies. See sections below for details on specific technologies.
@@ -47,7 +47,7 @@ The following fields are relevant for database and datastore spans. Where possib
 |`name`| e.g. `DynamoDB UpdateItem my_table`|  The span name should capture the operation name (as used by AWS for the action name) and the table name, if available. The format should be `DynamoDB <ActionName> <TableName>`. |
 |`type`|`db`|
 |`subtype`|`dynamodb`|
-|`action`| `query` | 
+|`action`| `query` |
 | __**context.db._**__ |<hr/>|<hr/>|
 |`_.instance`| e.g. `us-east-1` | The AWS region where the table is. |
 |`_.statement`| e.g. `ForumName = :name and Subject = :sub` | For a DynamoDB Query operation, capture the KeyConditionExpression in this field. |
@@ -62,7 +62,7 @@ The following fields are relevant for database and datastore spans. Where possib
 |`_.service.type`|`db`|
 |`_.service.resource`| `dynamodb` |
 |`_.cloud.region`| e.g. `us-east-1` | The AWS region where the table is, if available. |
-  
+
 ### AWS S3
 
 | Field | Value / Examples | Comments |
@@ -137,10 +137,10 @@ The following fields are relevant for database and datastore spans. Where possib
 |`name`| e.g. `GET` or `LRANGE` |  The name for Redis spans can simply be set to the command name. |
 |`type`|`db`|
 |`subtype`|`redis`|
-|`action`| `query` | 
+|`action`| `query` |
 | __**context.db._**__  |<hr/>|<hr/>|
 |`_.instance`| :heavy_minus_sign: |
-|`_.statement`|  :heavy_minus_sign: | 
+|`_.statement`|  :heavy_minus_sign: |
 |`_.type`|`redis`|
 |`_.user`| :heavy_minus_sign: |
 |`_.link`| :heavy_minus_sign: |
@@ -152,7 +152,7 @@ The following fields are relevant for database and datastore spans. Where possib
 |`_.service.type`|`db`|
 |`_.service.resource`| `redis` |
 
-### SQL Databases 
+### SQL Databases
 
 | Field | Common values / patterns for all SQL DBs | Comments |
 |-------|:---------------:|---------------|

--- a/specs/agents/tracing-instrumentation-db.md
+++ b/specs/agents/tracing-instrumentation-db.md
@@ -67,23 +67,23 @@ The following fields are relevant for database and datastore spans. Where possib
 
 | Field | Value / Examples | Comments |
 |-------|:---------------:|----------|
-|`name`| e.g. `S3 GetObject my-bucket`|  The span name should follow this pattern: `S3 <OperationName> <bucket-name>.` Note that the operation name is in PascalCase. |
+|`name`| e.g. `S3 GetObject my-bucket`|  The span name should follow this pattern: `S3 <OperationName> <bucket-name>`. Note that the operation name is in PascalCase. |
 |`type`|`storage`|
 |`subtype`|`s3`|
 |`action`| e.g. `GetObject` | The operation name in PascalCase. |
 | __**context.db._**__  |<hr/>|<hr/>|
-|`_.instance`| e.g. `us-east-1` | The AWS region where the table is. |
+|`_.instance`| e.g. `us-east-1` | The AWS region where the bucket is. |
 |`_.statement`| :heavy_minus_sign: |  |
-|`_.type`|`dynamodb`|
+|`_.type`|`s3`|
 |`_.user`| :heavy_minus_sign: |
 |`_.link`| :heavy_minus_sign: |
 |`_.rows_affected`| :heavy_minus_sign: |
 | __**context.destination._**__ |<hr/>|<hr/>|
-|`_.address`|e.g. `dynamodb.us-west-2.amazonaws.com`| Not available in some cases. Only set if the actual connection is available. |
-|`_.port`|e.g. `5432`| Not available in some cases. Only set if the actual connection is available. |
+|`_.address`|e.g. `s3.amazonaws.com`| Not available in some cases. Only set if the actual connection is available. |
+|`_.port`|e.g. `443`| Not available in some cases. Only set if the actual connection is available. |
 |`_.service.name`| `s3` |
 |`_.service.type`|`storage`|
-|`_.service.resource`| e.g. `accesspoint/myendpointslashes` or  `accesspoint:myendpointcolons`| The bucket name, if available. The s3 API allows either the bucket name or an Access Point to be provided when referring to a bucket. Access Points can use either slashes or colons. When an Access Point is provided, the access point name preceded by accesspoint/ or accesspoint: should be extracted. For example, given an Access Point such as `arn:aws:s3:us-west-2:123456789012:accesspoint/myendpointslashes`, the agent extracts `accesspoint/myendpointslashes`. Given an Access Point such as `arn:aws:s3:us-west-2:123456789012:accesspoint:myendpointcolons`, the agent extracts `accesspoint:myendpointcolons`. |
+|`_.service.resource`| e.g. `my-bucket`, `accesspoint/myendpointslashes`, or `accesspoint:myendpointcolons`| The bucket name, if available. The s3 API allows either the bucket name or an Access Point to be provided when referring to a bucket. Access Points can use either slashes or colons. When an Access Point is provided, the access point name preceded by accesspoint/ or accesspoint: should be extracted. For example, given an Access Point such as `arn:aws:s3:us-west-2:123456789012:accesspoint/myendpointslashes`, the agent extracts `accesspoint/myendpointslashes`. Given an Access Point such as `arn:aws:s3:us-west-2:123456789012:accesspoint:myendpointcolons`, the agent extracts `accesspoint:myendpointcolons`. |
 |`_.cloud.region`| e.g. `us-east-1` | The AWS region where the bucket is. |
 
 ### Elasticsearch


### PR DESCRIPTION
@AlexanderWert Here are some clarifications to the S3 tracing spec. I assume some of these were [copypasta](https://en.wikipedia.org/wiki/Copypasta) from the DynamoDB section.  Some removal of trailing whitespace is included in this diff (sorry about that), so this will be a slightly cleaner diff: https://github.com/elastic/apm/pull/451/files?w=1

Rendered: https://github.com/elastic/apm/blob/trentm/s3-copypasta/specs/agents/tracing-instrumentation-db.md#aws-s3

(I have some non-trivial Qs about the spec but I'll ask those separately.)