### PR TITLE
`exit_span_min_duration`: Support `us` unit

### DIFF
--- a/specs/agents/configuration.md
+++ b/specs/agents/configuration.md
@@ -42,7 +42,7 @@ The following list enumerates the available configuration types across the agent
 - `List`: Encoded as a comma-separated string (whitespace surrounding items should be stripped): `"foo,bar,baz"`.
 - `Mapping`: Encoded as a string, with `"key=value"` pairs separated by commas (whitespace surrounding items should be stripped): `"foo=bar,baz=foo"`.
 - `Duration`: Case-sensitive string with duration encoded using unit suffixes (`ms` for millisecond, `s` for second, `m` for minute). Validating regex: `^(-)?(\d+)(ms|s|m)$`.
-  - Except for [`exit_span_min_duration`](handling-huge-traces/tracing-spans-drop-fast-exit.md#exit_span_min_duration-configuration), which supports a microsecond duration (`us`). Validating regex: `^(-)?(\d+)(us|ms|s|m)$`.
+- `GranularDuration`: Case-sensitive string with duration encoded using unit suffixes which supports down to a microsecond duration (`us`). Validating regex: `^(-)?(\d+)(us|ms|s|m)$`.
 - `Size`: Case-insensitive string with a positive size encoded using unit suffixes (`b` for bytes, `kb` for kilobytes, `mb` for megabytes, `gb` for gigabytes, with a 1024 multiplier between each unit). Validating regex: `^(\d+)(b|kb|mb|gb)$`.
 
 #### Duration/Size Config Legacy Considerations

--- a/specs/agents/configuration.md
+++ b/specs/agents/configuration.md
@@ -42,6 +42,7 @@ The following list enumerates the available configuration types across the agent
 - `List`: Encoded as a comma-separated string (whitespace surrounding items should be stripped): `"foo,bar,baz"`.
 - `Mapping`: Encoded as a string, with `"key=value"` pairs separated by commas (whitespace surrounding items should be stripped): `"foo=bar,baz=foo"`.
 - `Duration`: Case-sensitive string with duration encoded using unit suffixes (`ms` for millisecond, `s` for second, `m` for minute). Validating regex: `^(-)?(\d+)(ms|s|m)$`.
+  - Except for [`exit_span_min_duration`](handling-huge-traces/tracing-spans-drop-fast-exit.md#exit_span_min_duration-configuration), which supports a microsecond duration (`us`). Validating regex: `^(-)?(\d+)(us|ms|s|m)$`.
 - `Size`: Case-insensitive string with a positive size encoded using unit suffixes (`b` for bytes, `kb` for kilobytes, `mb` for megabytes, `gb` for gigabytes, with a 1024 multiplier between each unit). Validating regex: `^(\d+)(b|kb|mb|gb)$`.
 
 #### Duration/Size Config Legacy Considerations

--- a/specs/agents/handling-huge-traces/tracing-spans-drop-fast-exit.md
+++ b/specs/agents/handling-huge-traces/tracing-spans-drop-fast-exit.md
@@ -24,9 +24,8 @@ Additionally, spans that lead to an error can't be discarded.
 | Default        | `1ms`      |
 | Central config | `true`     |
 
-TODO: should we introduce µs granularity for this config option?
-Adding `us` to all `duration`-typed options would create compatibility issues.
-So we probably want to support `us` for this option only.
+The minimum allowed duration for this setting is `1us` (microsecond). Agents may need to
+add support the `us` unit.
 
 ## Interplay with span compression
 


### PR DESCRIPTION
## Description
Removes the previous TODO in the spec in favor of adding support for the
microsecond unit (`us`) for the `exit_span_min_duration` setting.
