### PR TITLE
Spec 'error.exception.type' for an Elasticsearch client error to include responseBody.error.type

### DIFF
--- a/specs/agents/tracing-instrumentation-db.md
+++ b/specs/agents/tracing-instrumentation-db.md
@@ -124,7 +124,7 @@ In addition to [the usual error capture specification](./error-tracking.md), the
 
 | Error Field | Value / Examples | Comments |
 |-------------|:----------------:|----------|
-| `exception.type` | `$exceptionType` or `${exceptionType} (${esResponseBody.error.type})`, e.g. `ResponseError (index_not_found_exception)` | Some Elasticsearch client errors include an error [response body from Elasticsearch with a `error.type`](https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#common-options-error-options). For these errors, the APM agent SHOULD capture that type as in the given example. This helps with error grouping in the APM app. |
+| `exception.type` | `$exceptionType` or `${exceptionType} (${esResponseBody.error.type})`, e.g. `ResponseError (index_not_found_exception)` | Some Elasticsearch client errors include an error [response body from Elasticsearch with a `error.type`](https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#common-options-error-options). For these errors, the APM agent MAY capture that type as in the given example. This helps with error grouping in the APM app. |
 
 ### MongoDB
 

--- a/specs/agents/tracing-instrumentation-db.md
+++ b/specs/agents/tracing-instrumentation-db.md
@@ -97,8 +97,8 @@ The following fields are relevant for database and datastore spans. Where possib
 
 ### Elasticsearch
 
-| Field | Value / Examples | Comments |
-|-------|:---------------:|----------|
+| Span Field | Value / Examples | Comments |
+|------------|:----------------:|----------|
 |`name`| e.g. `Elasticsearch: GET /index/_search` |  The span name should be `Elasticsearch: <method> <path>` |
 |`type`|`db`|
 |`subtype`|`elasticsearch`|
@@ -116,9 +116,15 @@ The following fields are relevant for database and datastore spans. Where possib
 |`_.service.name`| `elasticsearch` | DEPRECATED, use `service.target.{type,name}` |
 |`_.service.type`|`db`| DEPRECATED, use `service.target.{type,name}` |
 |`_.service.resource`| `elasticsearch` | DEPRECATED, use `service.target.{type,name}` |
-| __**service.target._**__ |<hr/>|<hr/>|
+| __**context.service.target._**__ |<hr/>|<hr/>|
 |`_.type`| `elasticsearch` | |
 |`_.name`| :heavy_minus_sign: | |
+
+In addition to [the usual error capture specification](./error-tracking.md), the following apply to errors captured for Elasticsearch client auto-instrumentation.
+
+| Error Field | Value / Examples | Comments |
+|-------------|:----------------:|----------|
+| `exception.type` | `$exceptionType` or `${exceptionType} (${esResponseBody.error.type})`, e.g. `ResponseError (index_not_found_exception)` | Some Elasticsearch client errors include an error [response body from Elasticsearch with a `error.type`](https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#common-options-error-options). For these errors, the APM agent SHOULD capture that type as in the given example. This helps with error grouping in the APM app. |
 
 ### MongoDB
 


### PR DESCRIPTION
See https://github.com/elastic/apm-agent-nodejs/issues/2770 for earlier discussion. Currently when an Elasticsearch client returns an API error -- i.e. an error from Elasticsearch itself -- the captured APM error object (at least for the Node.js agent) has a generic `error.exception.type == "ResponseError"` and a `error.exception.stacktrace` that is identical for different types of Elasticsearch API errors. The result is that all ES errors (e.g. `resource_not_found_exception`, `illegal_argument_exception`) are all *grouped* together in the APM app (see the [APM server logic for setting `error.grouping_key`](https://github.com/elastic/apm-server/blob/931271c62a9024fa4b23a12ec574b42db9301b11/model/modelprocessor/groupingkey.go#L44-L76)).

The solution discussed above and implemented in the Node.js APM agent is to set `error.exception.type` to `$exceptionType (${esResponseBody.error.type})` for ES API errors.


# Trent to decide which checklist to use below

- May the instrumentation collect sensitive information, such as secrets or PII (ex. in headers)?
  - [ ] Yes
    - [ ] Add a section to the spec how agents should apply sanitization (such as `sanitize_field_names`)
  - [x] No
    - [x] Why? **Just adding an ES API code.**
  - [ ] n/a
- [x] Create PR as draft (**I messed up the process and created it as not-draft initially**)
- [x] Approval by at least one other agent
- [x] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [x] Approved by at least 2 agents + PM (if relevant)
- [ ] Merge after 7 days passed without objections
- [ ] [Create implementation issues through the meta issue template](https://github.com/elastic/apm/issues/new?assignees=&labels=meta%2C+apm-agents&template=apm-agents-meta.md) (this will automate issue creation for individual agents)
