### PR TITLE
Update the Lambda metadata fields that cannot be collected until first invocation

### DIFF
--- a/specs/agents/tracing-instrumentation-aws-lambda.md
+++ b/specs/agents/tracing-instrumentation-aws-lambda.md
@@ -31,7 +31,7 @@ Note that `faas.*` fields *are not* nested under the context property [in the in
 Automatically capturing cloud metadata doesn't work reliably from a Lambda environment. Moreover, retrieving cloud metadata through an additional HTTP request may slowdown the lambda function / increase cold start behaviour. Therefore, the generic cloud metadata fetching should be disabled when the agent is running in a lambda context (for instance through checking for the existence of the `AWS_LAMBDA_FUNCTION_NAME` environment variable).
 Where possible, metadata should be overwritten at Lambda runtime startup corresponding to the field specifications in this spec.
 
-Some metadata fields are not available at startup (e.g. `invokedFunctionArn` which is needed for `cloud.account.id`). Therefore, retrieval of metadata fields in a lambda context needs to be delayed until the first execution of the lambda function, so that information provided in the `context` object can used to set metadata fields properly.
+Some metadata fields are not available at startup (e.g. `invokedFunctionArn` which is needed for `cloud.account.id` and `faas.id`). Therefore, retrieval of metadata fields in a lambda context needs to be delayed until the first execution of the lambda function, so that information provided in the `context` object can used to set metadata fields properly.
 
 The following metadata fields are relevant for lambda functions:
 

--- a/specs/agents/tracing-instrumentation-aws-lambda.md
+++ b/specs/agents/tracing-instrumentation-aws-lambda.md
@@ -31,7 +31,7 @@ Note that `faas.*` fields *are not* nested under the context property [in the in
 Automatically capturing cloud metadata doesn't work reliably from a Lambda environment. Moreover, retrieving cloud metadata through an additional HTTP request may slowdown the lambda function / increase cold start behaviour. Therefore, the generic cloud metadata fetching should be disabled when the agent is running in a lambda context (for instance through checking for the existence of the `AWS_LAMBDA_FUNCTION_NAME` environment variable).
 Where possible, metadata should be overwritten at Lambda runtime startup corresponding to the field specifications in this spec.
 
-Some metadata fields are not available at startup (e.g. `invokedFunctionArn` which is needed for `service.id` and `cloud.region`). Therefore, retrieval of metadata fields in a lambda context needs to be delayed until the first execution of the lambda function, so that information provided in the `context` object can used to set metadata fields properly.
+Some metadata fields are not available at startup (e.g. `invokedFunctionArn` which is needed for `cloud.account.id`). Therefore, retrieval of metadata fields in a lambda context needs to be delayed until the first execution of the lambda function, so that information provided in the `context` object can used to set metadata fields properly.
 
 The following metadata fields are relevant for lambda functions:
 


### PR DESCRIPTION
This updates a small note in the Lambda spec due to metadata spec changes in #579.


## This is a small enhancement

- [x] Create PR as draft
- [x] Approval by at least one other agent
- [x] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [ ] Merge after 2 business days passed without objections

