### PR TITLE
Updating the metadata hostname specification

### DIFF
--- a/specs/agents/metadata.md
+++ b/specs/agents/metadata.md
@@ -22,6 +22,18 @@ System metadata relates to the host/container in which the service being monitor
    - pod name
    - pod UID
 
+#### Hostname
+
+The `system.hostname` field is deprecated in favour of two newer fields:
+- `system.configured_hostname` - the configured name of the host the monitored service is running on. It should only be 
+sent when configured by the user through the `ELASTIC_APM_HOSTNAME` config. 
+If provided, it is used as the event's hostname.
+- `system.detected_hostname` - the hostname detected by the APM agent. Wherever applicable, this field should contains 
+what the `hostname` command returns on the host machine, as it is mapped by the APM Server to the [`host.hostname` ECS field](https://www.elastic.co/guide/en/ecs/current/ecs-host.html#field-host-hostname). 
+Failing to conform to that may cause failure in correlation between APM traces and data reported by other clients 
+(e.g. Metricbeat).
+It will be used as the event's hostname if `configured_hostname` is not provided.
+
 #### Container/Kubernetes metadata
 
 On Linux, the container ID and some of the Kubernetes metadata can be extracted by parsing `/proc/self/cgroup`. For each line in the file, we split the line according to the format "hierarchy-ID:controller-list:cgroup-path", extracting the "cgroup-path" part. We then attempt to extract information according to the following algorithm:


### PR DESCRIPTION
@elastic/apm-agent-devs we just got a report that the link from APM traces to host metrics may be broken if the hostname discovery is not done as specified hereby, so please take a quick look to see whether such a fix is required in your agent