### PR TITLE
Fix OTel gherkin spec for messaging

### DIFF
--- a/tests/agents/gherkin-specs/otel_bridge.feature
+++ b/tests/agents/gherkin-specs/otel_bridge.feature
@@ -170,7 +170,6 @@ Feature: OpenTelemetry bridge
   # https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/messaging.md
   Scenario: Messaging consumer
     Given an agent
-    And an active transaction
     And OTel span is created with kind 'CONSUMER'
     And OTel span has following attributes
       | messaging.system  | anything |
@@ -242,5 +241,4 @@ Feature: OpenTelemetry bridge
       | rpc.system | grpc |
     And OTel span ends
     Then Elastic bridged transaction type is 'request'
-
 


### PR DESCRIPTION
## Description

When creating an OTel span, if the span kind is `CONSUMER` and `messaging.system` attribute is provided and there is no transaction active, then agents should create a messaging transaction.

The gherkin specification required to have an active transaction, which contradicts the ability to create a messaging transaction when a message is received.

## This is a small enhancement

- [x] Create PR as draft
- [x] Approval by at least one other agent
- [x] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [x] Merge after 2 business days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.

/schedule 2022-03-28