### PR TITLE
Correct capture_body config var values referred to in messaging spec

### DIFF
--- a/specs/agents/tracing-instrumentation-messaging.md
+++ b/specs/agents/tracing-instrumentation-messaging.md
@@ -158,7 +158,7 @@ agent should report 0 for this field.
 
 - **`context.message.body`**: similar to HTTP requests' `context.request.body`- only fill in messaging-related **transactions** (ie
 incoming messages creating a transaction) and not for outgoing messaging spans.
-   - Capture only when `ELASTIC_APM_CAPTURE_BODY` config is set to `true`.
+   - Capture only when `ELASTIC_APM_CAPTURE_BODY` config is set to `'all'` or `'transactions'`.
    - Only capture UTF-8 encoded message bodies.
    - Limit size to 10000 characters. If longer than this size, trim to 9999 and append with ellipsis
 - **`context.message.headers`**: similar to HTTP requests' `context.request.headers`- only fill in messaging-related **transactions**.
@@ -189,5 +189,4 @@ queues/topics/exchanges will be ignored.
 
 
 ### AWS messaging systems
-
 The instrumentation of [SQS](tracing-instrumentation-aws.md#sqs-simple-queue-service) and [SNS](tracing-instrumentation-aws.md#sns-aws-simple-notification-service) services generally follow this spec, with some nuances specified in the linked specs.

--- a/specs/agents/tracing-instrumentation-messaging.md
+++ b/specs/agents/tracing-instrumentation-messaging.md
@@ -189,4 +189,5 @@ queues/topics/exchanges will be ignored.
 
 
 ### AWS messaging systems
+
 The instrumentation of [SQS](tracing-instrumentation-aws.md#sqs-simple-queue-service) and [SNS](tracing-instrumentation-aws.md#sns-aws-simple-notification-service) services generally follow this spec, with some nuances specified in the linked specs.


### PR DESCRIPTION
A small thing I noticed when reading through the messaging spec, in prep for span link spec work.

## This is a small enhancement

- [x] Create PR as draft
- [x] Approval by at least one other agent
- [x] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [ ] ~Merge after 2 business days passed without objections~  This is just a small correction.

