### PR TITLE
Add spec for Span Link and Span Continuation 

### DIFF
--- a/specs/agents/span-links.md
+++ b/specs/agents/span-links.md
@@ -1,0 +1,36 @@
+## Span Links
+
+A Span or Transaction MAY be linked to zero or more other Spans/Transactions that are causally related.
+
+Specific use-cases for Span Links:
+
+1. When a single transaction represents the batch processing of several messages, the agent SHOULD be able to link back to the traces that have produced the messages.
+2.  When the agent receives a `traceparent` header from outside a trust boundary, it SHOULD restart the trace (creating a different trace id with its own sampling decision) and link to the originating trace.
+3. Close gap for the OTLP intake - [OTel's specification of span links](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/overview.md#links-between-spans)
+
+Spans and Transactions MUST collect links in the `links` array with the following fields on each item:
+- `trace.id`: the id of the linked trace.
+- `span.id`: the id of the linked span or transaction.
+
+Example:
+
+```
+ "links": [
+      {"trace": {"id": "traceId1"}, "span": {"id": "spanId1"}},
+      {"trace": {"id": "traceId2"}, "span": {"id": "spanId2"}},
+    ]
+```
+
+## Trace Continuation
+
+We can expect incoming requests into an application with our agent which contains a `traceparent` header added by a 3rd party component. In this situation we end up with traces where part of the trace is outside of our system.
+
+In order to handle this properly, the agent SHOULD implement a trace continuation strategy.
+
+The agent SHOULD offer a configuration called `trace_continuation_strategy` with the following values and behavior:
+
+- `continue_always`: The agent takes the `traceparent` header as it is and applies it to the new transaction.
+- `restart_always`: The agent always creates a new trace with a new trace id. In this case the agent MUST create a link in the new transaction pointing to the original trace.
+- `restart_external`: The agent first checks the `tracecontext` header. If the header contains the `es` vendor flag, it's treated as internal, otherwise (including the case when the `tracecontext` header is not present) it's treated as external. In case of external calls the agent MUST create a new trace with a new trace id and MUST create a link in the new transaction pointing to the original trace.
+
+The default is `continue_always`. 

--- a/specs/agents/span-links.md
+++ b/specs/agents/span-links.md
@@ -31,6 +31,6 @@ The agent SHOULD offer a configuration called `trace_continuation_strategy` with
 
 - `continue_always`: The agent takes the `traceparent` header as it is and applies it to the new transaction.
 - `restart_always`: The agent always creates a new trace with a new trace id. In this case the agent MUST create a link in the new transaction pointing to the original trace.
-- `restart_external`: The agent first checks the `tracecontext` header. If the header contains the `es` vendor flag, it's treated as internal, otherwise (including the case when the `tracecontext` header is not present) it's treated as external. In case of external calls the agent MUST create a new trace with a new trace id and MUST create a link in the new transaction pointing to the original trace.
+- `restart_external`: The agent first checks the `tracestate` header. If the header contains the `es` vendor flag, it's treated as internal, otherwise (including the case when the `tracestate` header is not present) it's treated as external. In case of external calls the agent MUST create a new trace with a new trace id and MUST create a link in the new transaction pointing to the original trace.
 
 The default is `continue_always`. 

--- a/specs/agents/span-links.md
+++ b/specs/agents/span-links.md
@@ -16,7 +16,7 @@ Example:
 
 ```
 "links": [
-  {"trace_id": "traceId1", "span_id": "spanId1"}},
-  {"trace_id": "traceId2"}, "span_id": "spanId2"}},
+  {"trace_id": "traceId1", "span_id": "spanId1"},
+  {"trace_id": "traceId2", "span_id": "spanId2"},
 ]
 ```

--- a/specs/agents/span-links.md
+++ b/specs/agents/span-links.md
@@ -1,11 +1,11 @@
 ## Span Links
 
-A Span or Transaction MAY be linked to zero or more other Spans/Transactions that are causally related.
+A Span or Transaction MAY link to zero or more other Spans/Transactions that are causally related.
 
-Specific use-cases for Span Links:
+Example use-cases for Span Links:
 
 1. When a single transaction represents the batch processing of several messages, the agent SHOULD be able to link back to the traces that have produced the messages.
-2.  When the agent receives a `traceparent` header from outside a trust boundary, it SHOULD restart the trace (creating a different trace id with its own sampling decision) and link to the originating trace.
+2. When the agent receives a `traceparent` header from outside a trust boundary, it SHOULD restart the trace (creating a different trace id with its own sampling decision) and link to the originating trace.
 3. Close gap for the OTLP intake - [OTel's specification of span links](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/overview.md#links-between-spans)
 
 Spans and Transactions MUST collect links in the `links` array with the following fields on each item:
@@ -15,17 +15,17 @@ Spans and Transactions MUST collect links in the `links` array with the followin
 Example:
 
 ```
- "links": [
-      {"trace": {"id": "traceId1"}, "span": {"id": "spanId1"}},
-      {"trace": {"id": "traceId2"}, "span": {"id": "spanId2"}},
-    ]
+"links": [
+  {"trace": {"id": "traceId1"}, "span": {"id": "spanId1"}},
+  {"trace": {"id": "traceId2"}, "span": {"id": "spanId2"}},
+]
 ```
 
 ## Trace Continuation
 
 We can expect incoming requests into an application with our agent which contains a `traceparent` header added by a 3rd party component. In this situation we end up with traces where part of the trace is outside of our system.
 
-In order to handle this properly, the agent SHOULD implement a trace continuation strategy.
+In order to handle this properly, the agent SHOULD offer several trace continuation strategies.
 
 The agent SHOULD offer a configuration called `trace_continuation_strategy` with the following values and behavior:
 

--- a/specs/agents/span-links.md
+++ b/specs/agents/span-links.md
@@ -4,33 +4,19 @@ A Span or Transaction MAY link to zero or more other Spans/Transactions that are
 
 Example use-cases for Span Links:
 
-1. When a single transaction represents the batch processing of several messages, the agent SHOULD be able to link back to the traces that have produced the messages.
-2. When the agent receives a `traceparent` header from outside a trust boundary, it SHOULD restart the trace (creating a different trace id with its own sampling decision) and link to the originating trace.
+1. When a single transaction represents the batch processing of several messages, the agent is able to link back to the traces that have produced the messages.
+2. When the agent receives a `traceparent` header from outside a trust boundary, it can restart the trace (creating a different trace id with its own sampling decision) and link to the originating trace.
 3. Close gap for the OTLP intake - [OTel's specification of span links](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/overview.md#links-between-spans)
 
 Spans and Transactions MUST collect links in the `links` array with the following fields on each item:
-- `trace.id`: the id of the linked trace.
-- `span.id`: the id of the linked span or transaction.
+- `trace_id`: the id of the linked trace.
+- `span_id`: the id of the linked span or transaction.
 
 Example:
 
 ```
 "links": [
-  {"trace": {"id": "traceId1"}, "span": {"id": "spanId1"}},
-  {"trace": {"id": "traceId2"}, "span": {"id": "spanId2"}},
+  {"trace_id": "traceId1", "span_id": "spanId1"}},
+  {"trace_id": "traceId2"}, "span_id": "spanId2"}},
 ]
 ```
-
-## Trace Continuation
-
-We can expect incoming requests into an application with our agent which contains a `traceparent` header added by a 3rd party component. In this situation we end up with traces where part of the trace is outside of our system.
-
-In order to handle this properly, the agent SHOULD offer several trace continuation strategies.
-
-The agent SHOULD offer a configuration called `trace_continuation_strategy` with the following values and behavior:
-
-- `continue_always`: The agent takes the `traceparent` header as it is and applies it to the new transaction.
-- `restart_always`: The agent always creates a new trace with a new trace id. In this case the agent MUST create a link in the new transaction pointing to the original trace.
-- `restart_external`: The agent first checks the `tracestate` header. If the header contains the `es` vendor flag, it's treated as internal, otherwise (including the case when the `tracestate` header is not present) it's treated as external. In case of external calls the agent MUST create a new trace with a new trace id and MUST create a link in the new transaction pointing to the original trace.
-
-The default is `continue_always`. 

--- a/specs/agents/span-links.md
+++ b/specs/agents/span-links.md
@@ -5,7 +5,7 @@ A Span or Transaction MAY link to zero or more other Spans/Transactions that are
 Example use-cases for Span Links:
 
 1. When a single transaction represents the batch processing of several messages, the agent is able to link back to the traces that have produced the messages.
-2. When the agent receives a `traceparent` header from outside a trust boundary, it can restart the trace (creating a different trace id with its own sampling decision) and link to the originating trace.
+2. When the agent receives a `traceparent` header from outside a trust boundary, it [can restart the trace](trace_continuation.md) (creating a different trace id with its own sampling decision) and link to the originating trace.
 3. Close gap for the OTLP intake - [OTel's specification of span links](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/overview.md#links-between-spans)
 
 Spans and Transactions MUST collect links in the `links` array with the following fields on each item:

--- a/specs/agents/trace-continuation.md
+++ b/specs/agents/trace-continuation.md
@@ -1,5 +1,14 @@
 ## Trace Continuation
 
+### `trace_continuation_strategy` configuration
+
+|                |   |
+|----------------|---|
+| Valid options  | `continue`, `restart`, `restart_external` |
+| Default        | `continue` |
+| Dynamic        | `true` |
+| Central config | `true` |
+
 The `traceparent` header of requests that are traced with our agents might have been added by a 3rd party component.
 
 This situation becomes more and more common as the w3c trace context gets adopted. In such cases we can end up with traces where part of the trace is outside of our system.
@@ -12,4 +21,4 @@ The agent SHOULD offer a configuration called `trace_continuation_strategy` with
 - `restart`: The agent always creates a new trace with a new trace id. In this case the agent MUST create a [span link](span-links.md) in the new transaction pointing to the original traceparent.
 - `restart_external`: The agent first checks the `tracestate` header. If the header contains the `es` vendor flag, it's treated as internal, otherwise (including the case when the `tracestate` header is not present) it's treated as external. In case of external calls the agent MUST create a new trace with a new trace id and MUST create a link in the new transaction pointing to the original trace.
 
-The default is `continue`.
+In the case of internal calls, the agent MUST use the `continue` strategy above.

--- a/specs/agents/trace-continuation.md
+++ b/specs/agents/trace-continuation.md
@@ -8,8 +8,8 @@ In order to handle this properly, the agent SHOULD offer several trace continuat
 
 The agent SHOULD offer a configuration called `trace_continuation_strategy` with the following values and behavior:
 
-- `continue_always`: The agent takes the `traceparent` header as it is and applies it to the new transaction.
-- `restart_always`: The agent always creates a new trace with a new trace id. In this case the agent MUST create a [span link](span-links.md) in the new transaction pointing to the original traceparent.
+- `continue`: The agent takes the `traceparent` header as it is and applies it to the new transaction.
+- `restart`: The agent always creates a new trace with a new trace id. In this case the agent MUST create a [span link](span-links.md) in the new transaction pointing to the original traceparent.
 - `restart_external`: The agent first checks the `tracestate` header. If the header contains the `es` vendor flag, it's treated as internal, otherwise (including the case when the `tracestate` header is not present) it's treated as external. In case of external calls the agent MUST create a new trace with a new trace id and MUST create a link in the new transaction pointing to the original trace.
 
-The default is `continue_always`. 
+The default is `continue`.

--- a/specs/agents/trace_continuation.md
+++ b/specs/agents/trace_continuation.md
@@ -1,0 +1,15 @@
+## Trace Continuation
+
+The `traceparent` header of requests that are traced with our agents might have been added by a 3rd party component.
+
+This situation becomes more and more common as the w3c trace context gets adopted. In such cases we can end up with traces where part of the trace is outside of our system.
+
+In order to handle this properly, the agent SHOULD offer several trace continuation strategies.
+
+The agent SHOULD offer a configuration called `trace_continuation_strategy` with the following values and behavior:
+
+- `continue_always`: The agent takes the `traceparent` header as it is and applies it to the new transaction.
+- `restart_always`: The agent always creates a new trace with a new trace id. In this case the agent MUST create a link in the new transaction pointing to the original trace.
+- `restart_external`: The agent first checks the `tracestate` header. If the header contains the `es` vendor flag, it's treated as internal, otherwise (including the case when the `tracestate` header is not present) it's treated as external. In case of external calls the agent MUST create a new trace with a new trace id and MUST create a link in the new transaction pointing to the original trace.
+
+The default is `continue_always`. 

--- a/specs/agents/trace_continuation.md
+++ b/specs/agents/trace_continuation.md
@@ -9,7 +9,7 @@ In order to handle this properly, the agent SHOULD offer several trace continuat
 The agent SHOULD offer a configuration called `trace_continuation_strategy` with the following values and behavior:
 
 - `continue_always`: The agent takes the `traceparent` header as it is and applies it to the new transaction.
-- `restart_always`: The agent always creates a new trace with a new trace id. In this case the agent MUST create a link in the new transaction pointing to the original trace.
+- `restart_always`: The agent always creates a new trace with a new trace id. In this case the agent MUST create a [span link](span-links.md) in the new transaction pointing to the original traceparent.
 - `restart_external`: The agent first checks the `tracestate` header. If the header contains the `es` vendor flag, it's treated as internal, otherwise (including the case when the `tracestate` header is not present) it's treated as external. In case of external calls the agent MUST create a new trace with a new trace id and MUST create a link in the new transaction pointing to the original trace.
 
 The default is `continue_always`. 


### PR DESCRIPTION
This PR specifies Span links and Span Continuation. The first is about introducing links between spans (and transactions), the second handles incoming HTTP requests with `traceparent` headers from outside Elastic APM.

Solves: https://github.com/elastic/apm/issues/596

- May the instrumentation collect sensitive information, such as secrets or PII (ex. in headers)?
  - [x] No
    - There won't be any new information collected. The agent will introduce a new array which will contain transaction/span ids and trace ids. This only introduces links between things which the agent already collects.
- [x] Link to meta issue: https://github.com/elastic/observability-dev/issues/1947  related issue:  https://github.com/elastic/apm/issues/286 
- [x] Create PR as draft
- [x] Approval by at least one other agent
- [x] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [x] Approved by at least 2 agents + PM (if relevant)
- [ ] Merge after 7 days passed without objections
- [ ] [Create implementation issues](https://gprom.app.elstc.co/issue-creator) (ideally add a milestone)
- [ ] [Create a status table](https://gprom.app.elstc.co/status/7.16) and add it to the meta issue
