### PR TITLE
Add long_field_max_length configuration option

### DIFF
--- a/specs/agents/README.md
+++ b/specs/agents/README.md
@@ -61,6 +61,7 @@ You can find details about each of these in the [APM Data Model](https://www.ela
 - [Agent Configuration](configuration.md)
 - [Agent logging](logging.md)
 - [Data sanitization](sanitization.md)
+- [Field limits](field-limits.md)
 
 # Processes
 

--- a/specs/agents/field-limits.md
+++ b/specs/agents/field-limits.md
@@ -1,0 +1,30 @@
+## Field limits
+
+The maximum length of metadata, transaction, span, et al fields are determined
+by the [APM Server Events Intake API schema](https://www.elastic.co/guide/en/apm/server/current/events-api.html).
+Fields that are names or identifiers of some resource of typically limited to
+1024 unicode characters.
+
+### `long_field_max_length` configuration
+
+Some APM event fields are not limited in the APM server intake API schema.
+Agents SHOULD limit the maximum length of the following fields by truncating.
+
+- `{transaction,error}.context.request.body`
+- `{transaction,span,error}.context.message.body`
+- `span.context.db.statement`
+- `error.exception.message`
+- `error.log.message`
+
+Agents MAY support the `long_field_max_length` configuration option to allow
+the user to configure this maximum length.
+
+|                |   |
+|----------------|---|
+| Type           | [`Size`](./configuration.md#configuration-value-types) |
+| Default        | `"10000b"` |
+| Dynamic        | `true` |
+| Central config | `true` |
+
+Ultimately the maximum length of any field is limited by the [`max_event_size`](https://www.elastic.co/guide/en/apm/server/current/configuration-process.html#max_event_size)
+configured for the receiving APM server.


### PR DESCRIPTION
This is a follow up to the [discussion issue](https://github.com/elastic/apm/issues/488) for a common config var for some of the longer fields that (a) aren't limited in length by the APM server intake API schema and (b) have some current agent-specific issues open to be made configurable.

Rendered here: https://github.com/trentm/apm/blob/long_field_max_length/specs/agents/field-limits.md

Some reviewer notes:
- The current hardcoded value in at least a couple of the agents is 10000, hence the default value of "10000b" which looks a little odd. If we don't object to changing that default slightly to 10240, then we can make the default "10kb". Objections?
- The user issues that led to this config option were for `{transaction,error}.context.request.body` and `span.context.db.statement` only. I added some other potential candidate fields for this config var `{transaction,span,error}.context.message.body`, `error.exception.message`, `error.log.message`. I have no strong preference on whether to include those other fields now, later or never. There are here for discussion. Thoughts? (The Node.js APM agent already has the [`errorMessageMaxLength`](https://www.elastic.co/guide/en/apm/agent/nodejs/current/configuration.html#error-message-max-length) config var for the latter two.)
- I'm ambivalent on "Central config: true" for this. It is certainly feasible, but are there reasons we'd consider avoiding adding *rarely used* config vars to the central config UI?
