### PR TITLE
Enable exact match compression by default

### DIFF
--- a/specs/agents/handling-huge-traces/tracing-spans-compress.md
+++ b/specs/agents/handling-huge-traces/tracing-spans-compress.md
@@ -20,7 +20,7 @@ The tradeoff is that some information such as DB statements of all the compresse
 |                |          |
 |----------------|----------|
 | Type           | `boolean`|
-| Default        | `false`  |
+| Default        | `true`  |
 | Dynamic        | `true`   |
 
 
@@ -94,7 +94,7 @@ The tradeoff is that the DB statements of all the compressed spans will not be c
 |                |          |
 |----------------|----------|
 | Type           | `duration`|
-| Default        | `5ms`    |
+| Default        | `0ms`    |
 | Dynamic        | `true`   |
 
 ## Composite span


### PR DESCRIPTION
We want to enable exact match span compression by default

- It's a relatively lossless way of compressing repetitive spans
- It can have a massively positive effect on storage efficiency
- Some of the things that we do lose is
  - We don't know the execution time of each individual event
  - The queries might differ slightly even though the span name is the same
- The user sees the effect of the span compression in the UI. If they don't like it, it's easy enough for them to opt out by setting `span_compression_enabled=false`.
- We should probably add a link from the span details of compressed spans to the [span compression docs](https://www.elastic.co/guide/en/apm/guide/current/span-compression.html) so that it's easier to know for users what's going on.

@elastic/apm-pm are you good with enabling span compression by default or would you like to get more feedback first?

---

- [x] Create PR as draft
- [x] Approval by at least one other agent
- [x] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [x] Merge after 2 business days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.


/schedule 2022-03-15