### PR TITLE
Add spec for default transaction.type and span.type

### DIFF
--- a/specs/agents/tracing-spans.md
+++ b/specs/agents/tracing-spans.md
@@ -17,7 +17,7 @@ for simpler and more performant UI queries.
 Each transaction has a `type` field, each span has both `type` and `subtype` fields.
 The values for each of those fields is protocol-specific and defined in the respective instrumentation specification
 for each protocol.
-If no `transaction.type` or `span.type` is provided or the value is an empty string, the agent needs to set a default value `unknown`.
+If no `transaction.type` or `span.type` is provided or the value is an empty string, the agent needs to set a default value `custom`.
 
 For spans, the type/subtype must fit the [span type specification in JSON format](../../tests/agents/json-specs/span_types.json).
 In order to help align all agents on this specification, changing `type` and `subtype` field values is not considered


### PR DESCRIPTION
Add a spec for setting a default value for `transaction.type` and `span.type` to apm agents and in apm-server. 

---

## This is a small enhancement

- [x] Create PR as draft
- [x] Approval by at least one other agent
- [x] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [ ] Merge after 2 business days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.

related to https://github.com/elastic/apm/issues/601 and https://github.com/elastic/apm-server/issues/7376