### PR TITLE
Azure Service Bus: Clarify metadata

### DIFF
--- a/specs/agents/tracing-instrumentation-messaging.md
+++ b/specs/agents/tracing-instrumentation-messaging.md
@@ -212,7 +212,7 @@ so that cross-language tracing works:
 | Messaging system       | Mechanism |
 | ---------------------- | --------- |
 | Azure Queue            | No mechanism |
-| Azure Service Bus      | Possibly `Diagnostic-Id` [application property](https://docs.microsoft.com/en-us/dotnet/api/azure.messaging.servicebus.servicebusmessage.applicationproperties). See [this doc](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-end-to-end-tracing). |
+| Azure Service Bus      | `Diagnostic-Id` [application property](https://docs.microsoft.com/en-us/dotnet/api/azure.messaging.servicebus.servicebusmessage.applicationproperties). See [this doc](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-end-to-end-tracing). |
 | Java Messaging Service | [Message Properties](https://docs.oracle.com/javaee/7/api/javax/jms/Message.html) |
 | Apache Kafka           | [Kafka Record headers](https://cwiki.apache.org/confluence/display/KAFKA/KIP-82%2B-%2BAdd%2BRecord%2BHeaders) using [binary trace context fields](tracing-distributed-tracing.md#binary-fields) |
 | RabbitMQ               | [Message Attributes](https://www.rabbitmq.com/tutorials/amqp-concepts.html#messages) (a.k.a. `AMQP.BasicProperties` in [Java API](https://www.rabbitmq.com/api-guide.html)) |


### PR DESCRIPTION
So far, no agent had distributed tracing and span link support for Azure Service Bus. .NET implemented it recently and it uses the `diagnostic-id` application property - as suggested in the spec.

For clarity and better compatibility across agents,  this PR removes the word "possibly" - so `diagnostic-id` should be the default metadata for trace context propagation in case of Azure Service Bus.

- [x] Create PR as draft
- [ ] Approval by at least one other agent
- [ ] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [ ] Merge after 2 business days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.