### PR TITLE
Introduce common setup language to gherkin specs

### DIFF
--- a/tests/agents/gherkin-specs/api_key.feature
+++ b/tests/agents/gherkin-specs/api_key.feature
@@ -3,22 +3,22 @@ Feature: APM server authentication with API key and secret token
   Scenario: A configured API key is sent in the Authorization header
     Given an agent configured with
       | setting    | value        |
-      | api key    | RTNxMjlXNEJt |
+      | api_key    | RTNxMjlXNEJt |
     When the agent sends a request to APM server
     Then the Authorization header of the request is 'ApiKey RTNxMjlXNEJt'
 
   Scenario: A configured secret token is sent in the Authorization header
     Given an agent configured with
       | setting       | value         |
-      | secret token  | secr3tT0ken   |
+      | secret_token  | secr3tT0ken   |
     When the agent sends a request to APM server
     Then the Authorization header of the request is 'Bearer secr3tT0ken'
 
   Scenario: A configured API key takes precedence over a secret token
     Given an agent configured with
       | setting       | value         |
-      | api key       | MjlXNEJasdfDt |
-      | secret token  | secr3tT0ken   |
+      | api_key       | MjlXNEJasdfDt |
+      | secret_token  | secr3tT0ken   |
     When the agent sends a request to APM server
     Then the Authorization header of the request is 'ApiKey MjlXNEJasdfDt'
 

--- a/tests/agents/gherkin-specs/api_key.feature
+++ b/tests/agents/gherkin-specs/api_key.feature
@@ -1,18 +1,24 @@
-Feature: API Key.
+Feature: APM server authentication with API key and secret token
 
-  Scenario: A configured API key is sent in the Authorization header.
-    Given an agent
-    When an api key is set to 'RTNxMjlXNEJt' in the config
-    Then the Authorization header is 'ApiKey RTNxMjlXNEJt'
+  Scenario: A configured API key is sent in the Authorization header
+    Given an agent configured with
+      | setting    | value        |
+      | api key    | RTNxMjlXNEJt |
+    When the agent sends a request to APM server
+    Then the Authorization header of the request is 'ApiKey RTNxMjlXNEJt'
 
-  Scenario: A configured API key takes precedence over a secret token.
-    Given an agent
-    When an api key is set to 'MjlXNEJasdfDt' in the config
-    And a secret_token is set to 'secr3tT0ken' in the config
-    Then the Authorization header is 'ApiKey MjlXNEJasdfDt'
+  Scenario: A configured secret token is sent in the Authorization header
+    Given an agent configured with
+      | setting       | value         |
+      | secret token  | secr3tT0ken   |
+    When the agent sends a request to APM server
+    Then the Authorization header of the request is 'Bearer secr3tT0ken'
 
-  Scenario: A configured secret token is sent if no API key is configured.
-    Given an agent
-    When a secret_token is set to 'secr3tT0ken' in the config
-    And an api key is not set in the config
-    Then the Authorization header is 'Bearer secr3tT0ken'
+  Scenario: A configured API key takes precedence over a secret token
+    Given an agent configured with
+      | setting       | value         |
+      | api key       | MjlXNEJasdfDt |
+      | secret token  | secr3tT0ken   |
+    When the agent sends a request to APM server
+    Then the Authorization header of the request is 'ApiKey MjlXNEJasdfDt'
+

--- a/tests/agents/gherkin-specs/azure_app_service_metadata.feature
+++ b/tests/agents/gherkin-specs/azure_app_service_metadata.feature
@@ -1,7 +1,9 @@
 Feature: Extracting Metadata for Azure App Service
 
   Background:
-    Given an instrumented application is configured to collect cloud provider metadata for azure
+    Given an agent configured with
+      | setting        | value |
+      | cloud provider | azure |
 
   Scenario Outline: Azure App Service with all environment variables present in expected format
     Given the following environment variables are present

--- a/tests/agents/gherkin-specs/azure_app_service_metadata.feature
+++ b/tests/agents/gherkin-specs/azure_app_service_metadata.feature
@@ -3,7 +3,7 @@ Feature: Extracting Metadata for Azure App Service
   Background:
     Given an agent configured with
       | setting        | value |
-      | cloud provider | azure |
+      | cloud_provider | azure |
 
   Scenario Outline: Azure App Service with all environment variables present in expected format
     Given the following environment variables are present

--- a/tests/agents/gherkin-specs/outcome.feature
+++ b/tests/agents/gherkin-specs/outcome.feature
@@ -7,48 +7,54 @@ Feature: Outcome
 
   Scenario: User set outcome on span has priority over instrumentation
     Given an active span
