### PR TITLE
Remove min value for `exit_span_min_duration`

### DIFF
--- a/specs/agents/handling-huge-traces/tracing-spans-drop-fast-exit.md
+++ b/specs/agents/handling-huge-traces/tracing-spans-drop-fast-exit.md
@@ -21,12 +21,9 @@ Additionally, spans that lead to an error can't be discarded.
 
 |                |            |
 |----------------|------------|
-| Type           | `duration` |
+| Type           | [`GranularDuration`](../configuration.md#configuration-value-types) |
 | Default        | `1ms`      |
 | Central config | `true`     |
-
-The minimum allowed duration for this setting is `1us` (microsecond). Agents may need to
-add support the `us` unit.
 
 ## Interplay with span compression
 


### PR DESCRIPTION
Remove min value for `exit_span_min_duration` to allow opting out of dropping fast exit spans.

This may impact the existing implementations for [.NET](https://github.com/elastic/apm-agent-dotnet/issues/1475), [Go](https://github.com/elastic/apm-agent-go/issues/1112), [PHP](https://github.com/elastic/apm-agent-php/issues/535), [Python](https://github.com/elastic/apm-agent-python/issues/1309), and the in-progress implementation for [Java](https://github.com/elastic/apm-agent-java/pull/2491). However, it seems most have not implemented a validation that would disallow users to set `exit_span_min_duration` to 0.

- [x] Create PR as draft
- [x] Approval by at least one other agent
- [x] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [x] Merge after 2 business days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.

/schedule 2022-03-10