### PR TITLE
Changes to lambda context capturing based on more tests and user feedback

### DIFF
--- a/specs/agents/tracing-instrumentation-aws-lambda.md
+++ b/specs/agents/tracing-instrumentation-aws-lambda.md
@@ -94,7 +94,7 @@ In addition the following fields should be set for API Gateway-based Lambda func
 Field | Value | Description | Source
 ---   | ---   | ---         | ---
 `type` | `request`| Transaction type: constant value for API gateway. | -
-`name` | e.g. `GET MyFunction` | Transaction name: Http method followed by a whitespace and the (resource) path. See section below. | -
+`name` | e.g. `GET /prod/proxy/{proxy+}` | Transaction name: Http method followed by a whitespace and the (resource) path. See section below. | -
 `transaction.result` | `HTTP Xxx` / `success` | `HTTP 5xx` if there was a function error (see [Lambda error handling doc](https://docs.aws.amazon.com/lambda/latest/dg/services-apigateway.html#services-apigateway-errors). If the [invocation response has a "statusCode" field](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.response), then set to `HTTP Xxx` based on the status code, otherwise `success`. | Error or `response.statusCode`.
 `faas.trigger.type` | `http` | Constant value for API gateway. | -
 `faas.trigger.request_id` | e.g. `afa4-a6...` | ID of the API gateway request. | `event.requestContext.requestId`

--- a/specs/agents/tracing-instrumentation-aws-lambda.md
+++ b/specs/agents/tracing-instrumentation-aws-lambda.md
@@ -16,6 +16,7 @@ Field | Value | Description | Source
 `type` | e.g. `request`, `messaging` | The transaction type. | Use `request` if trigger type is undefined.
 `outcome` | `success` / `failure` | Set to `failure` if there was a [function error](https://docs.aws.amazon.com/lambda/latest/dg/invocation-retries.html). | -
 `result` | `success` / `failure` / `HTTP Xxx` | See API Gateway below. For other triggers, set to `failure` if there was a function error, otherwise `success`. | Trigger specific.
+`faas.id` | e.g. `arn:aws:lambda:us-west-2:123456789012:function:my-function` | Use the ARN of the function **without the alias suffix**. | `context.invokedFunctionArn`, remove the 8th ARN segment if the ARN contains an alias suffix. `arn:aws:lambda:us-west-2:123456789012:function:my-function:someAlias` will become `arn:aws:lambda:us-west-2:123456789012:function:my-function`.
 `faas.trigger.type` | `other` | The trigger type. Use `other` if trigger type is unknown / cannot be specified. | More concrete triggers are `http`, `pubsub`, `datasource`, `timer` (see specific triggers below).
 `faas.execution` | `af9aa4-a6...` | The AWS request ID of the function invocation | `context.awsRequestId`
 `faas.coldstart` | `true` / `false` | Boolean value indicating whether a Lambda function invocation was a cold start or not. | [see section below](deriving-cold-starts)
@@ -37,10 +38,9 @@ The following metadata fields are relevant for lambda functions:
 Field | Value | Description | Source
 ---   | ---   | --- | ---
 `service.name`| e.g. `MyFunctionName` | If the service name is *explicitly* specified through the `service_name` agent config option, use the configured name. Otherwise, use the name of the Lambda function. | If the service name is not explicitly configured, use the Lambda function name: `AWS_LAMBDA_FUNCTION_NAME` or `context.functionName`
+`service.version` | e.g. `$LATEST` |  If the service version is *explicitly* specified through the `service_version` agent config option, use the configured version. Otherwise, use the lambda function version. | If the service version is not explicitly configured, use the Lambda function version: `AWS_LAMBDA_FUNCTION_VERSION` or `context.functionVersion`
 `service.framework.name` | `AWS Lambda` | Constant value for the framework name. | -
 `service.runtime.name`| e.g. `AWS_Lambda_java8` | The lambda runtime. | `AWS_EXECUTION_ENV`
-`service.id` | e.g. `arn:aws:lambda:us-west-2:123456789012:function:my-function` | If the *service name is explicitly* specified through the `service_name` agent config option, **leave the `service.id` field empty**. Otherwise, use the ARN of the function **without alias suffix** for the `service.id`. | `context.invokedFunctionArn`, remove the 8th ARN segment if the ARN contains an alias suffix. `arn:aws:lambda:us-west-2:123456789012:function:my-function:someAlias` will become `arn:aws:lambda:us-west-2:123456789012:function:my-function`.
-`service.version` | e.g. `$LATEST` | The lambda function version | `AWS_LAMBDA_FUNCTION_VERSION` or `context.functionVersion`
 `service.node.configured_name` | e.g. `2019/06/07/[$LATEST]e6f...` | The log stream name uniquely identifying a function instance. | `AWS_LAMBDA_LOG_STREAM_NAME` or `context.logStreamName`
 `cloud.provider` | `aws` | Constant value for the cloud provider. | -
 `cloud.region` | e.g. `us-east-1` | The cloud region. | `AWS_REGION`

--- a/specs/agents/tracing-instrumentation-aws-lambda.md
+++ b/specs/agents/tracing-instrumentation-aws-lambda.md
@@ -36,10 +36,10 @@ The following metadata fields are relevant for lambda functions:
 
 Field | Value | Description | Source
 ---   | ---   | --- | ---
-`service.name`| e.g. `MyFunctionName` | If the service name is *explicitly* specified through the `service.name` agent config option, use the configured name. Otherwise, use the name of the Lambda function. | If the service name is not explicitly configured, use the Lambda function name: `AWS_LAMBDA_FUNCTION_NAME` or `context.functionName`
+`service.name`| e.g. `MyFunctionName` | If the service name is *explicitly* specified through the `service_name` agent config option, use the configured name. Otherwise, use the name of the Lambda function. | If the service name is not explicitly configured, use the Lambda function name: `AWS_LAMBDA_FUNCTION_NAME` or `context.functionName`
 `service.framework.name` | `AWS Lambda` | Constant value for the framework name. | -
 `service.runtime.name`| e.g. `AWS_Lambda_java8` | The lambda runtime. | `AWS_EXECUTION_ENV`
-`service.id` | e.g. `arn:aws:lambda:us-west-2:123456789012:function:my-function` | If the *service name is explicitly* specified through the `service.name` agent config option, **leave the `service.id` field empty**. Otherwise, use the ARN of the function **without alias suffix** for the `service.id`. | `context.invokedFunctionArn`, remove the 8th ARN segment if the ARN contains an alias suffix. `arn:aws:lambda:us-west-2:123456789012:function:my-function:someAlias` will become `arn:aws:lambda:us-west-2:123456789012:function:my-function`.
+`service.id` | e.g. `arn:aws:lambda:us-west-2:123456789012:function:my-function` | If the *service name is explicitly* specified through the `service_name` agent config option, **leave the `service.id` field empty**. Otherwise, use the ARN of the function **without alias suffix** for the `service.id`. | `context.invokedFunctionArn`, remove the 8th ARN segment if the ARN contains an alias suffix. `arn:aws:lambda:us-west-2:123456789012:function:my-function:someAlias` will become `arn:aws:lambda:us-west-2:123456789012:function:my-function`.
 `service.version` | e.g. `$LATEST` | The lambda function version | `AWS_LAMBDA_FUNCTION_VERSION` or `context.functionVersion`
 `service.node.configured_name` | e.g. `2019/06/07/[$LATEST]e6f...` | The log stream name uniquely identifying a function instance. | `AWS_LAMBDA_LOG_STREAM_NAME` or `context.logStreamName`
 `cloud.provider` | `aws` | Constant value for the cloud provider. | -
@@ -118,7 +118,7 @@ For both payload format verions (1.0 and 2.0), the general pattern is `$method $
 
 *Payload format version 1.0:*
 
-For payload format version 1.0, use `${event.resourceContext.httpMethod}  /${event.requestContext.stage}${event.requestContext.resourcePath}`.
+For payload format version 1.0, use `${event.resourceContext.httpMethod} /${event.requestContext.stage}${event.requestContext.resourcePath}`.
 
 If `use_path_as_transaction_name` is applicable and set to `true`, use `${event.resourceContext.httpMethod}  /${event.requestContext.path}` as the transaction name.
 


### PR DESCRIPTION
## Changes
- **Change `transaction.name` for API Gateway-triggered Lambda functions**: To be consistent with other HTTP-based instrumentations include the low-cardinality resourcePath into the name. 
- **Respect setting for `use_path_as_transaction_name`**: If `use_path_as_transaction_name` is enabled use the *full* HTTP path for the `transaction.name` in API Gateway-triggered Lambda functions.
- **Respect `service_name` and `service_version` agent config options**: If `service_name` and/or `service_version` are explicitly configured use the configured values instead of the derived ones.
- **Use the full domain name of the API Gateway as `service.origin.name`**
- **Replaced `service.id` metadata field with new transaction-level field `faas.id`**: To being able to capture different Lambda function ARN values (semantically correct) under one APM service umbrella (for the scenario of consolidating multiple lambda functions in one APM service).

## This is a small enhancement

- [x] Create PR as draft
- [x] Approval by at least one other agent
- [x] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [ ] Merge after 2 business days passed without objections
