### PR TITLE
Add elasticsearch_capture_body_urls option

### DIFF
--- a/specs/agents/tracing-instrumentation-db.md
+++ b/specs/agents/tracing-instrumentation-db.md
@@ -125,12 +125,7 @@ The following fields are relevant for database and datastore spans. Where possib
 | __**context.http._**__ |<hr/>|<hr/>|
 |`_.status_code`|`200`|
 |`_.method`|`GET`|
-|`_.url.full`|`https://localhost:9200/index/_search?q=user.id:kimchy`|
-|`_.url.protocol`|`https`|
-|`_.url.hostname`|`localhost`|
-|`_.url.port`|`9200`|
-|`_.url.pathname`|`/index/_search`|
-|`_.url.search`|`q=user.id:kimchy`|
+|`_.url`|`https://localhost:9200/index/_search?q=user.id:kimchy`|
 | __**context.destination._**__ |<hr/>|<hr/>|
 |`_.address`|e.g. `localhost`|
 |`_.port`|e.g. `5432`|

--- a/specs/agents/tracing-instrumentation-db.md
+++ b/specs/agents/tracing-instrumentation-db.md
@@ -155,7 +155,7 @@ The Elasticsearch cluster name is not always available in ES clients, as a resul
 The URL patterns for which the agent is capturing the request body for Elasticsearch clients.
  
 Agents MAY offer this configuration option.
-If they don't, they MUST use hard-coded list of URLs that correspond with the default value of this option.
+If they don't, they MUST use a hard-coded list of URLs that correspond with the default value of this option.
 
 |                |            |
 |----------------|------------|

--- a/specs/agents/tracing-instrumentation-db.md
+++ b/specs/agents/tracing-instrumentation-db.md
@@ -117,7 +117,7 @@ The following fields are relevant for database and datastore spans. Where possib
 |`action`| `request` |
 | __**context.db._**__  |<hr/>|<hr/>|
 |`_.instance`| e.g. `my-cluster` | [Cluster name](#cluster-name), if available.
-|`_.statement`| e.g. <pre lang="json">{"query": {"match": {"user.id": "kimchy"}}}</pre> | For Elasticsearch search-type queries, the request body SHOULD be recorded according to the `elasticsearch_capture_body_urls` option (see below). If the body is gzip-encoded, the body should be decoded first.|
+|`_.statement`| e.g. <pre lang="json">{"query": {"match": {"user.id": "kimchy"}}}</pre> | For Elasticsearch search-type queries, the request body SHOULD be recorded according to the `elasticsearch_capture_body_urls` option (see below). If the body is gzip-encoded, the body MUST be decoded first.|
 |`_.type`|`elasticsearch`|
 |`_.user`| :heavy_minus_sign: |
 |`_.link`| :heavy_minus_sign: |

--- a/specs/agents/tracing-instrumentation-db.md
+++ b/specs/agents/tracing-instrumentation-db.md
@@ -117,11 +117,20 @@ The following fields are relevant for database and datastore spans. Where possib
 |`action`| `request` |
 | __**context.db._**__  |<hr/>|<hr/>|
 |`_.instance`| e.g. `my-cluster` | [Cluster name](#cluster-name), if available.
-|`_.statement`| e.g. <pre lang="json">{"query": {"match": {"user.id": "kimchy"}}}</pre> | For Elasticsearch search-type queries, the request body may be recorded. Alternatively, if a query is specified in HTTP query parameters, that may be used instead. If the body is gzip-encoded, the body should be decoded first.|
+|`_.statement`| e.g. <pre lang="json">{"query": {"match": {"user.id": "kimchy"}}}</pre> | For Elasticsearch search-type queries, the request body SHOULD be recorded according to the `elasticsearch_capture_body_urls` option (see below). If the body is gzip-encoded, the body should be decoded first.|
 |`_.type`|`elasticsearch`|
 |`_.user`| :heavy_minus_sign: |
 |`_.link`| :heavy_minus_sign: |
 |`_.rows_affected`| :heavy_minus_sign: |
+| __**context.http._**__ |<hr/>|<hr/>|
+|`_.status_code`|`200`|
+|`_.method`|`GET`|
+|`_.url.full`|`https://localhost:9200/index/_search?q=user.id:kimchy`|
+|`_.url.protocol`|`https`|
+|`_.url.hostname`|`localhost`|
+|`_.url.port`|`9200`|
+|`_.url.pathname`|`/index/_search`|
+|`_.url.search`|`q=user.id:kimchy`|
 | __**context.destination._**__ |<hr/>|<hr/>|
 |`_.address`|e.g. `localhost`|
 |`_.port`|e.g. `5432`|
@@ -140,6 +149,19 @@ The Elasticsearch cluster name is not always available in ES clients, as a resul
 - Use `x-found-handling-cluster` HTTP response header value.
 - Instrument `_node/http` calls and cache the result in the agent with `host:port` as key.
 - execute a request to Elasticsearch and cache the result in the agent with `host:port` as key.
+
+#### `elasticsearch_capture_body_urls` configuration
+
+The URL patterns for which the agent is capturing the request body for Elasticsearch clients.
+ 
+Agents MAY offer this configuration option.
+If they don't, they MUST use hard-coded list of URLs that correspond with the default value of this option.
+
+|                |            |
+|----------------|------------|
+| Type           | `List<`[`WildcardMatcher`](../../tests/agents/json-specs/wildcard_matcher_tests.json)`>` |
+| Default        | `*_search, *_msearch, *_msearch/template, *_search/template, *_count`                    |
+| Central config | `false`                                                                                  |
 
 ### MongoDB
 

--- a/specs/agents/tracing-instrumentation-db.md
+++ b/specs/agents/tracing-instrumentation-db.md
@@ -160,7 +160,7 @@ If they don't, they MUST use a hard-coded list of URLs that correspond with the 
 |                |            |
 |----------------|------------|
 | Type           | `List<`[`WildcardMatcher`](../../tests/agents/json-specs/wildcard_matcher_tests.json)`>` |
-| Default        | `*_search, *_msearch, *_msearch/template, *_search/template, *_count`                    |
+| Default        | `*/_search, */_search/template, */_msearch, */_msearch/template, */_async_search, */_count, */_sql, */_eql/search`|
 | Central config | `false`                                                                                  |
 
 ### MongoDB


### PR DESCRIPTION
Refs: https://github.com/elastic/apm-agent-nodejs/issues/2019
Closes: #665

We're only expecting to implement this in the Node.js agent in the near future.
Other agents may add this to their roadmap as they see fit but we won't create a cross-agent tracking issue.

- May the instrumentation collect sensitive information, such as secrets or PII (ex. in headers)?
  - [x] Yes
    - [x] Add a section to the spec how agents should apply sanitization (such as `sanitize_field_names`) We're only capturing the request body for search requests by default to minimize the risk. Users can also add a custom ingest node pipeline to parse and redact JSON if needed.
  - [ ] No
    - [ ] Why?
  - [ ] n/a
- [x] Create PR as draft
- [x] Approval by at least one other agent
- [x] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [x] Approved by at least 2 agents + PM (if relevant)
- [ ] Merge after 7 days passed without objections
- [x] [Create implementation issues through the meta issue template](https://github.com/elastic/apm/issues/new?assignees=&labels=meta%2C+apm-agents&template=apm-agents-meta.md) (this will automate issue creation for individual agents)

/schedule 2022-08-18