### PR TITLE
span type/subtype : add app/handler

### DIFF
--- a/tests/agents/json-specs/span_types.json
+++ b/tests/agents/json-specs/span_types.json
@@ -43,6 +43,12 @@
         "__used_by": [
           "ruby"
         ]
+      },
+      "handler": {
+        "__description": "Application handler",
+        "__used_by": [
+          "java"
+        ]
       }
     }
   },


### PR DESCRIPTION
Adding `app/handler` to accomodate Javalin plugin which is currently using it.

This is a temporary workaround and should be later be removed through #502 

For example, it would likely be merged in a generic `app/internal` for internal spans for alignment.