### PR TITLE
Spec adding span links for instrumentation of messaging systems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/specs/agents/tracing-instrumentation-aws.md
+++ b/specs/agents/tracing-instrumentation-aws.md
@@ -2,6 +2,7 @@
 
 We describe how to instrument some of AWS' services in this document.
 Some of the services can use existing specs. When there are differences or additions, they have been noted below.
+The spec for [instrumenting AWS Lambda](tracing-instrumentation-aws-lambda.md) is in a separate document.
 
 ### S3 (Simple Storage Service)
 


### PR DESCRIPTION
- Specify that span links should be used on "messaging" spans and
  on "messaging" transactions that cover a batch of messages, when
  messages include trace context.
- Add Lambda instrumentation handling for SQS and SNS triggers that
  include multiple records.
- Starts documenting message metadata mechanisms to use for propgating
  trace-context, for those systems that provide a facility.

Closes: #606


## This is a new spec or a bigger enhancement

- May the instrumentation collect sensitive information, such as secrets or PII (ex. in headers)?
  - [ ] Yes
    - [ ] Add a section to the spec how agents should apply sanitization (such as `sanitize_field_names`)
  - [ ] No
    - [ ] Why?
  - [x] n/a
- [x] Link to meta issue: #605
- [x] Create PR as draft
- [ ] Approval by at least one other agent
- [ ] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [ ] Approved by at least 2 agents + PM (if relevant)
- [ ] Merge after 7 days passed without objections
- [ ] [Create implementation issues](https://gprom.app.elstc.co/issue-creator) (ideally add a milestone)
- [ ] [Create a status table](https://gprom.app.elstc.co/status/7.16) and add it to the meta issue
