### PR TITLE
Some adjustments to User-Agent and span outcome gherkin specs

### DIFF
--- a/tests/agents/gherkin-specs/outcome.feature
+++ b/tests/agents/gherkin-specs/outcome.feature
@@ -48,11 +48,11 @@ Feature: Outcome
   @http
   Scenario Outline: HTTP transaction and span outcome
     Given an active transaction 
-    And a HTTP call is received that returns 'status'
+    And a HTTP call is received that returns <status>
     When the transaction ends
     Then the transaction outcome is '<server>'
     Given an active span 
-    And a HTTP call is made that returns 'status'
+    And a HTTP call is made that returns <status>
     When the span ends
     Then the span outcome is '<client>'
     Examples:

--- a/tests/agents/gherkin-specs/outcome.feature
+++ b/tests/agents/gherkin-specs/outcome.feature
@@ -76,7 +76,7 @@ Feature: Outcome
     Given an active transaction
     And a gRPC call is received that returns '<status>'
     When the transaction ends
-    Then transaction outcome is '<server>'
+    Then the transaction outcome is '<server>'
     Given an active span
     And a gRPC call is made that returns '<status>'
     When the span ends

--- a/tests/agents/gherkin-specs/user_agent.feature
+++ b/tests/agents/gherkin-specs/user_agent.feature
@@ -25,5 +25,5 @@ Feature: Agent Transport User agent Header
     Then the User-Agent header matches regex '^apm-agent-[a-z]+/[^ ]* \(<ESCAPED_SERVICE_NAME> <ESCAPED_SERVICE_VERSION>\)'
   Examples:
     | SERVICE_NAME               | ESCAPED_SERVICE_NAME  | SERVICE_VERSION            | ESCAPED_SERVICE_VERSION |
-    | myService                  | myService             | v42                        |                         |
+    | myService                  | myService             | v42                        | v42                     |
     | /()<>@, :;={}?\\[\\]\"\\\\ | _____________________ | /()<>@, :;={}?\\[\\]\"\\\\ | _____________________   |

--- a/tests/agents/gherkin-specs/user_agent.feature
+++ b/tests/agents/gherkin-specs/user_agent.feature
@@ -5,16 +5,19 @@ Feature: Agent Transport User agent Header
     When the agent sends a request to APM server
     Then the User-Agent header of the request matches regex '^apm-agent-[a-z]+/[^ ]* \(.*\)'
 
-  Scenario Outline: User-agent with service name only
+  Scenario: Default user-agent when setting invalid service
     Given an agent configured with
       | setting         | value            |
-      | service_name    | <SERVICE_NAME>   |
+      | service_name    | myService/()<>@  |
     When the agent sends a request to APM server
-    Then the User-Agent header of the request matches regex '^apm-agent-[a-z]+/[^ ]* \(<ESCAPED_SERVICE_NAME>\)'
-  Examples:
-    | SERVICE_NAME               | ESCAPED_SERVICE_NAME  |
-    | myService                  | myService             |
-    | /()<>@, :;={}?\\[\\]\"\\\\ | _____________________ |
+    Then the User-Agent header of the request matches regex '^apm-agent-[a-z]+/[^ ]* \(.*\)'
+
+  Scenario: User-agent with service name only
+    Given an agent configured with
+      | setting         | value            |
+      | service_name    | myService        |
+    When the agent sends a request to APM server
+    Then the User-Agent header of the request matches regex '^apm-agent-[a-z]+/[^ ]* \(myService\)'
 
   Scenario Outline: User-agent with service name and service version
     Given an agent configured with

--- a/tests/agents/gherkin-specs/user_agent.feature
+++ b/tests/agents/gherkin-specs/user_agent.feature
@@ -26,7 +26,7 @@ Feature: Agent Transport User agent Header
       | service_version | <SERVICE_VERSION> |
     When the agent sends a request to APM server
     Then the User-Agent header of the request matches regex '^apm-agent-[a-z]+/[^ ]* \(<ESCAPED_SERVICE_NAME> <ESCAPED_SERVICE_VERSION>\)'
