### PR TITLE
Add transaction_name_groups config spec

### DIFF
--- a/specs/agents/README.md
+++ b/specs/agents/README.md
@@ -38,6 +38,7 @@ You can find details about each of these in the [APM Data Model](https://www.ela
 - [Metadata](metadata.md)
 - Tracing
   - [Transactions](tracing-transactions.md)
+    - [Transaction Grouping](tracing-transaction-grouping.md)
   - [Spans](tracing-spans.md)
   - [Span destination](tracing-spans-destination.md)
   - [Handling huge traces](handling-huge-traces/)

--- a/specs/agents/tracing-transaction-grouping.md
+++ b/specs/agents/tracing-transaction-grouping.md
@@ -17,7 +17,7 @@ With this option,
 you can group transaction names that contain dynamic parts with a wildcard expression.
 For example,
 the pattern `GET /user/*/cart` would consolidate transactions,
-such as `GET /users/42/cart`, into a single group.
+such as `GET /users/42/cart` and `GET /users/73/cart` into a single transaction name `GET /users/*/cart`, hence reducing the transaction name cardinality.
 
 |                |                                                                                          |
 |----------------|------------------------------------------------------------------------------------------|

--- a/specs/agents/tracing-transaction-grouping.md
+++ b/specs/agents/tracing-transaction-grouping.md
@@ -27,6 +27,7 @@ The first matching expression wins, so make sure to place more specific expressi
 | Dynamic        | `true`                                                                                   |
 | Central config | `true`                                                                                   |
 
+The `url_groups` option that the Java and PHP agent offered is deprecated in favor of `transaction_name_groups`.
 ### When to apply the grouping
 
 The grouping can be applied either every time the transaction name is set, or lazily, when the transaction name is read.

--- a/specs/agents/tracing-transaction-grouping.md
+++ b/specs/agents/tracing-transaction-grouping.md
@@ -1,0 +1,37 @@
+## Transaction Grouping
+
+Even though agents should choose a transaction name that has a reasonable cardinality,
+they can't always guarantee that.
+For example,
+when the auto-instrumentation of a job scheduling framework sets the transaction name to the name of the instrumented job,
+the agent has no control over the job name itself.
+While usually the job name is expected to have low cardinality,
+users might set dynamic parts as part of the job name, such as a UUID.
+
+In order to give users an option to group transactions whose name contain dynamic parts that don't require code changes,
+agents MAY implement the following configuration option:
+
+### `transaction_name_groups` configuration
+
+With this option,
+you can group transaction names that contain dynamic parts with a wildcard expression.
+For example,
+the pattern `GET /user/*/cart` would consolidate transactions,
+such as `GET /users/42/cart`, into a single group.
+
+|                |                                                                                          |
+|----------------|------------------------------------------------------------------------------------------|
+| Type           | `List<`[`WildcardMatcher`](../../tests/agents/json-specs/wildcard_matcher_tests.json)`>` |
+| Default        | `<none>`                                                                                 |
+| Dynamic        | `true`                                                                                   |
+| Central config | `true`                                                                                   |
+
+### When to apply the grouping
+
+The grouping can be applied either every time the transaction name is set, or lazily, when the transaction name is read.
+
+It's not sufficient to only apply the grouping when the transaction ends.
+That's because when an error is tracked, the transaction name is copied to the error object.
+See also [the error spec](error-tracking.md)
+
+Agents MUST also ensure that the grouping is applied before breakdown metrics are reported.

--- a/specs/agents/tracing-transaction-grouping.md
+++ b/specs/agents/tracing-transaction-grouping.md
@@ -18,6 +18,7 @@ you can group transaction names that contain dynamic parts with a wildcard expre
 For example,
 the pattern `GET /user/*/cart` would consolidate transactions,
 such as `GET /users/42/cart` and `GET /users/73/cart` into a single transaction name `GET /users/*/cart`, hence reducing the transaction name cardinality.
+The first matching expression wins, so make sure to place more specific expressions before more generic ones, for example: `GET /users/*/cart, GET /users/*`.
 
 |                |                                                                                          |
 |----------------|------------------------------------------------------------------------------------------|


### PR DESCRIPTION
For now, this option is only intended to be implemented in Java where we got a specific request.
However, the option itself is not specific to Java and can also be implemented by other agent as the need arises. We should still make sure that the option is potentially useful and feasible to implement in other agents, too.

Some agents have a concept of filters or processors that let users achieve similar things. However, the intent of the option is to allow users to group transactions without requiring code changes.

Reference implementation: https://github.com/elastic/apm-agent-java/pull/2676

- [x] Create PR as draft
- [x] Approval by at least one other agent
- [x] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [ ] Merge after 2 business days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.
