### PR TITLE
Not assuming FQDN in discovered hostname by default

### DIFF
--- a/specs/agents/metadata.md
+++ b/specs/agents/metadata.md
@@ -45,10 +45,16 @@ else
     hostname = env.get("HOSTNAME")
   if (hostname == null || hostname.length == 0)
     hostname = env.get("HOST")
+    
+if hostname != null
+  hostname = hostname.trim()                          // see details below **
 ```
 `*` this algorithm is using external commands in order to be OS-specific and language-independent, however these 
 may be replaced with language-specific APIs that provide the equivalent result. The main consideration when choosing 
 what to use is to avoid hostname discovery that relies on DNS lookup.
+
+`**` in this case, `trim()` refers to the removal of all leading and trailing characters of which codepoint is less-than
+or equal to `U+0020` (space).
 
 Agents MAY use alternative approaches, but those need to generally conform to the basic concept. Failing to discover the 
 proper hostname may cause failure in correlation between APM traces and data reported by other clients (e.g. 

--- a/specs/agents/metadata.md
+++ b/specs/agents/metadata.md
@@ -45,10 +45,6 @@ else
     hostname = env.get("HOSTNAME")
   if (hostname == null || hostname.length == 0)
     hostname = env.get("HOST")
-
-if hostname != null
-  hostname_parts[] = hostname.split(".")
-  hostname = hostname_parts[0]
 ```
 `*` this algorithm is using external commands in order to be OS-specific and language-independent, however these 
 may be replaced with language-specific APIs that provide the equivalent result. The main consideration when choosing 

--- a/specs/agents/metadata.md
+++ b/specs/agents/metadata.md
@@ -45,7 +45,7 @@ else
     hostname = env.get("HOSTNAME")
   if (hostname == null || hostname.length == 0)
     hostname = env.get("HOST")
-    
+
 if hostname != null
   hostname = hostname.trim()                          // see details below **
 ```


### PR DESCRIPTION
<!--
Agent spec PR checklist

Delete all of this if the PR is not changing the agent spec.
Delete sections that don't apply to this PR.
If a specific checkbox doesn't apply, ~strike through~ and check it instead of deleting it.
-->
Context: https://github.com/elastic/apm-agent-java/issues/2284 - assuming that dots in the discovered hostname are related to fqdn is invalid, so the naive approach proposed above should not be used.
For now, let's drop any fqdn logic and reiterate that in the future, if required, with some better logic, for example- using a [FQDN-specific regex](https://regexr.com/3g5j0).

## This is a small enhancement

- [x] Create PR as draft
- [x] Approval by at least one other agent
- [x] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/master/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [x] Merge after 2 business days passed without objections
