### PR TITLE
Spec: services dependencies granularity NoSQL

### DIFF
--- a/specs/agents/tracing-instrumentation-db.md
+++ b/specs/agents/tracing-instrumentation-db.md
@@ -2,6 +2,7 @@
 ## Table of Contents
 * [Database and Datastore spans](#database-and-datastore-spans)
 * [Specific Databases](#specific-databases)
+  * [Casandra](#cassandra)
   * [AWS DynamoDb](#aws-dynamodb)
   * [AWS S3](#aws-s3)
   * [Elasticsearch](#elasticsearch)
@@ -42,6 +43,17 @@ The following fields are relevant for database and datastore spans. Where possib
 
 
 ## Specific Databases
+
+### Cassandra
+
+| Field                                  | Value / Examples                   | Comments      |
+|----------------------------------------|:-----------------------------------|---------------|
+| `type`                                 | `db`                               |               |
+| `subtype`                              | `cassandra`                        |               |
+| `context.db.instance`                  | e.g. `customers`                   | Keyspace name |
+| `context.destination.service.resource` | `cassandra`, `cassandra/customers` | DEPRECATED    |
+| `service.target.type`                  | `cassandra`                        |               |
+| `service.target.name`                  | e.g. `customers`                   | Keyspace name |
 
 ### AWS DynamoDb
 

--- a/specs/agents/tracing-instrumentation-db.md
+++ b/specs/agents/tracing-instrumentation-db.md
@@ -137,7 +137,7 @@ The following fields are relevant for database and datastore spans. Where possib
 
 The Elasticsearch cluster name is not always available in ES clients, as a result the following strategy should be used (by order of priority):
 - Call internal API in the client library to get cached cluster name.
-- Use `x-found-handling-cluster` HTTP response header value in HTTP response headers.
+- Use `x-found-handling-cluster` HTTP response header value.
 - Instrument `_node/http` calls and cache the result in the agent with `host:port` as key.
 - execute a request to Elasticsearch and cache the result in the agent with `host:port` as key.
 

--- a/specs/agents/tracing-instrumentation-db.md
+++ b/specs/agents/tracing-instrumentation-db.md
@@ -2,9 +2,9 @@
 ## Table of Contents
 * [Database and Datastore spans](#database-and-datastore-spans)
 * [Specific Databases](#specific-databases)
-  * [Casandra](#cassandra)
   * [AWS DynamoDb](#aws-dynamodb)
   * [AWS S3](#aws-s3)
+  * [Casandra](#cassandra)
   * [Elasticsearch](#elasticsearch)
   * [MongoDB](#mongodb)
   * [Redis](#redis)
@@ -43,17 +43,6 @@ The following fields are relevant for database and datastore spans. Where possib
 
 
 ## Specific Databases
-
-### Cassandra
-
-| Field                                  | Value / Examples                   | Comments      |
-|----------------------------------------|:-----------------------------------|---------------|
-| `type`                                 | `db`                               |               |
-| `subtype`                              | `cassandra`                        |               |
-| `context.db.instance`                  | e.g. `customers`                   | Keyspace name |
-| `context.destination.service.resource` | `cassandra`, `cassandra/customers` | DEPRECATED    |
-| `service.target.type`                  | `cassandra`                        |               |
-| `service.target.name`                  | e.g. `customers`                   | Keyspace name |
 
 ### AWS DynamoDb
 
@@ -106,6 +95,17 @@ The following fields are relevant for database and datastore spans. Where possib
 | __**service.target._**__ |<hr/>|<hr/>|
 |`_.type`| `s3` ||
 |`_.name`| e.g. `my-bucket`, `accesspoint/myendpointslashes`, or `accesspoint:myendpointcolons` | The bucket name, if available. The s3 API allows either the bucket name or an Access Point to be provided when referring to a bucket. Access Points can use either slashes or colons. When an Access Point is provided, the access point name preceded by accesspoint/ or accesspoint: should be extracted. For example, given an Access Point such as `arn:aws:s3:us-west-2:123456789012:accesspoint/myendpointslashes`, the agent extracts `accesspoint/myendpointslashes`. Given an Access Point such as `arn:aws:s3:us-west-2:123456789012:accesspoint:myendpointcolons`, the agent extracts `accesspoint:myendpointcolons`. |
+
+### Cassandra
+
+| Field                                  | Value / Examples                   | Comments      |
+|----------------------------------------|:-----------------------------------|---------------|
+| `type`                                 | `db`                               |               |
+| `subtype`                              | `cassandra`                        |               |
+| `context.db.instance`                  | e.g. `customers`                   | Keyspace name |
+| `context.destination.service.resource` | `cassandra`, `cassandra/customers` | DEPRECATED    |
+| `service.target.type`                  | `cassandra`                        |               |
+| `service.target.name`                  | e.g. `customers`                   | Keyspace name |
 
 ### Elasticsearch
 

--- a/specs/agents/tracing-instrumentation-db.md
+++ b/specs/agents/tracing-instrumentation-db.md
@@ -116,7 +116,7 @@ The following fields are relevant for database and datastore spans. Where possib
 |`subtype`|`elasticsearch`|
 |`action`| `request` |
 | __**context.db._**__  |<hr/>|<hr/>|
-|`_.instance`| :heavy_minus_sign: |
+|`_.instance`| e.g. `my-cluster` | [Cluster name](#cluster-name), if available.
 |`_.statement`| e.g. <pre lang="json">{"query": {"match": {"user.id": "kimchy"}}}</pre> | For Elasticsearch search-type queries, the request body may be recorded. Alternatively, if a query is specified in HTTP query parameters, that may be used instead. If the body is gzip-encoded, the body should be decoded first.|
 |`_.type`|`elasticsearch`|
 |`_.user`| :heavy_minus_sign: |
@@ -127,10 +127,19 @@ The following fields are relevant for database and datastore spans. Where possib
 |`_.port`|e.g. `5432`|
 |`_.service.name`| `elasticsearch` | DEPRECATED, use `service.target.{type,name}` |
 |`_.service.type`|`db`| DEPRECATED, use `service.target.{type,name}` |
-|`_.service.resource`| `elasticsearch` | DEPRECATED, use `service.target.{type,name}` |
+|`_.service.resource`| `elasticsearch`, `elasticsearch/my-cluster` | DEPRECATED, use `service.target.{type,name}` |
 | __**service.target._**__ |<hr/>|<hr/>|
 |`_.type`| `elasticsearch` | |
-|`_.name`| :heavy_minus_sign: | |
+|`_.name`| e.g. `my-cluster` | [Cluster name](#cluster-name), if available.
+
+
+#### Cluster name
+
+The Elasticsearch cluster name is not always available in ES clients, as a result the following strategy should be used (by order of priority):
+- Call internal API in the client library to get cached cluster name.
+- Use `x-found-handling-cluster` HTTP response header value in HTTP response headers.
+- Instrument `_node/http` calls and cache the result in the agent with `host:port` as key.
+- execute a request to Elasticsearch and cache the result in the agent with `host:port` as key.
 
 ### MongoDB
 

--- a/specs/agents/tracing-instrumentation-db.md
+++ b/specs/agents/tracing-instrumentation-db.md
@@ -152,7 +152,7 @@ The following fields are relevant for database and datastore spans. Where possib
 |`_.port`|e.g. `5432`|
 |`_.service.name`| `mongodb` | DEPRECATED, use `service.target.{type,name}`  |
 |`_.service.type`|`db`| DEPRECATED, use `service.target.{type,name}` |
-|`_.service.resource`| `mongodb` | DEPRECATED, use `service.target.{type,name}` |
+|`_.service.resource`| `mongodb/customers` | DEPRECATED, use `service.target.{type,name}` |
 | __**service.target._**__ |<hr/>|<hr/>|
 |`_.type`| `mongob` | |
 |`_.name`| e.g. `customers` | Database name, same as `db.instance` if available  |

--- a/specs/agents/tracing-instrumentation-db.md
+++ b/specs/agents/tracing-instrumentation-db.md
@@ -75,7 +75,7 @@ The following fields are relevant for database and datastore spans. Where possib
 |`_.port`|e.g. `5432`|
 |`_.service.name`| `dynamodb` | DEPRECATED
 |`_.service.type`|`db`| DEPRECATED
-|`_.service.resource`| `dynamodb` | DEPRECATED
+|`_.service.resource`| `dynamodb`, `dynamodb/us-east-1`| DEPRECATED
 |`_.cloud.region`| e.g. `us-east-1` | The AWS region where the table is, if available. |
 | __**service.target._**__ |<hr/>|<hr/>|
 |`_.type`| `dynamodb` ||

--- a/specs/agents/tracing-instrumentation-db.md
+++ b/specs/agents/tracing-instrumentation-db.md
@@ -141,7 +141,7 @@ The following fields are relevant for database and datastore spans. Where possib
 |`subtype`|`mongodb`|
 |`action`|e.g. `find` , `insert`, etc.| The MongoDB command executed with this action. |
 | __**context.db._**__  |<hr/>|<hr/>|
-|`_.instance`| :heavy_minus_sign: |
+|`_.instance`| e.g. `customers` | Database name, if available |
 |`_.statement`| e.g. <pre lang="json">find({status: {$in: ["A","D"]}})</pre> | The MongoDB command encoded as MongoDB Extended JSON.|
 |`_.type`|`mongodb`|
 |`_.user`| :heavy_minus_sign: |
@@ -155,7 +155,7 @@ The following fields are relevant for database and datastore spans. Where possib
 |`_.service.resource`| `mongodb` | DEPRECATED, use `service.target.{type,name}` |
 | __**service.target._**__ |<hr/>|<hr/>|
 |`_.type`| `mongob` | |
-|`_.name`| :heavy_minus_sign: | |
+|`_.name`| e.g. `customers` | Database name, same as `db.instance` if available  |
 
 ### Redis
 


### PR DESCRIPTION
Implement #646 for NoSQL databases

### Summary of changes

- For Cassandra, define `db.instance` to the Keyspace name (if available)
- For MongoDB, define `db.instance` to the Database name (if available)
- For Elasticsearch, define `db.instance` as the Cluster name (if available, with heuristic).

### Out of scope (for now)

- Databases that do not have a database or cluster name (a cluster being just a set of hosts) using `host:port` in `service.target.name` would have high cardinality and provide limited value
- [x] CosmosDB (Azure), I guess [from this](https://github.com/elastic/apm/blob/main/specs/agents/tracing-instrumentation-azure.md#azure-storage) that we can't easily capture the region name and set `db.instance`.
  - option 1: skip this from the spec for now and refine cloud-based services with a separate spec PR
  - option 2: use the "account name" for Azure services which is easy to capture, unlike the actual region name, this strategy would also likely be applied to other Azure services (so at least it should be consistent across all Azure services).
  EDIT: opened #661 to deal with this separately

### To be clarified/discussed

----
### Already clarified/discussed
- [x] What can we do for databases that don't have a database nor cluster name, should we fallback to using the `host:port` format for `service.target.name` ? I would be in favor to keep it as-is for now as the added granularity would be of limited value (cardinality == number of hosts)
  - [x] Redis
  - [x] Memcached
- [x] What values of `service.target.name` should we pick for Elasticsearch spans ?
  - cluster name seems to be a good candidate
  - `host:port` might have high cardinality with many ES nodes (would be similar to Redis and Memcached described above)
  - cluster name might not be accessible from application side depending on the client used.
  - if an extra call to ES is required, then agents should cache the value with the `host:port` as key.
  - the added granularity might provide limited value unless application communicates with multiple clusters.

----
- [x] Create PR as draft
- [x] Approval by at least one other agent
- [ ] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [ ] Merge after 2 business days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.