-    And user sets span outcome to 'failure'
-    When span terminates with outcome 'success'
-    Then span outcome is 'failure'
+    And the span outcome is 'success'
+    And a user sets the span outcome to 'failure'
+    When the span ends
+    Then the span outcome is 'failure'
 
   Scenario: User set outcome on transaction has priority over instrumentation
     Given an active transaction
-    And user sets transaction outcome to 'unknown'
-    When transaction terminates with outcome 'failure'
-    Then transaction outcome is 'unknown'
+    And the transaction outcome is 'failure'
+    And a user sets the transaction outcome to 'unknown'
+    When the transaction ends
+    Then the transaction outcome is 'unknown'
 
   # ---- span & transaction outcome from reported errors
 
   Scenario: span with error
     Given an active span
-    When span terminates with an error
-    Then span outcome is 'failure'
+    And an error is reported to the span
+    When the span ends
+    Then the span outcome is 'failure'
 
   Scenario: span without error
     Given an active span
-    When span terminates
-    Then span outcome is 'success'
+    When the span ends
+    Then the span outcome is 'success'
 
   Scenario: transaction with error
     Given an active transaction
-    When transaction terminates with an error
-    Then transaction outcome is 'failure'
+    And an error is reported to the transaction
+    When the transaction ends
+    Then the transaction outcome is 'failure'
 
   Scenario: transaction without error
     Given an active transaction
-    When transaction terminates
-    Then transaction outcome is 'success'
+    When the transaction ends
+    Then the transaction outcome is 'success'
 
   # ---- HTTP
 
   @http
   Scenario Outline: HTTP transaction and span outcome
-    Given an active HTTP transaction with <status> response code
-    When transaction terminates
-    Then transaction outcome is "<server>"
-    Given an active HTTP span with <status> response code
-    When span terminates
-    Then span outcome is "<client>"
+    Given an active transaction 
+    And a HTTP call is received that returns 'status'
+    When the transaction ends
+    Then the transaction outcome is '<server>'
+    Given an active span 
+    And a HTTP call is made that returns 'status'
+    When the span ends
+    Then the span outcome is '<client>'
     Examples:
       | status | client  | server  |
       | 100    | success | success |
@@ -67,12 +73,14 @@ Feature: Outcome
 
   @grpc
   Scenario Outline: gRPC transaction and span outcome
-    Given an active gRPC transaction with '<status>' status
-    When transaction terminates
-    Then transaction outcome is "<server>"
-    Given an active gRPC span with '<status>' status
-    When span terminates
-    Then span outcome is "<client>"
+    Given an active transaction
+    And a gRPC call is received that returns '<status>'
+    When the transaction ends
+    Then transaction outcome is '<server>'
+    Given an active span
+    And a gRPC call is made that returns '<status>'
+    When the span ends
+    Then the span outcome is '<client>'
     Examples:
       | status              | client  | server  |
       | OK                  | success | success |

--- a/tests/agents/gherkin-specs/outcome.feature
+++ b/tests/agents/gherkin-specs/outcome.feature
@@ -1,55 +1,53 @@
 Feature: Outcome
 
+  Background: An agent with default configuration
+    Given an agent
+
   # ---- user set outcome
 
   Scenario: User set outcome on span has priority over instrumentation
-    Given an agent
-    And an active span
+    Given an active span
     And user sets span outcome to 'failure'
-    And span terminates with outcome 'success'
+    When span terminates with outcome 'success'
     Then span outcome is 'failure'
 
   Scenario: User set outcome on transaction has priority over instrumentation
-    Given an agent
-    And an active transaction
+    Given an active transaction
     And user sets transaction outcome to 'unknown'
-    And transaction terminates with outcome 'failure'
+    When transaction terminates with outcome 'failure'
     Then transaction outcome is 'unknown'
 
   # ---- span & transaction outcome from reported errors
 
   Scenario: span with error
-    Given an agent
-    And an active span
-    And span terminates with an error
+    Given an active span
+    When span terminates with an error
     Then span outcome is 'failure'
 
   Scenario: span without error
-    Given an agent
-    And an active span
-    And span terminates without error
+    Given an active span
+    When span terminates
     Then span outcome is 'success'
 
   Scenario: transaction with error
-    Given an agent
-    And an active transaction
-    And transaction terminates with an error
+    Given an active transaction
+    When transaction terminates with an error
     Then transaction outcome is 'failure'
 
   Scenario: transaction without error
-    Given an agent
-    And an active transaction
-    And transaction terminates without error
+    Given an active transaction
+    When transaction terminates
     Then transaction outcome is 'success'
 
   # ---- HTTP
 
   @http
   Scenario Outline: HTTP transaction and span outcome
-    Given an agent
-    And an HTTP transaction with <status> response code
+    Given an active HTTP transaction with <status> response code
+    When transaction terminates
     Then transaction outcome is "<server>"
