### PR TITLE
Complete exit spans spec change

### DIFF
--- a/specs/agents/handling-huge-traces/tracing-spans-compress.md
+++ b/specs/agents/handling-huge-traces/tracing-spans-compress.md
@@ -120,7 +120,7 @@ and they define properties under the `composite` context.
 
 ### Effects on metric processing
 
-As laid out in the [span destination spec](tracing-spans-destination.md#contextdestinationserviceresource),
+As laid out in the [span destination spec](../tracing-spans-destination.md#contextdestinationserviceresource),
 APM Server tracks span destination metrics.
 To avoid compressed spans to skew latency metrics and cause throughput metrics to be under-counted,
 APM Server will take `composite.count` into account when tracking span destination metrics.
@@ -130,7 +130,7 @@ APM Server will take `composite.count` into account when tracking span destinati
 ### Eligibility for compression
 
 A span is eligible for compression if all the following conditions are met
-1. It's an [exit span](tracing-spans.md#exit-spans)
+1. It's an [exit span](../tracing-spans.md#exit-spans)
 2. The trace context of this span has not been propagated to a downstream service
 3. If the span has `outcome` (i.e., `outcome` is present and it's not `null`) then it should be `success`.
   It means spans with outcome indicating an issue of potential interest should not be compressed.    

--- a/specs/agents/handling-huge-traces/tracing-spans-drop-fast-exit.md
+++ b/specs/agents/handling-huge-traces/tracing-spans-drop-fast-exit.md
@@ -59,7 +59,7 @@ Propagating the trace context to downstream services is also known as out-of-pro
 ### `discardable` flag
 
 Spans store an additional `discardable` flag in order to determine whether a span can be discarded.
-The default value is `true` for [exit spans](tracing-spans.md#exit-spans) and `false` for any other span.
+The default value is `true` for [exit spans](../tracing-spans.md#exit-spans) and `false` for any other span.
 
 According to the [limitations](#Limitations),
 there are certain situations where the `discardable` flag of a span is set to `false`:

--- a/specs/agents/tracing-spans-destination.md
+++ b/specs/agents/tracing-spans-destination.md
@@ -85,7 +85,7 @@ A user-supplied value MUST have the highest precedence, regardless if it was set
 
 **Value**
 
-For all [exit spans](handling-huge-traces/tracing-spans.md#exit-spans), unless the `context.destination.service.resource` field was set by the user to `null` or an empty 
+For all [exit spans](tracing-spans.md#exit-spans), unless the `context.destination.service.resource` field was set by the user to `null` or an empty 
 string through API, agents MUST infer the value of this field based on properties that are set on the span.
 
 If no value is set to the `context.destination.service.resource` field, the logic for automatically inferring 

--- a/tests/agents/json-specs/service_resource_inference.json
+++ b/tests/agents/json-specs/service_resource_inference.json
@@ -43,6 +43,20 @@
   },
   {
     "span": {
+      "exit": "false",
+      "type": "custom",
+      "subtype": "proprietary-db",
+      "context": {
+        "db": {
+          "instance": "myInstance"
+        }
+      }
+    },
+    "expected_resource": null,
+    "failure_message": "The output for non-exit spans should be `null` even if exit-related context data is set"
+  },
+  {
+    "span": {
       "exit": "true",
       "type": "db",
       "subtype": "mysql",


### PR DESCRIPTION
A completion for #483 :
- Fixing docs links
- Adding a test case that `service.resource` field is not automatically inferred for non-explicit exit spans when exit-related context data is set