### PR TITLE
spec DISABLE_SEND config option

### DIFF
--- a/specs/agents/README.md
+++ b/specs/agents/README.md
@@ -44,6 +44,7 @@ You can find details about each of these in the [APM Data Model](https://www.ela
   - [Distributed tracing](tracing-distributed-tracing.md)
   - [Tracer API](tracing-api.md)
   - Instrumentation
+      - [AWS](tracing-instrumentation-aws.md)
       - [Databases](tracing-instrumentation-db.md)
       - [HTTP](tracing-instrumentation-http.md)
       - [Messaging systems](tracing-instrumentation-messaging.md)

--- a/specs/agents/configuration.md
+++ b/specs/agents/configuration.md
@@ -69,3 +69,33 @@ Failure to process one config attribute should not affect processing of others.
 #### Feature flag
 
 Agents should implement a [configuration option](https://docs.google.com/spreadsheets/d/1JJjZotapacA3FkHc2sv_0wiChILi3uKnkwLTjtBmxwU), (`CENTRAL_CONFIG`) which lets users disable the central configuration polling.
+
+
+### Configuration options
+
+This section specifies *some* configuration options common to two or more APM
+agents. Some configuration options are discussed elsewhere in this repository
+if they better match a particular section -- for example
+[`transaction_ignore_urls`](./tracing-instrumentation-http.md#transaction_ignore_urls-configuration).
+
+#### `ELASTIC_APM_DISABLE_SEND`
+
+`ELASTIC_APM_DISABLE_SEND` is a boolean configuration option to have an APM agent
+be enabled but not communicate with an APM server. Use cases for setting this
+`true` include getting the following, **without** having deployed an APM server
+for event collection.
+
+- maintaining the ability to create traces and log trace/transaction/span IDs
+  through the log correlation feature, and
+- getting automatic distributed tracing via the https://w3c.github.io/trace-context/[W3C HTTP headers]
+
+Agents that implement this configuration option:
+
+- MUST NOT attempt to communicate with APM server. This includes central configuration.
+- MUST NOT log warnings/errors related to failures to communicate with APM server.
+- MUST continue to propagate trace headers (`traceparent`, `tracestate`, etc.)
+  per normal.
+- MUST continue to support [log correlation](./log-correlation.md)
+- SHOULD attempt to reduce runtime overhead where possible. For example,
+  because events will be dropped there is no need to collect stack traces,
+  collect metrics, or to calculate breakdown metrics.


### PR DESCRIPTION
This is part of my [adding `disableSend` support to the Node.js APM agent](https://github.com/elastic/apm-agent-nodejs/pull/2127).

Currently the Java, Python, and Ruby agents implement `disable_send`:

- https://www.elastic.co/guide/en/apm/agent/python/current/configuration.html#config-disable-send
- https://www.elastic.co/guide/en/apm/agent/java/current/config-reporter.html#config-disable-send
- https://www.elastic.co/guide/en/apm/agent/ruby/current/configuration.html#config-disable-send

I'm not sure if they meet the current `MUST` / `SHOULD` semantics I've proposed.

* * *

@felixbarny I'd appreciate a sanity check from you on this:

1. I didn't see an obvious existing spec file for this (didn't feel right in transport.md), so I've started a general section at the bottom of configuration.md.
2. Do the proposed `MUST`s and `SHOULD`s raise any red flags for my being Node.js-centric?