### PR TITLE
Disable payload compression for localhost

### DIFF
--- a/specs/agents/transport.md
+++ b/specs/agents/transport.md
@@ -48,6 +48,6 @@ The APM Server accepts both uncompressed and compressed HTTP requests. The follo
 - gzip data format (`Content-Encoding: gzip`)
 
 Agents MUST compress the HTTP payload, optimising for speed over compactness (typically known as the "best speed" level).
-If the host part of the APM Server URL is either `localhost` or `127.0.0.1`, agents SHOULD disable compression.
+If the host part of the APM Server URL is either `localhost`, `127.0.0.1`, `::1`, or `0:0:0:0:0:0:0:1`, agents SHOULD disable compression.
 To do so, agents can either completely omit calling the compression library and remove the `Content-Encoding` header,
 or simply use the compresion level `NO_COMPRESSION`.

--- a/specs/agents/transport.md
+++ b/specs/agents/transport.md
@@ -49,5 +49,6 @@ The APM Server accepts both uncompressed and compressed HTTP requests. The follo
 
 Agents MUST compress the HTTP payload, optimising for speed over compactness (typically known as the "best speed" level).
 If the host part of the APM Server URL is either `localhost`, `127.0.0.1`, `::1`, or `0:0:0:0:0:0:0:1`, agents SHOULD disable compression.
-To do so, agents can either completely omit calling the compression library and remove the `Content-Encoding` header,
-or simply use the compresion level `NO_COMPRESSION`.
+
+Agents MUST NOT use the compression level `NO_COMPRESSION` to disable compression.
+That's because the [Lambda extension](https://github.com/elastic/apm-aws-lambda/tree/astorm/docs/apm-lambda-extension) would otherwise consider the data as being compressed (due to the `Content-Encoding` header) and send data to APM Server that's actually uncompressed.

--- a/specs/agents/transport.md
+++ b/specs/agents/transport.md
@@ -51,4 +51,4 @@ Agents MUST compress the HTTP payload, optimising for speed over compactness (ty
 If the host part of the APM Server URL is either `localhost`, `127.0.0.1`, `::1`, or `0:0:0:0:0:0:0:1`, agents SHOULD disable compression.
 
 Agents MUST NOT use the compression level `NO_COMPRESSION` to disable compression.
-That's because the [Lambda extension](https://github.com/elastic/apm-aws-lambda/tree/astorm/docs/apm-lambda-extension) would otherwise consider the data as being compressed (due to the `Content-Encoding` header) and send data to APM Server that's actually uncompressed.
+That's because the [Lambda extension](https://github.com/elastic/apm-aws-lambda/tree/main/apm-lambda-extension) would otherwise consider the data as being compressed (due to the `Content-Encoding` header) and send data to APM Server that's actually uncompressed.

--- a/specs/agents/transport.md
+++ b/specs/agents/transport.md
@@ -62,7 +62,7 @@ The APM Server accepts both uncompressed and compressed HTTP requests. The follo
 - zlib data format (`Content-Encoding: deflate`)
 - gzip data format (`Content-Encoding: gzip`)
 
-Agents MUST compress the HTTP payload, optimising for speed over compactness (typically known as the "best speed" level).
+Agents MUST compress the HTTP payload and SHOULD optimize for speed over compactness (typically known as the "best speed" level).
 
 If the host part of the APM Server URL is either `localhost`, `127.0.0.1`, `::1`, or `0:0:0:0:0:0:0:1`, agents SHOULD disable compression.
 Agents MUST NOT use the compression level `NO_COMPRESSION` to disable compression.

--- a/specs/agents/transport.md
+++ b/specs/agents/transport.md
@@ -47,4 +47,7 @@ The APM Server accepts both uncompressed and compressed HTTP requests. The follo
 - zlib data format (`Content-Encoding: deflate`)
 - gzip data format (`Content-Encoding: gzip`)
 
-Agents should compress the HTTP payload by default, optimising for speed over compactness (typically known as the "best speed" level).
+Agents MUST compress the HTTP payload, optimising for speed over compactness (typically known as the "best speed" level).
+If the host part of the APM Server URL is either `localhost` or `127.0.0.1`, agents SHOULD disable compression.
+To do so, agents can either completely omit calling the compression library and remove the `Content-Encoding` header,
+or simply use the compresion level `NO_COMPRESSION`.


### PR DESCRIPTION
This will be specifically relevant for the Lambda instrumentation. But also useful more generally as local APM Server is becoming the norm.

The localhost detection is very basic right now but also simple and should cover most cases. We may do something more sophisticated in the future or add a config option to toggle compression for more manual control.

The benefits are:
- Higher throughput of events that can be sent to APM Server/the Lambda extension.
- Lower latency when flushing data. This is especially important in Lambda as flushing is on the critical path. The longer the flush takes, the longer the end user has to wait for the Lambda's response.
- Lower CPU usage compared to sending out the same number of events with compression enabled.

Potential downsides
- More requests to APM Server have to be made as `api_request_size` fills up more quickly. This may result in a higher allocation rate. This shouldn't be an issue in Lambda environments, as we're ending the request after each transaction anyway.

Follow-ups for the future: consider always using lz4 compression. Based on initial benchmarks, this could further increase throughput while also decreasing CPU utilization, even compared to no compression. The main tradeoff is a decreased compression ratio.