### PR TITLE
Markdown syntax: avoid a table here because it cannot handle pipes in cells

### DIFF
--- a/specs/agents/configuration.md
+++ b/specs/agents/configuration.md
@@ -33,20 +33,16 @@ emit a log warning about the ignored value.
 
 ### Configuration Value Types
 
-The following table enumerates the available configuration types across the
-agents:
+The following list enumerates the available configuration types across the agents:
 
-
-| Type | Description (if needed) |
-|------|-------------------------|
-| String   |  |
-| Integer  |  |
-| Float    |  |
-| Boolean  | Encoded as a lower-case boolean string: `"false"`, `"true"` |
-| List     | Encoded as a comma-separated string (whitespace surrounding items should be stripped): `"foo,bar,baz"` |
-| Mapping  | Encoded as a string, with `"key=value"` pairs separated by commas (whitespace surrounding items should be stripped): `"foo=bar,baz=foo"` |
-| Duration | Case-sensitive string with duration encoded using unit suffixes (`ms` for millisecond, `s` for second, `m` for minute). Validating regex: `^(-)?(\d+)(ms|s|m)$` |
-| Size     | Case-insensitive string with a positive size encoded using unit suffixes (`b` for bytes, `kb` for kilobytes, `mb` for megabytes, `gb` for gigabytes, with a 1024 multiplier between each unit). Validating regex: `^(\d+)(b|kb|mb|gb)$` |
+- `String`
+- `Integer`
+- `Float`
+- `Boolean`: Encoded as a lower-case boolean string: `"false"`, `"true"`.
+- `List`: Encoded as a comma-separated string (whitespace surrounding items should be stripped): `"foo,bar,baz"`.
+- `Mapping`: Encoded as a string, with `"key=value"` pairs separated by commas (whitespace surrounding items should be stripped): `"foo=bar,baz=foo"`.
+- `Duration`: Case-sensitive string with duration encoded using unit suffixes (`ms` for millisecond, `s` for second, `m` for minute). Validating regex: `^(-)?(\d+)(ms|s|m)$`.
+- `Size`: Case-insensitive string with a positive size encoded using unit suffixes (`b` for bytes, `kb` for kilobytes, `mb` for megabytes, `gb` for gigabytes, with a 1024 multiplier between each unit). Validating regex: `^(\d+)(b|kb|mb|gb)$`.
 
 #### Duration/Size Config Legacy Considerations
 


### PR DESCRIPTION
[GitHub Flavored Markdown tables](https://github.github.com/gfm/#tables-extension-) cannot cope with literal `|` (vertical bars) in cells data. They get interpreted as cell delimiters. That is a problem for the regexes in https://github.com/elastic/apm/blob/master/specs/agents/configuration.md#configuration-value-types

The regexes below are incomplete when rendered:

| Type | Description (if needed) |
|------|-------------------------|
| ...  | ... |
| Duration | ... Validating regex: `^(-)?(\d+)(ms|s|m)$` |
| Size     | ... Validating regex: `^(\d+)(b|kb|mb|gb)$` |


## Option 1

Per https://stackoverflow.com/questions/49809122/vertical-bar-symbol-within-a-markdown-table one workaround is using `&#124;` and `<code>...</code>` like so:

```
| Type | Description (if needed) |
|------|-------------------------|
| ...  | ... |
| Duration | ... Validating regex: <code>^(-)?(\d+)(ms&#124;s&#124;m)$</code> |
| Size     | ... Validating regex: <code>^(\d+)(b&#124;kb&#124;mb&#124;gb)$</code> |
```

Rendered:

| Type | Description (if needed) |
|------|-------------------------|
| ...  | ... |
| Duration | ... Validating regex: <code>^(-)?(\d+)(ms&#124;s&#124;m)$</code> |
| Size     | ... Validating regex: <code>^(\d+)(b&#124;kb&#124;mb&#124;gb)$</code> |

The downside is that this regex is obscure for those reading the raw .md file in their editor.


## Option 2

Use a list instead of a table.
Rendered: https://github.com/trentm/apm/blob/no-table-no-cry/specs/agents/configuration.md#configuration-value-types
