### PR TITLE
Minimum delay for retries when central config cannot be retrieved

### DIFF
--- a/specs/agents/configuration.md
+++ b/specs/agents/configuration.md
@@ -82,6 +82,8 @@ Agents should poll the APM Server for config periodically by sending an HTTP req
 
 The server will respond with a JSON object, where each key maps a config attribute to a string value. The string value should be interpreted the same as if it were passed in via an environment variable. Upon receiving these config changes, the agent will update its configuration dynamically, overriding any config previously specified. That is, config via Kibana takes highest precedence.
 
+To ensure graceful recovery if the APM Server is offline or there is a network partition, agents should only retry central configuration requests occasionally, and should add a modest random delay when retrying to avoid thundering herd issues when the partition resolves.
+
 To minimise the amount of work required by users, agents should aim to enable this feature by default. This excludes RUM, where there is a performance penalty.
 
 #### Interaction with local config

--- a/specs/agents/configuration.md
+++ b/specs/agents/configuration.md
@@ -82,8 +82,6 @@ Agents should poll the APM Server for config periodically by sending an HTTP req
 
 The server will respond with a JSON object, where each key maps a config attribute to a string value. The string value should be interpreted the same as if it were passed in via an environment variable. Upon receiving these config changes, the agent will update its configuration dynamically, overriding any config previously specified. That is, config via Kibana takes highest precedence.
 
-To ensure graceful recovery if the APM Server is offline or there is a network partition, agents should only retry at a maximum every 5 seconds, regardless of Cache-Control headers being less than that value. If the Cache-Control header is zero (or less than zero), it should be treated as missing (i.e. use default retry time)
-
 To minimise the amount of work required by users, agents should aim to enable this feature by default. This excludes RUM, where there is a performance penalty.
 
 #### Interaction with local config
@@ -128,6 +126,8 @@ Central config failure. Invalid value for transactionSampleRate: 1.2 (out of ran
 ```
 
 Failure to process one config attribute should not affect processing of others.
+
+To ensure graceful recovery if the APM Server is offline or there is a network partition, agents should only retry at a maximum every 5 seconds, regardless of Cache-Control headers being less than that value. If the Cache-Control header is zero (or less than zero), it should be treated as missing (i.e. use default retry time)
 
 #### Feature flag
 

--- a/specs/agents/configuration.md
+++ b/specs/agents/configuration.md
@@ -127,7 +127,7 @@ Central config failure. Invalid value for transactionSampleRate: 1.2 (out of ran
 
 Failure to process one config attribute should not affect processing of others.
 
-To ensure graceful recovery if the APM Server is offline or there is a network partition, agents should only retry at a maximum every 5 seconds, regardless of Cache-Control headers being less than that value. If the Cache-Control header is zero (or less than zero), it should be treated as missing (i.e. use default retry time)
+To ensure graceful recovery if the APM Server is offline or there is a network partition, agents should only retry at a maximum every 5 seconds, regardless of Cache-Control headers being less than that value. If the Cache-Control header is zero (or less than zero), it should be treated as missing (i.e. use default retry time).
 
 #### Feature flag
 

--- a/specs/agents/configuration.md
+++ b/specs/agents/configuration.md
@@ -82,7 +82,7 @@ Agents should poll the APM Server for config periodically by sending an HTTP req
 
 The server will respond with a JSON object, where each key maps a config attribute to a string value. The string value should be interpreted the same as if it were passed in via an environment variable. Upon receiving these config changes, the agent will update its configuration dynamically, overriding any config previously specified. That is, config via Kibana takes highest precedence.
 
-To ensure graceful recovery if the APM Server is offline or there is a network partition, agents should only retry central configuration requests occasionally, and should add a modest random delay when retrying to avoid thundering herd issues when the partition resolves.
+To ensure graceful recovery if the APM Server is offline or there is a network partition, agents should only retry at a maximum every 5 seconds, regardless of Cache-Control headers being less than that value.
 
 To minimise the amount of work required by users, agents should aim to enable this feature by default. This excludes RUM, where there is a performance penalty.
 

--- a/specs/agents/configuration.md
+++ b/specs/agents/configuration.md
@@ -82,7 +82,7 @@ Agents should poll the APM Server for config periodically by sending an HTTP req
 
 The server will respond with a JSON object, where each key maps a config attribute to a string value. The string value should be interpreted the same as if it were passed in via an environment variable. Upon receiving these config changes, the agent will update its configuration dynamically, overriding any config previously specified. That is, config via Kibana takes highest precedence.
 
-To ensure graceful recovery if the APM Server is offline or there is a network partition, agents should only retry at a maximum every 5 seconds, regardless of Cache-Control headers being less than that value.
+To ensure graceful recovery if the APM Server is offline or there is a network partition, agents should only retry at a maximum every 5 seconds, regardless of Cache-Control headers being less than that value. If the Cache-Control header is zero (or less than zero), it should be treated as missing (i.e. use default retry time)
 
 To minimise the amount of work required by users, agents should aim to enable this feature by default. This excludes RUM, where there is a performance penalty.
 


### PR DESCRIPTION
In the Ruby Agent we had a report of unbounded memory growth when the central configuration server (APM Server) is offline and behind a reverse proxy which does not return empty payloads.

This behavior would be avoided if there were a minimum retry time and rate, per the spec change.

As these changes are optional and suggested, I opted for the shorter template without a meta issue.


- May the instrumentation collect sensitive information, such as secrets or PII (ex. in headers)?
  - [ ] Yes
    - [ ] Add a section to the spec how agents should apply sanitization (such as `sanitize_field_names`)
  - [x] No
    - [ ] Why?
  - [ ] n/a
- [x] Create PR as draft
- [x] Approval by at least one other agent
- [x] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [x] Approved by at least 2 agents + PM (if relevant)
- [ ] Merge after 7 days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.
- [ ] [Create implementation issues through the meta issue template](https://github.com/elastic/apm/issues/new?assignees=&labels=meta%2C+apm-agents&template=apm-agents-meta.md) (this will automate issue creation for individual agents)

/schedule 2022-09-21