### PR TITLE
Spec: services dependencies granularity Messaging

### DIFF
--- a/specs/agents/tracing-instrumentation-azure.md
+++ b/specs/agents/tracing-instrumentation-azure.md
@@ -140,7 +140,9 @@ A new span is created when there is a current transaction, and when a message is
 | APM field | Required? | Format | Notes | Example |
 | --------- | --------- | ------ | ----- | ------- |
 | `context.destination.address` | yes | URL host | | `accountname.queue.core.windows.net` |
-| `context.destination.service.resource` | yes | `azurequeue/<QueueName>` | | `azurequeue/accountname` |
+| `context.destination.service.resource` | yes | `azurequeue/<QueueName>` | | `azurequeue/queuename` |
+| `context.service.target.type` | yes | `azurequeue` | | |
+| `context.service.target.name` | yes | `<QueueName>` | | `queuename` |
 
 ----
 
@@ -362,6 +364,8 @@ A new span is created when there is a current transaction, and when a message is
 | --------- | --------- | ------ | ----- | ------- |
 | `context.destination.address` | yes | URL host | | `namespace.servicebus.windows.net` |
 | `context.destination.service.resource` | yes | azureservicebus/`<Queue>`\|`<Topic>` | | `azurequeue/myqueue`, `azureservicebus/mytopic` |
+| `context.service.target.type` | yes | `azureservicebus` | | |
+| `context.service.target.name` | yes | `<Queue>`\|`<Topic>` | | `mytopic` |
 
 ----
 

--- a/specs/agents/tracing-instrumentation-messaging.md
+++ b/specs/agents/tracing-instrumentation-messaging.md
@@ -176,11 +176,13 @@ incoming messages creating a transaction) and not for outgoing messaging spans.
    - Intake: key-value pairs, same like `context.request.headers`.
 - **`context.service.framework.name`**: same as `span.subtype`, but not in lowercase, e.g. `Kafka`, `RabbitMQ`
 
-#### Span destination fields
+#### Span context fields
 
 - **`context.destination.address`**: optional. Not available in some cases. Only set if the actual connection is available.
 - **`context.destination.port`**: optional. Not available in some cases. Only set if the actual connection is available.
-- **`context.destination.service.*`**: See [destination spec](tracing-spans-destination.md)
+- **`context.destination.service.resource*`**: mandatory. Value should be either `${span.subtype}/${context.mesage.queue.name}` or `${span.subtype}`.
+- **`context.service.target.type`**: mandatory. Same value as `span.subtype`. See [Service Target](tracing-spans-service-target.md) for details.
+- **`context.service.target.name`**: optional. same value as `context.mesage.queue.name` if available. See [Service Target](tracing-spans-service-target.md) for details.
 
 ### `ignore_message_queues` configuration
 

--- a/specs/agents/tracing-instrumentation-messaging.md
+++ b/specs/agents/tracing-instrumentation-messaging.md
@@ -181,6 +181,8 @@ incoming messages creating a transaction) and not for outgoing messaging spans.
 - **`context.destination.address`**: optional. Not available in some cases. Only set if the actual connection is available.
 - **`context.destination.port`**: optional. Not available in some cases. Only set if the actual connection is available.
 - **`context.destination.service.resource*`**: mandatory. Value should be either `${span.subtype}/${context.mesage.queue.name}` or `${span.subtype}`.
+- **`context.destination.service.type*`**: deprecated but mandatory until 7.14.0. See [destination spec](tracing-spans-destination.md) for details.
+- **`context.destination.service.name`**: deprecated but mandatory until 7.14.0. See [destination spec](tracing-spans-destination.md) for details.
 - **`context.service.target.type`**: mandatory. Same value as `span.subtype`. See [Service Target](tracing-spans-service-target.md) for details.
 - **`context.service.target.name`**: optional. same value as `context.mesage.queue.name` if available. See [Service Target](tracing-spans-service-target.md) for details.
 

--- a/specs/agents/tracing-spans-destination.md
+++ b/specs/agents/tracing-spans-destination.md
@@ -20,10 +20,10 @@ The only field still required is `context.destination.service.resource` until AP
 Agents MUST NOT manually set these fields.
 Agents MUST NOT offer non-deprecated public APIs to set them.
 
-The intake JSON spec (up until at least 7.15) requires the deprecated fields to be present if `context.destination.service.resource` is set.
+The intake JSON spec until 7.14.0 requires the deprecated fields to be present if `context.destination.service.resource` is set.
 Future versions of APM Server will remove the fields from the intake API and drop it if sent by agents.
 
-Agents MAY omit the deprecated fields when sending spans to an APM Server version that doesn't require the field.
+Agents MAY omit the deprecated fields when sending spans to an APM Server version >= 7.14.0 .
 Otherwise, the field MUST be serialized as an empty string if `context.destination.service.resource` is set.
 Both options result in the fields being omitted from the Elasticsearch document.
 


### PR DESCRIPTION
Part of #646 for messaging spans.

Specify which value of `service.target.name` we should use or the following span subtypes/instrumentations:

- `azurequeue` : queue name
- `azureservicebus` : queue or topic name
- other: use already captured queue name

For AWS, Azure and other cloud-based services, we DO NOT use the region name as a fallback as we do for some services, the general rule is to always use the queue or topic name if available.

- [x] Create PR as draft
- [x] Approval by at least one other agent
- [x] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [ ] Merge after 2 business days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.
