### PR TITLE
Drop destination.service.{name,type} from azure/db

### DIFF
--- a/specs/agents/tracing-instrumentation-azure.md
+++ b/specs/agents/tracing-instrumentation-azure.md
@@ -51,9 +51,7 @@ is `foo/bar/baz`.
 | APM field | Required? | Format | Notes | Example |
 | --------- | --------- | ------ | ----- | ------- |
 | `context.destination.address` | yes | URL host | | `accountname.blob.core.windows.net` |
-| `context.destination.service.name` | yes | `azureblob` | | | 
 | `context.destination.service.resource` | yes | `azureblob/<Storage Account Name>` | | `azureblob/accountname` |
-| `context.destination.service.type` | yes | `storage` | | | 
 
 
 #### Determining operations
@@ -142,9 +140,7 @@ A new span is created when there is a current transaction, and when a message is
 | APM field | Required? | Format | Notes | Example |
 | --------- | --------- | ------ | ----- | ------- |
 | `context.destination.address` | yes | URL host | | `accountname.queue.core.windows.net` |
-| `context.destination.service.name` | yes | `azurequeue` | | | 
 | `context.destination.service.resource` | yes | `azurequeue/<QueueName>` | | `azurequeue/accountname` |
-| `context.destination.service.type` | yes | `messaging` | | | 
 
 ----
 
@@ -228,9 +224,7 @@ Entities are similar to rows and properties are similar to columns.
 | APM field | Required? | Format | Notes | Example |
 | --------- | --------- | ------ | ----- | ------- |
 | `context.destination.address` | yes | URL host | | `accountname.table.core.windows.net` |
-| `context.destination.service.name` | yes | `azuretable` | | | 
 | `context.destination.service.resource` | yes | `azuretable/<Storage Account Name>` | | `azuretable/accountname` |
-| `context.destination.service.type` | yes | `storage` | | |
 
 #### Determining operations
 
@@ -288,9 +282,7 @@ The `<ResourceName>` is determined from the path of the URL.
 | APM field | Required? | Format | Notes | Example |
 | --------- | --------- | ------ | ----- | ------- |
 | `context.destination.address` | yes | URL host | | `accountname.file.core.windows.net` |
-| `context.destination.service.name` | yes | `azurefile` | | | 
 | `context.destination.service.resource` | yes | `azurefile/<Storage Account Name>` | | `azurefile/accountname` |
-| `context.destination.service.type` | yes | `storage` | | |
 
 #### Determining operations
 
@@ -370,9 +362,7 @@ A new span is created when there is a current transaction, and when a message is
 | APM field | Required? | Format | Notes | Example |
 | --------- | --------- | ------ | ----- | ------- |
 | `context.destination.address` | yes | URL host | | `namespace.servicebus.windows.net` |
-| `context.destination.service.name` | yes | azureservicebus | | | 
 | `context.destination.service.resource` | yes | azureservicebus/`<Queue>`\|`<Topic>` | | `azurequeue/myqueue`, `azureservicebus/mytopic` |
-| `context.destination.service.type` | yes | `messaging` | | | 
 
 ----
 

--- a/specs/agents/tracing-instrumentation-db.md
+++ b/specs/agents/tracing-instrumentation-db.md
@@ -32,8 +32,6 @@ The following fields are relevant for database and datastore spans. Where possib
 | <hr/> |<hr/>|<hr/>|
 |`context.destination.address`|The hostname / address of the database.| :x: |
 |`context.destination.port`|The port under which the database is accessible.| :x: |
-|`context.destination.service.name`| The `destination.service.name` is used to denote "sameness" of the service. E.g. multiple instances of Oracle databases have all the same name `oracle`. For databases and storages the same value as for the `span.subtype` should be used.| :white_check_mark:|
-|`context.destination.service.type`| Should be the same as the `span.type`. Value: `db`| :white_check_mark:|
 |`context.destination.service.resource`|  Used to detect unique destinations from each service. This field should contain all information that is needed to differentiate different database / storage instances (e.g. in the service map). See details below on how to set this field for specific technologies.| :white_check_mark:|
 |`context.destination.cloud.region`| The cloud region in case the datastore is hosted in a public cloud or is a managed datasatore / database. E.g. AWS regions, such as `us-east-1` | :x: |
 


### PR DESCRIPTION
`context.destination.service.name` and `context.destination.service.type` are deprecated, and should be automatically inferred by agents (https://github.com/elastic/apm/issues/448). Remove mention of these fields from domain-specific instrumentation specs.