### PR TITLE
`span_stack_trace_min_duration` config spec

### DIFF
--- a/specs/agents/configuration.md
+++ b/specs/agents/configuration.md
@@ -10,6 +10,22 @@ Here's a list of the config options across all agents, their types, default valu
 
 They are provided as environment variables but depending on the language there might be several feasible ways to let the user tweak them. For example besides the environment variable `ELASTIC_APM_SERVER_URL`, the Node.js Agent might also allow the user to configure the server URL via a config option named `serverUrl`, while the Python Agent might also allow the user to configure it via a config option named `server_url`.
 
+### Configuration Value Types
+
+The following table enumerates the available configuration types across the
+agents:
+
+
+| Type | Description (if needed) |
+|------|-------------------------|
+| String   |  |
+| Integer  |  |
+| Float    |  |
+| Boolean  | Encoded as a lower-case boolean string: `"false"`, `"true"` |
+| List     | Encoded as a comma-separated string: `"foo,bar,baz"` |
+| Mapping  | Encoded as a string, with `"key=value"` pairs separated by commas: `"foo=bar,baz=foo"` |
+| Duration | String with millisecond duration encoded with optional suffixes (`ms` for millisecond, `s` for second, `m` for minute): `"5ms"` would convert to `5` in code, and `"5m"` would convert to `300000` in code. |
+
 ### APM Agent Configuration via Kibana
 
 Also known as "central configuration". Agents can query the APM Server for configuration updates; the server proxies and caches requests to Kibana.

--- a/specs/agents/tracing-spans.md
+++ b/specs/agents/tracing-spans.md
@@ -54,7 +54,35 @@ The documentation should clarify that spans with `unknown` outcomes are ignored 
 
 ### Span stack traces
 
-Spans may have an associated stack trace, in order to locate the associated source code that caused the span to occur. If there are many spans being collected this can cause a significant amount of overhead in the application, due to the capture, rendering, and transmission of potentially large stack traces. It is possible to limit the recording of span stack traces to only spans that are slower than a specified duration, using the config variable `ELASTIC_APM_SPAN_FRAMES_MIN_DURATION`.
+Spans may have an associated stack trace, in order to locate the associated
+source code that caused the span to occur. If there are many spans being
+collected this can cause a significant amount of overhead in the application,
+due to the capture, rendering, and transmission of potentially large stack
+traces. It is possible to limit the recording of span stack traces to only
+spans that are slower than a specified duration, using the config variable
+`ELASTIC_APM_SPAN_STACK_TRACE_MIN_DURATION`. (Previously
+`ELASTIC_APM_SPAN_FRAMES_MIN_DURATION`.)
+
+#### `span_stack_trace_min_duration` configuration
+
+Sets the minimum duration of a span for which stack frames/traces will be
+captured.
+
+This option is case-insensitive.
+
+|                |   |
+|----------------|---|
+| Valid options  | `-1`, `0`, [duration](configuration.md#configuration-value-types) |
+| Default        | `5ms` (`5`)  |
+| Dynamic        | `true` |
+| Central config | `true` |
+
+A negative value will result in never capturing the stack traces.
+
+A value of 0 will result in always capturing the stack traces.
+
+A non-default value for this configuration option should override any value
+set for the deprecated `SPAN_FRAMES_MIN_DURATION`.
 
 ### Span count
 


### PR DESCRIPTION
Closes #94 

The old `span_frames_min_duration` will continue to be supported until further notice, though I anticipate we'll update the central config to use the new option only.