### PR TITLE
Sanitize `*auth*` instead of `authorization`

### DIFF
--- a/specs/agents/sanitization.md
+++ b/specs/agents/sanitization.md
@@ -16,7 +16,7 @@ how an agent will sanitize data.
 |                |   |
 |----------------|---|
 | Type           | `List<`[`WildcardMatcher`](../../tests/agents/json-specs/wildcard_matcher_tests.json)`>` |
-| Default        | `password, passwd, pwd, secret, *key, *token*, *session*, *credit*, *card*, authorization, set-cookie` |
+| Default        | `password, passwd, pwd, secret, *key, *token*, *session*, *credit*, *card*, *auth*, set-cookie` |
 | Dynamic        | `true` |
 | Central config | `true` |
 


### PR DESCRIPTION
- May the instrumentation collect sensitive information, such as secrets or PII (ex. in headers)?
  - [ ] Yes
    - [ ] Add a section to the spec how agents should apply sanitization (such as `sanitize_field_names`)
  - [ ] No
    - [ ] Why?
  - [x] n/a
- [ ] Link to meta issue: # <!-- create a meta issue if it does not exist yet -->
- [x] Create PR as draft
- [x] Approval by at least one other agent
- [x] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/master/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [x] Approved by at least 2 agents + PM (if relevant)
- [ ] Merge after 7 days passed without objections
- [ ] [Create implementation issues](https://gprom.app.elstc.co/issue-creator) (ideally add a milestone)
- [ ] [Create a status table](https://gprom.app.elstc.co/status/7.16) and add it to the meta issue
- [ ] Update [Kibana central config `defaultMessage`](https://github.com/elastic/kibana/blob/2c4dfde1740ea3456ce905cb8dcb48a4234e7b44/x-pack/plugins/apm/common/agent_configuration/setting_definitions/general_settings.ts#L223-L240) once all/most of the agents have releases with the change

/schedule 2021-12-13