### PR TITLE
Distinguish outcome step and setup step definition

### DIFF
--- a/tests/agents/gherkin-specs/outcome.feature
+++ b/tests/agents/gherkin-specs/outcome.feature
@@ -7,14 +7,14 @@ Feature: Outcome
 
   Scenario: User set outcome on span has priority over instrumentation
     Given an active span
-    And the span outcome is 'success'
+    And the agent sets the span outcome to 'success'
     And a user sets the span outcome to 'failure'
     When the span ends
     Then the span outcome is 'failure'
 
   Scenario: User set outcome on transaction has priority over instrumentation
     Given an active transaction
-    And the transaction outcome is 'failure'
+    And the agent sets the transaction outcome to 'failure'
     And a user sets the transaction outcome to 'unknown'
     When the transaction ends
     Then the transaction outcome is 'unknown'


### PR DESCRIPTION
It's problematic that both a scenario condition (`Given`/`And`) and the expected result (`Then`) use the same step definition.
Not sure how it is in other languages, but in Java you cannot use the same step definition for different keywords.
If the intention is that both steps will check the span/transaction outcome, then this doesn't work as well because, at least in the Java agent, the outcome is only set when the span/transaction is ended (it would return `unknown` before).
Applying this change should resolve this problem.
