### PR TITLE
Specify naming scheme of default service name

### DIFF
--- a/specs/agents/configuration.md
+++ b/specs/agents/configuration.md
@@ -122,6 +122,5 @@ After onboarding, users can customize settings for which the defaults aren't app
 
 By default, agents MUST send data to the APM Server at `http://localhost:8200/`.
 If possible, agents SHOULD detect sensible defaults for `service.name` and `service.version`.
-Even if detecting these values is not possible, a default value for `service.name` MUST be provided for frictionless onboarding.
-The default name MUST be `unknown-${service.agent.name}-service`.
+In any case agents MUST include `service.name` - if discovering it is not possible then the default value: `unknown-${service.agent.name}-service` MUST be used.
 This naming pattern allows the UI to display inline help on how to manually configure the name.

--- a/specs/agents/configuration.md
+++ b/specs/agents/configuration.md
@@ -117,9 +117,11 @@ Agents should implement a [configuration option](https://docs.google.com/spreads
 ### Zero-configuration support
 
 To decrease onboarding friction,
-APM agents should not require any configuration to send data to a local APM Server.
+APM agents MUST not require any configuration to send data to a local APM Server.
 After onboarding, users can customize settings for which the defaults aren't appropriate.
 
-By default, agents should send data to the APM Server at `http://localhost:8200/`.
-If possible, agents should detect sensible defaults for `service.name` and `service.version`.
-Even if detecting these values is not possible, a default value for `service.name` should be provided for frictionless onboarding.
+By default, agents MUST send data to the APM Server at `http://localhost:8200/`.
+If possible, agents SHOULD detect sensible defaults for `service.name` and `service.version`.
+Even if detecting these values is not possible, a default value for `service.name` MUST be provided for frictionless onboarding.
+The default name MUST be `unknown-${service.agent.name}-service`.
+This naming pattern allows the UI to display inline help on how to manually configure the name.


### PR DESCRIPTION
Also turns some SHOULDs into MUSTs

- [x] Create PR as draft
- [x] Approval by at least one other agent
- [x] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/master/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [x] Merge after 2 business days passed without objections


Relates to https://github.com/elastic/observability-design/issues/21
/cc @formgeist 