### PR TITLE
Use main references for APM Server

### DIFF
--- a/specs/agents/metadata.md
+++ b/specs/agents/metadata.md
@@ -133,7 +133,7 @@ Services running on AWS Lambda [require specific values](tracing-instrumentation
 
 ### Cloud Provider Metadata
 
-[Cloud provider metadata](https://github.com/elastic/apm-server/blob/master/docs/spec/v2/metadata.json)
+[Cloud provider metadata](https://github.com/elastic/apm-server/blob/main/docs/spec/v2/metadata.json)
 is collected from local cloud provider metadata services:
 
 - availability_zone
@@ -160,7 +160,7 @@ Any intake API requests to the APM server should be delayed until this
 metadata is available.
 
 A sample implementation of this metadata collection is available in
-[the Python agent](https://github.com/elastic/apm-agent-python/blob/master/elasticapm/utils/cloud.py).
+[the Python agent](https://github.com/elastic/apm-agent-python/blob/main/elasticapm/utils/cloud.py).
 
 Fetching of cloud metadata for services running as AWS Lambda functions follow a [different approach defined in the tracing-instrumentation-aws-lambda spec](tracing-instrumentation-aws-lambda.md).
 

--- a/specs/agents/process-new-fields.md
+++ b/specs/agents/process-new-fields.md
@@ -11,7 +11,7 @@ it would create new fields in the index and then stop using it when we standardi
 For example `context.elasticsearch.url` in the intake API becomes `elasticsearch.url` in Elasticsearch, `context.elasticsearch.error_reason` becomes `elasticsearch.error_reason` etc.
 * The proposal needs to specify which fields should be indexed.
 An APM Server person might need to assist here to determine the right data type for the indexed fields.
-* The proposal should include the suggested [JSON Schema](https://github.com/elastic/apm-server/tree/master/docs/spec/v2) changes for all new fields.
+* The proposal should include the suggested [JSON Schema](https://github.com/elastic/apm-server/tree/main/docs/spec/v2) changes for all new fields.
 This forces alignment on the exact field names, JSON data type, length restrictions etc.
 * Make sure to check if [ECS](https://github.com/elastic/ecs) has defined appropriate fields for what you're proposing.
 * Agents should agree to the changes in a voting format (checkboxes),
@@ -85,7 +85,7 @@ Agents OK with this change:
 - [ ] ...
 
 1. When agent devs and APM Server agree, APM Server implements the changes necessary
-1. When merged into `master`, agent devs can implement the fields immediately.
-The agent tests against APM Server `master` now tests the integration with the new fields in the JSON Schema.
+1. When merged into `main`, agent devs can implement the fields immediately.
+The agent tests against APM Server `main` now tests the integration with the new fields in the JSON Schema.
 1. Agents can release when their test are green. Next APM Server release will include the changes,
 which might include indexing some new fields.

--- a/specs/agents/tracing-distributed-tracing.md
+++ b/specs/agents/tracing-distributed-tracing.md
@@ -8,7 +8,7 @@ We implement the [W3C standards](https://www.w3.org/TR/trace-context-1/) for
 
 Our `trace_id`, `parent_id`, and the combined `traceparent` HTTP header follow
 the standard established by the
-[W3C Trace-Context Spec](https://github.com/w3c/trace-context/blob/master/spec/20-http_request_header_format.md#traceparent-header).
+[W3C Trace-Context Spec](https://github.com/w3c/trace-context/blob/main/spec/20-http_request_header_format.md#traceparent-header).
 
 The `traceparent` header is composed of four parts:
 

--- a/specs/agents/tracing-instrumentation-aws-lambda.md
+++ b/specs/agents/tracing-instrumentation-aws-lambda.md
@@ -24,7 +24,7 @@ Field | Value | Description | Source
 `context.cloud.origin.*` | - | Do not set these fields if trigger type is `other`.  | Trigger specific.
 `context.service.origin.*` | - | Do not set these fields if trigger type is `other`. | Trigger specific.
 
-Note that `faas.*` fields *are not* nested under the context property [in the intake api](https://github.com/elastic/apm-server/blob/master/docs/spec/v2/transaction.json)! `faas` is a top-level key on the transaction.
+Note that `faas.*` fields *are not* nested under the context property [in the intake api](https://github.com/elastic/apm-server/blob/main/docs/spec/v2/transaction.json)! `faas` is a top-level key on the transaction.
 
 ### Overwriting Metadata
 Automatically capturing cloud metadata doesn't work reliably from a Lambda environment. Moreover, retrieving cloud metadata through an additional HTTP request may slowdown the lambda function / increase cold start behaviour. Therefore, the generic cloud metadata fetching should be disabled when the agent is running in a lambda context (for instance through checking for the existance of the `AWS_LAMBDA_FUNCTION_NAME` environment variable).

--- a/specs/terminology.md
+++ b/specs/terminology.md
@@ -17,7 +17,7 @@ Usually not everything is instrumented because that would incur a very large ove
  > A **stack frame** is a frame of data that gets pushed onto the stack. In the case of a call stack, a stack frame would represent a function call and its argument data ([Source](https://stackoverflow.com/a/10057535/434980))
 
 We distinguish between the user's own code, and the code of the user's dependencies. Often the user is more interested in stack frames from their own code, so these are highlighted.
-[Further reading](https://www.elastic.co/guide/en/apm/agent/nodejs/master/performance-tuning.html#performance-source-lines)
+[Further reading](https://www.elastic.co/guide/en/apm/agent/nodejs/main/performance-tuning.html#performance-source-lines)
 
 #### Real User Monitoring (RUM)
 Real User Monitoring (RUM) tries to capture the real user’s experience with the application. Generally this means monitoring the application on the user’s machine e.g. their browsers or mobile devices. The APM agent used in the browser is called [RUM agent](https://www.elastic.co/guide/en/apm/agent/rum-js/4.x/intro.html)

--- a/specs/terminology.md
+++ b/specs/terminology.md
@@ -17,7 +17,7 @@ Usually not everything is instrumented because that would incur a very large ove
  > A **stack frame** is a frame of data that gets pushed onto the stack. In the case of a call stack, a stack frame would represent a function call and its argument data ([Source](https://stackoverflow.com/a/10057535/434980))
 
 We distinguish between the user's own code, and the code of the user's dependencies. Often the user is more interested in stack frames from their own code, so these are highlighted.
-[Further reading](https://www.elastic.co/guide/en/apm/agent/nodejs/main/performance-tuning.html#performance-source-lines)
+[Further reading](https://www.elastic.co/guide/en/apm/agent/nodejs/master/performance-tuning.html#performance-source-lines)
 
 #### Real User Monitoring (RUM)
 Real User Monitoring (RUM) tries to capture the real user’s experience with the application. Generally this means monitoring the application on the user’s machine e.g. their browsers or mobile devices. The APM agent used in the browser is called [RUM agent](https://www.elastic.co/guide/en/apm/agent/rum-js/4.x/intro.html)

--- a/tests/agents/json-specs/w3c_distributed_tracing.json
+++ b/tests/agents/json-specs/w3c_distributed_tracing.json
@@ -1,5 +1,5 @@
 //
-// from https://github.com/w3c/distributed-tracing/blob/master/test/test_data.json
+// from https://github.com/w3c/distributed-tracing/blob/main/test/test_data.json
 //
 // NOTE: This file is manually copied from the above link and
 //       there is currently NO automation keeping it in sync with the upstream version.


### PR DESCRIPTION
APM Server is now main based. And fixed some other main references for some other projects which were already changed to main