### PR TITLE
add user-agent spec + gherkin spec

### DIFF
--- a/specs/agents/transport.md
+++ b/specs/agents/transport.md
@@ -2,6 +2,19 @@
 
 Agents send data to the APM Server as JSON (application/json) or ND-JSON (application/x-ndjson) over HTTP. We describe here various details to guide transport implementation.
 
+### User-Agent
+
+In order to help debugging and gathering usage statistics, agents should use one following values for the `User-Agent` HTTP header:
+
+- Header value should start with `elasticapm-${language}/${agent.version}`.
+- If both `service.name` and `service.version` are set, append ` ${service.name}/${service.version}`
+- If only `service.name` is set, append `${service.name}`
+
+Examples:
+- `elasticapm-java/v1.25.0`
+- `elasticapm-ruby/4.4.0 myservice`
+- `elasticapm-python/6.4.0 myservice/v42.7`
+
 ### Background sending
 
 In order to avoid impacting application performance and behaviour, agents should (where possible) send data in a non-blocking manner, e.g. via a background thread/goroutine/process/what-have-you, or using asynchronous I/O.

--- a/specs/agents/transport.md
+++ b/specs/agents/transport.md
@@ -6,14 +6,16 @@ Agents send data to the APM Server as JSON (application/json) or ND-JSON (applic
 
 In order to help debugging and gathering usage statistics, agents should use one of the following values for the `User-Agent` HTTP header:
 
-- Header value should start with `elasticapm-${language}/${agent.version}`.
-- If both `service.name` and `service.version` are set, append ` ${service.name}/${service.version}`
-- If only `service.name` is set, append `${service.name}`
+- Header value should start with agent github repository as prefix and version `apm-agent-${language}/${agent.version}`.
+- If both `service.name` and `service.version` are set, append ` (${service.name} ${service.version})`
+- If only `service.name` is set, append `(${service.name})`
+
+An executable gherkin specification is also provided in [user_agent.feature](../../tests/agents/gherkin-specs/user_agent.feature).
 
 Examples:
-- `elasticapm-java/v1.25.0`
-- `elasticapm-ruby/4.4.0 myservice`
-- `elasticapm-python/6.4.0 myservice/v42.7`
+- `apm-agent-java/v1.25.0`
+- `apm-agent-ruby/4.4.0 (myservice)`
+- `apm-agent-python/6.4.0 (myservice v42.7)`
 
 ### Background sending
 

--- a/specs/agents/transport.md
+++ b/specs/agents/transport.md
@@ -4,7 +4,7 @@ Agents send data to the APM Server as JSON (application/json) or ND-JSON (applic
 
 ### User-Agent
 
-In order to help debugging and gathering usage statistics, agents should use one following values for the `User-Agent` HTTP header:
+In order to help debugging and gathering usage statistics, agents should use one of the following values for the `User-Agent` HTTP header:
 
 - Header value should start with `elasticapm-${language}/${agent.version}`.
 - If both `service.name` and `service.version` are set, append ` ${service.name}/${service.version}`

--- a/tests/agents/gherkin-specs/user_agent.feature
+++ b/tests/agents/gherkin-specs/user_agent.feature
@@ -4,16 +4,16 @@ Feature: Agent Transport User agent Header
     Given an agent
     When service name is not set
     When service version is not set
-    Then the User-Agent header matches regex 'elasticapm-(java|ruby|python|dotnet|nodejs|go|php)/[^ ]*'
+    Then the User-Agent header matches regex 'elasticapm-[a-z]+/[^ ]*'
 
   Scenario: User-agent with service name only
     Given an agent
     When service name is set to 'myService'
     When service version is not set
-    Then the User-Agent header matches regex 'elasticapm-(java|ruby|python|dotnet|nodejs|go|php)/[^ ]* myService'
+    Then the User-Agent header matches regex 'elasticapm-[a-z]+/[^ ]* myService'
 
   Scenario: User-agent with service name and service version
     Given an agent
     When service name is set to 'myService'
     When service version is set to 'v42'
-    Then the User-Agent header matches regex 'elasticapm-(java|ruby|python|dotnet|nodejs|go|php)/[^ ]* myService/v42'
+    Then the User-Agent header matches regex 'elasticapm-[a-z]+/[^ ]* myService/v42'

--- a/tests/agents/gherkin-specs/user_agent.feature
+++ b/tests/agents/gherkin-specs/user_agent.feature
@@ -4,16 +4,16 @@ Feature: Agent Transport User agent Header
     Given an agent
     When service name is not set
     When service version is not set
-    Then the User-Agent header matches regex '^elasticapm-[a-z]+/[^ ]*'
+    Then the User-Agent header matches regex '^apm-agent-[a-z]+/[^ ]*'
 
   Scenario: User-agent with service name only
     Given an agent
     When service name is set to 'myService'
     When service version is not set
-    Then the User-Agent header matches regex '^elasticapm-[a-z]+/[^ ]* myService'
+    Then the User-Agent header matches regex '^apm-agent-[a-z]+/[^ ]* \(myService\)'
 
   Scenario: User-agent with service name and service version
     Given an agent
     When service name is set to 'myService'
     When service version is set to 'v42'
-    Then the User-Agent header matches regex '^elasticapm-[a-z]+/[^ ]* myService/v42'
+    Then the User-Agent header matches regex '^apm-agent-[a-z]+/[^ ]* \(myService v42\)'

--- a/tests/agents/gherkin-specs/user_agent.feature
+++ b/tests/agents/gherkin-specs/user_agent.feature
@@ -4,16 +4,16 @@ Feature: Agent Transport User agent Header
     Given an agent
     When service name is not set
     When service version is not set
-    Then the User-Agent header matches regex 'elasticapm-[a-z]+/[^ ]*'
+    Then the User-Agent header matches regex '^elasticapm-[a-z]+/[^ ]*'
 
   Scenario: User-agent with service name only
     Given an agent
     When service name is set to 'myService'
     When service version is not set
-    Then the User-Agent header matches regex 'elasticapm-[a-z]+/[^ ]* myService'
+    Then the User-Agent header matches regex '^elasticapm-[a-z]+/[^ ]* myService'
 
   Scenario: User-agent with service name and service version
     Given an agent
     When service name is set to 'myService'
     When service version is set to 'v42'
-    Then the User-Agent header matches regex 'elasticapm-[a-z]+/[^ ]* myService/v42'
+    Then the User-Agent header matches regex '^elasticapm-[a-z]+/[^ ]* myService/v42'

--- a/tests/agents/gherkin-specs/user_agent.feature
+++ b/tests/agents/gherkin-specs/user_agent.feature
@@ -1,0 +1,19 @@
+Feature: Agent Transport User agent Header
+
+  Scenario: Default user-agent
+    Given an agent
+    When service name is not set
+    When service version is not set
+    Then the User-Agent header matches regex 'elasticapm-(java|ruby|python|dotnet|nodejs|go|php)/[^ ]*'
+
+  Scenario: User-agent with service name only
+    Given an agent
+    When service name is set to 'myService'
+    When service version is not set
+    Then the User-Agent header matches regex 'elasticapm-(java|ruby|python|dotnet|nodejs|go|php)/[^ ]* myService'
+
+  Scenario: User-agent with service name and service version
+    Given an agent
+    When service name is set to 'myService'
+    When service version is set to 'v42'
+    Then the User-Agent header matches regex 'elasticapm-(java|ruby|python|dotnet|nodejs|go|php)/[^ ]* myService/v42'


### PR DESCRIPTION
- Adding a shared spec for HTTP user-agent header value 
- Adding gherkin executable spec (might be overkill)

Fixes #509 

<!--- This section is a generated snippet, don't modify it manually --->

# Status
| Summary: | ![custom ep](https://img.shields.io/endpoint?url=https%3A%2F%2Fgiss.app.elstc.co%2Fapi%2Fmeta%2Felastic%2F514%2Fclosed&logo=verizon&style=for-the-badge) ![custom ep](https://img.shields.io/endpoint?url=https%3A%2F%2Fgiss.app.elstc.co%2Fapi%2Fmeta%2Felastic%2F514%2Fin%2520progress&style=for-the-badge) ![custom ep](https://img.shields.io/endpoint?url=https%3A%2F%2Fgiss.app.elstc.co%2Fapi%2Fmeta%2Felastic%2F514%2Fopen&style=for-the-badge)|
|---|---|

| Agent | User-agent header for transport |
|---|---:|
| dot-net | [![issue details](https://img.shields.io/endpoint?url=https%3A%2F%2Fgiss.app.elstc.co%2Fapi%2Fms%2Felastic%2Fapm-agent-dotnet%2F1517)](https://github.com/elastic/apm-agent-dotnet/issues/1517) [![issue details](https://img.shields.io/endpoint?url=https%3A%2F%2Fgiss.app.elstc.co%2Fapi%2Fstatus%2Felastic%2Fapm-agent-dotnet%2F1517)](https://github.com/elastic/apm-agent-dotnet/issues/1517)|
| Go | [![issue details](https://img.shields.io/endpoint?url=https%3A%2F%2Fgiss.app.elstc.co%2Fapi%2Fms%2Felastic%2Fapm-agent-go%2F1136)](https://github.com/elastic/apm-agent-go/issues/1136) [![issue details](https://img.shields.io/endpoint?url=https%3A%2F%2Fgiss.app.elstc.co%2Fapi%2Fstatus%2Felastic%2Fapm-agent-go%2F1136)](https://github.com/elastic/apm-agent-go/issues/1136)|
| PHP | [![issue details](https://img.shields.io/endpoint?url=https%3A%2F%2Fgiss.app.elstc.co%2Fapi%2Fms%2Felastic%2Fapm-agent-php%2F560)](https://github.com/elastic/apm-agent-php/issues/560) [![issue details](https://img.shields.io/endpoint?url=https%3A%2F%2Fgiss.app.elstc.co%2Fapi%2Fstatus%2Felastic%2Fapm-agent-php%2F560)](https://github.com/elastic/apm-agent-php/issues/560)|
| Ruby | [![issue details](https://img.shields.io/endpoint?url=https%3A%2F%2Fgiss.app.elstc.co%2Fapi%2Fms%2Felastic%2Fapm-agent-ruby%2F1169)](https://github.com/elastic/apm-agent-ruby/issues/1169) [![issue details](https://img.shields.io/endpoint?url=https%3A%2F%2Fgiss.app.elstc.co%2Fapi%2Fstatus%2Felastic%2Fapm-agent-ruby%2F1169)](https://github.com/elastic/apm-agent-ruby/issues/1169)|
| NodeJS | [![issue details](https://img.shields.io/endpoint?url=https%3A%2F%2Fgiss.app.elstc.co%2Fapi%2Fms%2Felastic%2Fapm-agent-nodejs%2F2364)](https://github.com/elastic/apm-agent-nodejs/issues/2364) [![issue details](https://img.shields.io/endpoint?url=https%3A%2F%2Fgiss.app.elstc.co%2Fapi%2Fstatus%2Felastic%2Fapm-agent-nodejs%2F2364)](https://github.com/elastic/apm-agent-nodejs/issues/2364)|
| Python | [![issue details](https://img.shields.io/endpoint?url=https%3A%2F%2Fgiss.app.elstc.co%2Fapi%2Fms%2Felastic%2Fapm-agent-python%2F1355)](https://github.com/elastic/apm-agent-python/issues/1355) [![issue details](https://img.shields.io/endpoint?url=https%3A%2F%2Fgiss.app.elstc.co%2Fapi%2Fstatus%2Felastic%2Fapm-agent-python%2F1355)](https://github.com/elastic/apm-agent-python/issues/1355)|


 <!--- End of generated section --->