### PR TITLE
Add ELB section for lambda instrumentation

### DIFF
--- a/specs/agents/tracing-instrumentation-aws-lambda.md
+++ b/specs/agents/tracing-instrumentation-aws-lambda.md
@@ -151,7 +151,7 @@ Field | Value | Description | Source
 ---   | ---   | ---         | ---
 `type` | `request`| Transaction type: constant value for ELB. | -
 `name` | e.g. `GET /prod/proxy/{proxy+}` | Transaction name: Http method followed by a whitespace and the (resource) path. See section below. | -
-`transaction.result` | `HTTP Xxx` / `success` | `HTTP 5xx` if there was a function error (see [Lambda error handling doc](https://docs.aws.amazon.com/lambda/latest/dg/services-apigateway.html#services-apigateway-errors). If the [invocation response has a "statusCode" field](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.response), then set to `HTTP Xxx` based on the status code, otherwise `success`. | Error or `response.statusCode`.
+`transaction.result` | `HTTP Xxx` / `success` | `HTTP 5xx` if there was a function error. If the [invocation response has a "statusCode" field](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/lambda-functions.html#respond-to-load-balancer), then set to `HTTP Xxx` based on the status code, otherwise `success`. | Error or `response.statusCode`.
 `faas.trigger.type` | `http` | Constant value for ELB. | -
 `faas.trigger.request_id` | e.g. `Root=1-xxxxxxxxxxxxxx` | AWS Trace ID of the ELB request. | `event.headers.x-amzn-trace-id`
 `context.service.origin.name` | e.g. `targetgroup/lambda...5c45c6791a` | ELB target group | Derived from the 6th segment of `event.requestContext.elb.targetGroupArn`

--- a/specs/agents/tracing-instrumentation-aws-lambda.md
+++ b/specs/agents/tracing-instrumentation-aws-lambda.md
@@ -82,7 +82,7 @@ Lambda functions can be triggered in many different ways. A generic transaction 
 
 If none of the above apply, the fallback should be a generic instrumentation (as described above) that can deal with any type of trigger (thus capturing only the minimal available information).
 
-### API Gateway (V1 & V2)
+### API Gateway / Lambda URLS
 There are two different API Gateway versions (V1 & V2) that differ slightly in the information (`event` object) that is passed to the Lambda handler function.
 
 With both versions, the `event` object contains information about the http request.
@@ -103,7 +103,7 @@ Field | Value | Description | Source
 `context.service.origin.name` | e.g. `gdnrpwmtsb...amazonaws.com` | The full domain name of the API Gateway. | `event.requestContext.domainName`
 `context.service.origin.id` | e.g. `gy415nu...` | `event.requestContext.apiId` |
 `context.service.origin.version` | e.g. `1.0` | `1.0` for API Gateway V1, `2.0` for API Gateway V2. | `event.version` (or `1.0` if that field is not present)
-`context.cloud.origin.service.name` | `api gateway` | Constant value for API gateway. | -
+`context.cloud.origin.service.name` | `api gateway` or `lambda url` | Constant value. | Detect lambda URLs by searching for `.lambda-url.` in the URL. Otherwise assume API Gateway.
 `context.cloud.origin.account.id` | e.g. `12345678912` | Account ID of the API gateway. | `event.requestContext.accountId`
 `context.cloud.origin.provider` | `aws` | Use `aws` as constant value. | -
 

--- a/specs/agents/tracing-instrumentation-aws-lambda.md
+++ b/specs/agents/tracing-instrumentation-aws-lambda.md
@@ -140,6 +140,7 @@ of API Gateway. In this case the `event` object will be structured differently.
 The agent should use the information in the request and response objects to
 fill the HTTP context (`context.request` and `context.response`) fields in the
 same way it is done for HTTP transactions.
+[Request/Response Docs](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/lambda-functions.html#receive-event-from-load-balancer)
 
 In particular, agents must use the `event.headers` to retrieve the
 `traceparent` and the `tracestate` and use them to start the transaction for
@@ -153,11 +154,12 @@ Field | Value | Description | Source
 `name` | e.g. `GET /prod/proxy/{proxy+}` | Transaction name: Http method followed by a whitespace and the (resource) path. See section below. | -
 `transaction.result` | `HTTP Xxx` / `success` | `HTTP 5xx` if there was a function error. If the [invocation response has a "statusCode" field](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/lambda-functions.html#respond-to-load-balancer), then set to `HTTP Xxx` based on the status code, otherwise `success`. | Error or `response.statusCode`.
 `faas.trigger.type` | `http` | Constant value for ELB. | -
-`faas.trigger.request_id` | e.g. `Root=1-xxxxxxxxxxxxxx` | AWS Trace ID of the ELB request. | `event.headers.x-amzn-trace-id`
+`faas.trigger.request_id` | e.g. `Root=1-5bdb40ca-556d8b0c50dc66f0511bf520` | AWS Trace ID of the ELB request. | `event.headers.x-amzn-trace-id`
 `context.service.origin.name` | e.g. `targetgroup/lambda...5c45c6791a` | ELB target group | Derived from the 6th segment of `event.requestContext.elb.targetGroupArn`
 `context.service.origin.id` | e.g. `arn:aws:elasticlo...65c45c6791a` | ELB target group ARN | `event.requestContext.elb.targetGroupArn` |
 `context.cloud.origin.service.name` | `elb` | Constant value for ELB. | -
 `context.cloud.origin.account.id` | e.g. `123456789012` | Account ID for the ELB. | Derived from the 5th segment of `event.requestContext.elb.targetGroupArn`
+`context.cloud.origin.region` | e.g. `us-east-2` | Cloud region. | Derived from the 4th segment of `event.requestContext.elb.targetGroupArn`
 `context.cloud.origin.provider` | `aws` | Use `aws` as constant value. | -
 
 Note that the `context.service.origin.version` is omitted for ELB requests.
@@ -182,7 +184,7 @@ An example ELB event:
         "connection": "Keep-Alive",
         "host": "blabla.com",
         "user-agent": "Apache-HttpClient/4.5.13 (Java/11.0.15)",
-        "x-amzn-trace-id": "Root=1-xxxxxxxxxxxxxx",
+        "x-amzn-trace-id": "Root=1-5bdb40ca-556d8b0c50dc66f0511bf520",
         "x-forwarded-for": "199.99.99.999",
         "x-forwarded-port": "443",
         "x-forwarded-proto": "https"

--- a/specs/agents/tracing-instrumentation-aws-lambda.md
+++ b/specs/agents/tracing-instrumentation-aws-lambda.md
@@ -103,7 +103,7 @@ Field | Value | Description | Source
 `context.service.origin.name` | e.g. `gdnrpwmtsb...amazonaws.com` | The full domain name of the API Gateway. | `event.requestContext.domainName`
 `context.service.origin.id` | e.g. `gy415nu...` | `event.requestContext.apiId` |
 `context.service.origin.version` | e.g. `1.0` | `1.0` for API Gateway V1, `2.0` for API Gateway V2. | `event.version` (or `1.0` if that field is not present)
-`context.cloud.origin.service.name` | `api gateway` or `lambda url` | Constant value. | Detect lambda URLs by searching for `.lambda-url.` in the URL. Otherwise assume API Gateway.
+`context.cloud.origin.service.name` | `api gateway` or `lambda url` | Constant value. | Detect lambda URLs by searching for `.lambda-url.` in the `event.requestContext.domainName`. Otherwise assume API Gateway.
 `context.cloud.origin.account.id` | e.g. `12345678912` | Account ID of the API gateway. | `event.requestContext.accountId`
 `context.cloud.origin.provider` | `aws` | Use `aws` as constant value. | -
 

--- a/specs/agents/tracing-instrumentation-aws-lambda.md
+++ b/specs/agents/tracing-instrumentation-aws-lambda.md
@@ -154,8 +154,7 @@ Field | Value | Description | Source
 `name` | e.g. `GET /prod/proxy/{proxy+}` | Transaction name: Http method followed by a whitespace and the (resource) path. See section below. | -
 `transaction.result` | `HTTP Xxx` / `success` | `HTTP 5xx` if there was a function error. If the [invocation response has a "statusCode" field](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/lambda-functions.html#respond-to-load-balancer), then set to `HTTP Xxx` based on the status code, otherwise `success`. | Error or `response.statusCode`.
 `faas.trigger.type` | `http` | Constant value for ELB. | -
-`faas.trigger.request_id` | e.g. `Root=1-5bdb40ca-556d8b0c50dc66f0511bf520` | AWS Trace ID of the ELB request. | `event.headers.x-amzn-trace-id`
-`context.service.origin.name` | e.g. `targetgroup/lambda...5c45c6791a` | ELB target group | Derived from the 6th segment of `event.requestContext.elb.targetGroupArn`
+`context.service.origin.name` | e.g. `targetgroup` | ELB target group | `event.requestContext.elb.targetGroupArn` is formed as `arn:aws:elasticloadbalancing:region-code:account-id:targetgroup/target-group-name/target-group-id`, so use `targetGroupArn.split(':')[5].split('/')[1]` to get the `target-group-name`.
 `context.service.origin.id` | e.g. `arn:aws:elasticlo...65c45c6791a` | ELB target group ARN | `event.requestContext.elb.targetGroupArn` |
 `context.cloud.origin.service.name` | `elb` | Constant value for ELB. | -
 `context.cloud.origin.account.id` | e.g. `123456789012` | Account ID for the ELB. | Derived from the 5th segment of `event.requestContext.elb.targetGroupArn`

--- a/specs/agents/tracing-instrumentation-aws-lambda.md
+++ b/specs/agents/tracing-instrumentation-aws-lambda.md
@@ -157,7 +157,7 @@ Field | Value | Description | Source
 `context.service.origin.name` | e.g. `targetgroup/lambda...5c45c6791a` | ELB target group | Derived from the 6th segment of `event.requestContext.elb.targetGroupArn`
 `context.service.origin.id` | e.g. `arn:aws:elasticlo...65c45c6791a` | ELB target group ARN | `event.requestContext.elb.targetGroupArn` |
 `context.cloud.origin.service.name` | `elb` | Constant value for ELB. | -
-`context.cloud.origin.account.id` | e.g. `123456789012` | Account ID of the ELB. | Derived from the 5th segment of `event.requestContext.elb.targetGroupArn`
+`context.cloud.origin.account.id` | e.g. `123456789012` | Account ID for the ELB. | Derived from the 5th segment of `event.requestContext.elb.targetGroupArn`
 `context.cloud.origin.provider` | `aws` | Use `aws` as constant value. | -
 
 Note that the `context.service.origin.version` is omitted for ELB requests.


### PR DESCRIPTION
Elastic Load Balancer (ELB) can now be attached to lambda functions directly, without an API Gateway. This necessitates an additional section for event parsing. 

There is no obvious candidate for `trigger.request_id`, so I've omitted it for this trigger type.

I've also removed the `context.service.origin.version` as compared to API gateway, since it's not relevant for ELB.

Python implementation [here](https://github.com/elastic/apm-agent-python/pull/1605)

- [x] Create PR as draft
- [x] Approval by at least one other agent
- [x] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [x] Approved by at least 2 agents + PM (if relevant)
- [ ] Merge after 7 days passed without objections
- [ ] [Create implementation issues through the meta issue template](https://github.com/elastic/apm/issues/new?assignees=&labels=meta%2C+apm-agents&template=apm-agents-meta.md) (this will automate issue creation for individual agents)

/schedule 2022-08-30
