### PR TITLE
ci: synchronize gherkin-specs to apm-agent-nodejs

### DIFF
--- a/.ci/.jenkins-agents.yml
+++ b/.ci/.jenkins-agents.yml
@@ -18,5 +18,5 @@ agents:
     FEATURES_PATH: "features"
     JSON_SPECS_PATH: "spec/fixtures"
   - REPO: "apm-agent-nodejs"
-    FEATURES_PATH: "test/fixtures/gherkin-specs"
+    FEATURES_PATH: "test/cucumber/gherkin-specs"
     JSON_SPECS_PATH: "test/fixtures/json-specs"

--- a/.ci/.jenkins-agents.yml
+++ b/.ci/.jenkins-agents.yml
@@ -18,4 +18,5 @@ agents:
     FEATURES_PATH: "features"
     JSON_SPECS_PATH: "spec/fixtures"
   - REPO: "apm-agent-nodejs"
+    FEATURES_PATH: "test/fixtures/gherkin-specs"
     JSON_SPECS_PATH: "test/fixtures/json-specs"


### PR DESCRIPTION
Get tests/agents/gherkin-specs/... syncing to the Node.js APM agent repo (alongside the json-specs).
I wanted these for the "otel_bridge.feature" for https://github.com/elastic/apm-agent-nodejs/pull/2641 work.