-    Given an HTTP span with <status> response code
+    Given an active HTTP span with <status> response code
+    When span terminates
     Then span outcome is "<client>"
     Examples:
       | status | client  | server  |
@@ -69,10 +67,11 @@ Feature: Outcome
 
   @grpc
   Scenario Outline: gRPC transaction and span outcome
-    Given an agent
-    And a gRPC transaction with '<status>' status
+    Given an active gRPC transaction with '<status>' status
+    When transaction terminates
     Then transaction outcome is "<server>"
-    Given a gRPC span with '<status>' status
+    Given an active gRPC span with '<status>' status
+    When span terminates
     Then span outcome is "<client>"
     Examples:
       | status              | client  | server  |

--- a/tests/agents/gherkin-specs/user_agent.feature
+++ b/tests/agents/gherkin-specs/user_agent.feature
@@ -8,7 +8,7 @@ Feature: Agent Transport User agent Header
   Scenario Outline: User-agent with service name only
     Given an agent configured with
       | setting         | value            |
-      | service name    | <SERVICE_NAME>   |
+      | service_name    | <SERVICE_NAME>   |
     When the agent sends a request to APM server
     Then the User-Agent header matches regex '^apm-agent-[a-z]+/[^ ]* \(<ESCAPED_SERVICE_NAME>\)'
   Examples:
@@ -19,9 +19,8 @@ Feature: Agent Transport User agent Header
   Scenario Outline: User-agent with service name and service version
     Given an agent configured with
       | setting         | value             |
-      | setting         | value             |
-      | service name    | <SERVICE_NAME>    |
-      | service version | <SERVICE_VERSION> |
+      | service_name    | <SERVICE_NAME>    |
+      | service_version | <SERVICE_VERSION> |
     When the agent sends a request to APM server
     Then the User-Agent header of the request matches regex '^apm-agent-[a-z]+/[^ ]* \(<ESCAPED_SERVICE_NAME> <ESCAPED_SERVICE_VERSION>\)'
   Examples:

--- a/tests/agents/gherkin-specs/user_agent.feature
+++ b/tests/agents/gherkin-specs/user_agent.feature
@@ -2,18 +2,29 @@ Feature: Agent Transport User agent Header
 
   Scenario: Default user-agent
     Given an agent
-    When service name is not set
-    When service version is not set
+    When the agent sends a request to APM server
     Then the User-Agent header matches regex '^apm-agent-[a-z]+/[^ ]*'
 
-  Scenario: User-agent with service name only
-    Given an agent
-    When service name is set to 'myService'
-    When service version is not set
-    Then the User-Agent header matches regex '^apm-agent-[a-z]+/[^ ]* \(myService\)'
+  Scenario Outline: User-agent with service name only
+    Given an agent configured with
+      | setting         | value            |
+      | service name    | <SERVICE_NAME>   |
+    When the agent sends a request to APM server
+    Then the User-Agent header matches regex '^apm-agent-[a-z]+/[^ ]* \(<ESCAPED_SERVICE_NAME>\)'
+  Examples:
+    | SERVICE_NAME               | ESCAPED_SERVICE_NAME  |
+    | myService                  | myService             |
+    | /()<>@, :;={}?\\[\\]\"\\\\ | _____________________ |
 
-  Scenario: User-agent with service name and service version
-    Given an agent
-    When service name is set to 'myService'
-    When service version is set to 'v42'
-    Then the User-Agent header matches regex '^apm-agent-[a-z]+/[^ ]* \(myService v42\)'
+  Scenario Outline: User-agent with service name and service version
+    Given an agent configured with
+      | setting         | value             |
+      | setting         | value             |
+      | service name    | <SERVICE_NAME>    |
+      | service version | <SERVICE_VERSION> |
+    When the agent sends a request to APM server
+    Then the User-Agent header of the request matches regex '^apm-agent-[a-z]+/[^ ]* \(<ESCAPED_SERVICE_NAME> <ESCAPED_SERVICE_VERSION>\)'
+  Examples:
+    | SERVICE_NAME               | ESCAPED_SERVICE_NAME  | SERVICE_VERSION            | ESCAPED_SERVICE_VERSION |
+    | myService                  | myService             | v42                        |                         |
+    | /()<>@, :;={}?\\[\\]\"\\\\ | _____________________ | /()<>@, :;={}?\\[\\]\"\\\\ | _____________________   |


### PR DESCRIPTION
This commit introduces common agent setup language to gherkin specs:

- Given an agent: an agent with the default configuration
- Given an agent configure with `<TABLE>`: an agent with specific configuration

Add examples to User-Agent feature to demonstrate characters
that should be escaped in header values.