### PR TITLE
Sanitize *auth* instead of authorization - Fixed the second appearance

### DIFF
--- a/specs/agents/sanitization.md
+++ b/specs/agents/sanitization.md
@@ -25,7 +25,7 @@ how an agent will sanitize data.
 Agents MUST provide a minimum default configuration of
 
     [ 'password', 'passwd', 'pwd', 'secret', '*key', '*token*', '*session*',
-      '*credit*','*card*', 'authorization', 'set-cookie']
+      '*credit*','*card*', '*auth*', 'set-cookie']
 
 for the `sanitize_field_names` configuration value.  Agent's MAY include the
 following extra fields in their default configuration to avoid breaking changes


### PR DESCRIPTION
Fixed the second appearance  of the default value  (in Configuration section) tat still has the old `authorization` instead of the new `*auth*`

<!--
Agent spec PR checklist

Delete all of this if the PR is not changing the agent spec.
Delete sections that don't apply to this PR.
If a specific checkbox doesn't apply, ~strike through~ and check it instead of deleting it.
-->

<!--
Use this section if the spec requires changes in at most two agents.

Examples:
- Typos or clarifications without semantic changes
- Changes in a spec before it has been implemented
- Features that are only implemented in two agents
-->

- [x] Create PR as draft
- [x] ~~Approval by at least one other agent~~
- [x] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - [x] Remove PM from reviewers if impact on product is negligible
  - [x] Remove agents from reviewers if the change is not relevant for them
- [x] Merge after 2 business days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.
