### PR TITLE
added some spec documentation for mobile agents

### DIFF
--- a/specs/agents/mobile/README.md
+++ b/specs/agents/mobile/README.md
@@ -1,0 +1,42 @@
+# Introduction
+
+General documentation for the mobile apm agents can be found in [Getting started with APM](https://www.elastic.co/guide/en/apm/get-started/current/overview.html) docs.
+
+The mobile specific docs can be found:
+
+* [iOS Agent](https://www.elastic.co/guide/en/apm/agent/swift/0.x/intro.html)
+* Android Agent (TBD)
+
+## Open Telementry
+The mobile agents are the first agents at Elastic to be built on top of Open-Telementry. 
+A large portion of the mobile agents' functionality can be attributed to the [opentelementry-swift](https://github.com/open-telemetry/opentelemetry-swift) and [opentelementry-java](https://github.com/open-telemtry/opentelemetry-java) packages.
+
+The Open-Telemetry libraries adhere to the semantic conventions outlined in [opentelementry-specifications](https://github.com/open-telemetry/opentelemetry-specification). 
+However, the Elastic mobile agents don't set every attribute defined (many only apply to server type monitoring). Additionally, these Open Telementry attributes will be remapped to Elastic specific terms. 
+
+## Semantic Conventions and APM Server Mappings
+
+
+### Trace Common 
+Here is a list of common attributes added onto spans.
+
+| OTel Convention        | Elastic Convention         | Example                          | 
+|------------------------|----------------------------|----------------------------------| 
+| `service.name`         | `service.name`             | `opbeans-swift`                  |
+| `os.description`       | `host.os.platform`         | `iOS Version 15.5 (Build 19F70)` |
+| `os.version`           | `labels.os_version`        | `15.5.0`                         |
+| `os.name`              | `labels.os_name`           | `iOS`                            |
+| `service.namespace`    | `labels.service_namespace` | `co.elastic.opbeans-swift`       | 
+| `telemetry.sdk.version` | `agent.version`            | `1.0`                            
+| `service.version` | `service.version`          | `5.2.0 (1123)`                   
+| `telemetry.sdk.language` | -                          | `swift`                           |
+| `telemetry.sdk.name` | -                          | `opentelementry`|
+| - | `agent.name` | `iOS/swift` 
+| `os.type` | `host.os.platform`         | `darwin` 
+| `deivce.id` | `labels.device_id` | `E733F41E-DF47-4BB4-AAF0-FD784FD95653` | 
+
+
+### `URLSessionInstrumentation` 
+| OTel Convention | Elastic convention |
+|-----------------|--------------------|
+|                 |                    |


### PR DESCRIPTION


<!--
Use this section if the spec requires changes in at most two agents.

Examples:
- Typos or clarifications without semantic changes
- Changes in a spec before it has been implemented
- Features that are only implemented in two agents
-->

- [ ] Create PR as draft
- [ ] Approval by at least one other agent
- [ ] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [ ] Merge after 2 business days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.

<!--
Use this section if the spec requires changes in more than two agents.

This extended template ensures that we have a meta issue and tracking issues so that we don't forget about implementing the changes in all affected agents.
-->

- May the instrumentation collect sensitive information, such as secrets or PII (ex. in headers)?
  - [ ] Yes
    - [ ] Add a section to the spec how agents should apply sanitization (such as `sanitize_field_names`)
  - [ ] No
    - [ ] Why?
  - [ ] n/a
- [ ] Create PR as draft
- [ ] Approval by at least one other agent
- [ ] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [ ] Approved by at least 2 agents + PM (if relevant)
- [ ] Merge after 7 days passed without objections
- [ ] [Create implementation issues through the meta issue template](https://github.com/elastic/apm/issues/new?assignees=&labels=meta%2C+apm-agents&template=apm-agents-meta.md) (this will automate issue creation for individual agents)
