### PR TITLE
Disable dropping fast exit spans by default

### DIFF
--- a/specs/agents/handling-huge-traces/tracing-spans-drop-fast-exit.md
+++ b/specs/agents/handling-huge-traces/tracing-spans-drop-fast-exit.md
@@ -22,7 +22,7 @@ Additionally, spans that lead to an error can't be discarded.
 |                |            |
 |----------------|------------|
 | Type           | `duration` |
-| Default        | `1ms`      |
+| Default        | `0ms`      |
 | Central config | `true`     |
 
 The minimum allowed duration for this setting is `1us` (microsecond). Agents may need to


### PR DESCRIPTION
As discussed in the weekly, we'd like to disable dropping fast exit spans by default.

- What's considered "fast" is application-specific and coming up with a good default that works for all users isn't easy.
- While 1ms seems like a reasonable threshold, it can still be a significant event if the total duration of a request is 10ms
- A prerequisite to dropping fast exit spans by default is adding indicators to the UI that tell users something like "we dropped 42 spans to Redis which accounted for 21ms in total"
- We also want to get more feedback from our user base before dropping fast exit spans by default.

---

- [x] Create PR as draft
- [x] Approval by at least one other agent
- [x] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [ ] Merge after 2 business days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.

/schedule 2022-03-10