### PR TITLE
Clarify that a compression-eligible span must not be buffered on an already ended parent

### DIFF
--- a/specs/agents/handling-huge-traces/tracing-spans-compress.md
+++ b/specs/agents/handling-huge-traces/tracing-spans-compress.md
@@ -153,8 +153,9 @@ boolean isCompressionEligible() {
 
 ### Span buffering
 
-Non-compression-eligible spans may be reported immediately after they have ended.
-When a compression-eligible span ends, it does not immediately get reported.
+When a span ends, if it is not compression-eligible or if its parent has already
+ended, it may be reported immediately.  Otherwise, it does not immediately get
+reported.
 Instead, the span is buffered within its parent.
 A span/transaction can buffer at most one child span.
 
@@ -172,7 +173,7 @@ void onEnd() {
 }
 
 void onChildEnd(Span child) {
-    if (!child.isCompressionEligible()) {
+    if (ended || !child.isCompressionEligible()) {
         if (buffered != null) {
             report(buffered)
             buffered = null


### PR DESCRIPTION
Otherwise, if a compression-eligible span ends after its parent has
ended, then buffering it on the parent will result in it (or its later
sibling) not being reported.


https://github.com/elastic/apm-agent-nodejs/pull/2623#pullrequestreview-932417034 shows and discusses a Node.js example where a compression-eligible span ends after its parent has ended. (This isn't a far-fetched scenario in Node.js.) 

# Checklist

- May the instrumentation collect sensitive information, such as secrets or PII (ex. in headers)?
  - [ ] Yes
    - [ ] Add a section to the spec how agents should apply sanitization (such as `sanitize_field_names`)
  - [ ] No
    - [ ] Why?
  - [x] n/a
- [x] Create PR as draft
- [x] Approval by at least one other agent
- [x] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [x] Approved by at least 2 agents + PM (if relevant)
- [ ] Merge after 7 days passed without objections
- [ ] [Create implementation issues through the meta issue template](https://github.com/elastic/apm/issues/new?assignees=&labels=meta%2C+apm-agents&template=apm-agents-meta.md) (this will automate issue creation for individual agents)
