### PR TITLE
Changing cucumber specs dir setting for sync

### DIFF
--- a/.ci/.jenkins-agents.yml
+++ b/.ci/.jenkins-agents.yml
@@ -6,7 +6,7 @@ agents:
     FEATURES_PATH: "features"
     JSON_SPECS_PATH: "internal/testdata/json-specs"
   - REPO: "apm-agent-java"
-    FEATURES_PATH: "apm-agent-core/src/test/resources/specs"
+    FEATURES_PATH: "apm-agent-core/src/test/resources/specs/cucumber"
     JSON_SPECS_PATH: "apm-agent-core/src/test/resources/json-specs"
   - REPO: "apm-agent-php"
     FEATURES_PATH: "tests/APM_Agents_shared/gherkin-specs"


### PR DESCRIPTION
I want to move the cucumber code to a separate package, but Cucumber searches the scripts based on the directory, so I am editing this as well