### PR TITLE
Increase span_stack_trace_min_duration

### DIFF
--- a/specs/agents/tracing-spans.md
+++ b/specs/agents/tracing-spans.md
@@ -81,12 +81,12 @@ captured.
 
 This values for this option are case-sensitive.
 
-|                |   |
-|----------------|---|
+|                |                                                        |
+|----------------|--------------------------------------------------------|
 | Valid options  | [duration](configuration.md#configuration-value-types) |
-| Default        | `5ms` (soft default, agents may modify as needed) |
-| Dynamic        | `true` |
-| Central config | `true` |
+| Default        | `500ms`                                                |
+| Dynamic        | `true`                                                 |
+| Central config | `true`                                                 |
 
 A negative value will result in never capturing the stack traces.
 


### PR DESCRIPTION
- Errors are unaffected in this proposal
- Performance impact too high as-is
- Bad cost/benefit ratio
- Most other tracers never capture stack traces

Open questions
- Can we do this in a minor?

Related
- https://github.com/elastic/kibana/issues/68757

---

- [x] Create PR as draft
- [ ] Approval by at least one other agent
- [ ] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [ ] Merge after 2 business days passed without objections