-  Examples:
-    | SERVICE_NAME               | ESCAPED_SERVICE_NAME  | SERVICE_VERSION            | ESCAPED_SERVICE_VERSION |
-    | myService                  | myService             | v42                        | v42                     |
-    | /()<>@, :;={}?\\[\\]\"\\\\ | _____________________ | /()<>@, :;={}?\\[\\]\"\\\\ | _____________________   |
+    Examples:
+      | SERVICE_NAME   | ESCAPED_SERVICE_NAME  | SERVICE_VERSION   | ESCAPED_SERVICE_VERSION |
+      | myService      | myService             | v42               | v42                     |
+      | myService      | myService             | 123(:\;)456       | 123_:_;_456             |

--- a/tests/agents/gherkin-specs/user_agent.feature
+++ b/tests/agents/gherkin-specs/user_agent.feature
@@ -3,14 +3,14 @@ Feature: Agent Transport User agent Header
   Scenario: Default user-agent
     Given an agent
     When the agent sends a request to APM server
-    Then the User-Agent header matches regex '^apm-agent-[a-z]+/[^ ]*'
+    Then the User-Agent header of the request matches regex '^apm-agent-[a-z]+/[^ ]*'
 
   Scenario Outline: User-agent with service name only
     Given an agent configured with
       | setting         | value            |
       | service_name    | <SERVICE_NAME>   |
     When the agent sends a request to APM server
-    Then the User-Agent header matches regex '^apm-agent-[a-z]+/[^ ]* \(<ESCAPED_SERVICE_NAME>\)'
+    Then the User-Agent header of the request matches regex '^apm-agent-[a-z]+/[^ ]* \(<ESCAPED_SERVICE_NAME>\)'
   Examples:
     | SERVICE_NAME               | ESCAPED_SERVICE_NAME  |
     | myService                  | myService             |
@@ -22,7 +22,7 @@ Feature: Agent Transport User agent Header
       | service_name    | <SERVICE_NAME>    |
       | service_version | <SERVICE_VERSION> |
     When the agent sends a request to APM server
-    Then the User-Agent header matches regex '^apm-agent-[a-z]+/[^ ]* \(<ESCAPED_SERVICE_NAME> <ESCAPED_SERVICE_VERSION>\)'
+    Then the User-Agent header of the request matches regex '^apm-agent-[a-z]+/[^ ]* \(<ESCAPED_SERVICE_NAME> <ESCAPED_SERVICE_VERSION>\)'
   Examples:
     | SERVICE_NAME               | ESCAPED_SERVICE_NAME  | SERVICE_VERSION            | ESCAPED_SERVICE_VERSION |
     | myService                  | myService             | v42                        | v42                     |

--- a/tests/agents/gherkin-specs/user_agent.feature
+++ b/tests/agents/gherkin-specs/user_agent.feature
@@ -22,7 +22,7 @@ Feature: Agent Transport User agent Header
       | service_name    | <SERVICE_NAME>    |
       | service_version | <SERVICE_VERSION> |
     When the agent sends a request to APM server
-    Then the User-Agent header of the request matches regex '^apm-agent-[a-z]+/[^ ]* \(<ESCAPED_SERVICE_NAME> <ESCAPED_SERVICE_VERSION>\)'
+    Then the User-Agent header matches regex '^apm-agent-[a-z]+/[^ ]* \(<ESCAPED_SERVICE_NAME> <ESCAPED_SERVICE_VERSION>\)'
   Examples:
     | SERVICE_NAME               | ESCAPED_SERVICE_NAME  | SERVICE_VERSION            | ESCAPED_SERVICE_VERSION |
     | myService                  | myService             | v42                        |                         |

--- a/tests/agents/gherkin-specs/user_agent.feature
+++ b/tests/agents/gherkin-specs/user_agent.feature
@@ -3,7 +3,7 @@ Feature: Agent Transport User agent Header
   Scenario: Default user-agent
     Given an agent
     When the agent sends a request to APM server
-    Then the User-Agent header of the request matches regex '^apm-agent-[a-z]+/[^ ]*'
+    Then the User-Agent header of the request matches regex '^apm-agent-[a-z]+/[^ ]* \(.*\)'
 
   Scenario Outline: User-agent with service name only
     Given an agent configured with


### PR DESCRIPTION
1. Seems we can reuse the same step definition for all scenarios. Did I miss anything?
2. The expected escaped `service_version` should be the same if there's nothing to escape
3. The Java agent doesn't escape `service_name` or `service_version`, it rejects `service_name` that doesn't match the `^[a-zA-Z0-9 _-]+$` regex and allows any `service_version`. Are we the only ones doing so?