### PR TITLE
OTel bridge require null transaction result

### DIFF
--- a/specs/agents/tracing-api-otel.md
+++ b/specs/agents/tracing-api-otel.md
@@ -106,6 +106,10 @@ This behavior is not expected with OTel API with status, thus bridged spans/tran
 altered by reporting (or lack of reporting) of an error. Here the behavior should be identical to when the end-user provides
 the outcome explicitly and thus have higher priority over the inferred value.
 
+For OTel spans that are mapped to Elastic Transactions, agent should ensure that `transaction.result` is not sent and let
+the server infer the value from `otel.attributes`. This allows to have consistent values for `transaction.result` between
+agent intake and native OTLP intake.
+
 ### Attributes mapping
 
 OTel relies on key-value pairs for span attributes.

--- a/tests/agents/gherkin-specs/otel_bridge.feature
+++ b/tests/agents/gherkin-specs/otel_bridge.feature
@@ -70,7 +70,7 @@ Feature: OpenTelemetry bridge
     And OTel span ends
     Then Elastic bridged object is a transaction
     Then Elastic bridged transaction outcome is "<outcome>"
-    Then Elastic bridged transaction result is null
+    Then Elastic bridged transaction result is not set
     Examples:
       | status | outcome |
       | unset  | unknown |

--- a/tests/agents/gherkin-specs/otel_bridge.feature
+++ b/tests/agents/gherkin-specs/otel_bridge.feature
@@ -70,6 +70,7 @@ Feature: OpenTelemetry bridge
     And OTel span ends
     Then Elastic bridged object is a transaction
     Then Elastic bridged transaction outcome is "<outcome>"
+    Then Elastic bridged transaction result is null
     Examples:
       | status | outcome |
       | unset  | unknown |


### PR DESCRIPTION
During the investigation of https://github.com/elastic/apm-server/issues/8067 we found out that the behavior of the apm-server does not infer any value for `transaction.result` if a value is already set.

As a result, when an agent sets the `transaction.result` value in the OTel bridge, setting any of the usual attribute `http.status_code` = `200` does not produce a transaction that has `transaction.result` = `HTTP 2xx` as would have been expected.

This is mostly a bugfix in the spec and very likely not controversial nor require further discussion.
Only agents that do rely on the OTel bridge gherkin spec should be directly impacted, but checking the behavior in all bridge implementations would still be required.

- May the instrumentation collect sensitive information, such as secrets or PII (ex. in headers)?
  - [x] n/a
- [x] Create PR as draft
- [x] Approval by at least one other agent
- [ ] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [ ] Approved by at least 2 agents + PM (if relevant)
- [ ] Merge after 7 days passed without objections
- [ ] [Create implementation issues through the meta issue template](https://github.com/elastic/apm/issues/new?assignees=&labels=meta%2C+apm-agents&template=apm-agents-meta.md) (this will automate issue creation for individual agents)
