### PR TITLE
Refer to sanitization spec page instead of duplicating patterns

### DIFF
--- a/specs/agents/tracing-instrumentation-http.md
+++ b/specs/agents/tracing-instrumentation-http.md
@@ -19,21 +19,8 @@ In addition to the above properties, HTTP-specific properties should be recorded
 
 By default request bodies are not captured. It should be possible to configure agents to enable their capture using the config variable `ELASTIC_APM_CAPTURE_BODY`. By default agents will capture request headers, but it should be possible to disable their capture using the config variable `ELASTIC_APM_CAPTURE_HEADERS`.
 
-Request and response headers, cookies, and form bodies should be sanitised (i.e. secrets removed). Each agent should define a default list of keys to sanitise, which should include at least the following (using wildcard matching):
+Captured request and response headers, cookies, and form bodies MUST be sanitised (i.e. secrets removed) according to [data sanitization rules](https://github.com/elastic/apm/blob/main/specs/agents/sanitization.md#data-sanitization).
 
-  - `password`
-  - `passwd`
-  - `pwd`
-  - `secret`
-  - `*key`
-  - `*token*`
-  - `*session*`
-  - `*credit*`
-  - `*card*`
-  - `authorization`
-  - `set-cookie`
-
-Agents may may include additional patterns if there are common conventions specific to language frameworks.
 
 ### `transaction_ignore_urls` configuration
 

--- a/specs/agents/tracing-instrumentation-http.md
+++ b/specs/agents/tracing-instrumentation-http.md
@@ -19,7 +19,7 @@ In addition to the above properties, HTTP-specific properties should be recorded
 
 By default request bodies are not captured. It should be possible to configure agents to enable their capture using the config variable `ELASTIC_APM_CAPTURE_BODY`. By default agents will capture request headers, but it should be possible to disable their capture using the config variable `ELASTIC_APM_CAPTURE_HEADERS`.
 
-Captured request and response headers, cookies, and form bodies MUST be sanitised (i.e. secrets removed) according to [data sanitization rules](https://github.com/elastic/apm/blob/main/specs/agents/sanitization.md#data-sanitization).
+Captured request and response headers, cookies, and form bodies MUST be sanitised (i.e. secrets removed) according to [data sanitization rules](sanitization.md#data-sanitization).
 
 
 ### `transaction_ignore_urls` configuration


### PR DESCRIPTION
https://github.com/elastic/apm/pull/663 was recently added to correct an updated in the duplicated list of sanitization field patterns. This replaces another duplicate list in the HTTP tracing spec with a reference to the sanitization spec page.

- [x] Create PR as draft
- [x] Approval by at least one other agent
- [x] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [ ] Merge after 2 business days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.


/schedule 2022-08-05
