### PR TITLE
Revert "ci: synchronize gherkin-specs to apm-agent-nodejs (#640)"

### DIFF
--- a/.ci/.jenkins-agents.yml
+++ b/.ci/.jenkins-agents.yml
@@ -18,5 +18,4 @@ agents:
     FEATURES_PATH: "features"
     JSON_SPECS_PATH: "spec/fixtures"
   - REPO: "apm-agent-nodejs"
-    FEATURES_PATH: "test/cucumber/gherkin-specs"
     JSON_SPECS_PATH: "test/fixtures/json-specs"


### PR DESCRIPTION
This reverts commit 467403fed5d54d759f58c2faa7b899467abec15f.

We will not be using the gherkin-specs directly in the Node.js APM
agent. See https://github.com/elastic/apm-agent-nodejs/pull/2672
