### PR TITLE
Exclude HTTP/2 pseudo-headers from sanitization

### DIFF
--- a/specs/agents/sanitization.md
+++ b/specs/agents/sanitization.md
@@ -40,9 +40,9 @@ MUST still be reported in the agent payload. Agents MAY choose the string
 they use to replace the value so long as it's consistent and does not reveal
 the value it has replaced. The replacement string SHOULD be `[REDACTED]`.
 
-Fields that MUST be sanitized are the HTTP Request headers, HTTP Response
-headers, and form fields in an `application/x-www-form-urlencoded` request
-body.  No fields (including `set-cookie` headers) are exempt from this.
+Fields that MUST be sanitized are:
+- HTTP Request and Response headers (except [HTTP/2 pseudo-headers](https://datatracker.ietf.org/doc/html/rfc7540#section-8.1.2.3) which SHOULD NOT be redacted), and
+- form fields in an `application/x-www-form-urlencoded` request body.
 
 The query string and other captured request bodies (such as `application/json`)
 SHOULD NOT be sanitized.


### PR DESCRIPTION
(This separates out the HTTP/2 pseudo-header discussion on https://github.com/elastic/apm/pull/573. See some earlier discussion on options there.)

This is to avoid conflict between the ':authority' HTTP/2 pseudo-header
and the addition of `*auth*` to the `sanitize_field_names` default patterns in #573.

The Node.js HTTP/2 core lib includes the HTTP/2 pseudo-headers in `$requestObject.headers` and `$responseObject.headers`, so its normal capturing of headers includes them. Are other agents that have HTTP/2 support the same or different?


## This is a small enhancement

- [x] Create PR as draft
- [x] Approval by at least one other agent
- [x] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/master/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [ ] Merge after 2 business days passed without objections

