### PR TITLE
Backend granularity (service.target.*) clarifications

### DIFF
--- a/specs/agents/handling-huge-traces/tracing-spans-compress.md
+++ b/specs/agents/handling-huge-traces/tracing-spans-compress.md
@@ -87,7 +87,7 @@ boolean isSameKind(Span other) {
 }
 ```
 
-When applying this compression strategy, the `span.name` is set to `Calls to <...>` determined as follows:
+When applying this compression strategy, the `span.name` is set to `Calls to <...>` determined from `service.target.*` as follows:
 
 ```js
 function getCompositeSpanName(serviceTarget) {

--- a/specs/agents/handling-huge-traces/tracing-spans-compress.md
+++ b/specs/agents/handling-huge-traces/tracing-spans-compress.md
@@ -87,7 +87,25 @@ boolean isSameKind(Span other) {
 }
 ```
 
-When applying this compression strategy, the `span.name` is set to `Calls to $span.destination.service.resource`.
+When applying this compression strategy, the `span.name` is set to `Calls to <...>` determined as follows:
+
+```js
+function getCompositeSpanName(serviceTarget) {
+    const prefix = 'Calls to '
+    if (!serviceTarget.type) {
+        if (!serviceTarget.name) {
+            return prefix + 'unknown'
+        } else {
+            return prefix + serviceTarget.name
+        }
+    } else if (!serviceTarget.name) {
+        return prefix + serviceTarget.type
+    } else {
+        return prefix + serviceTarget.type + '/' + serviceTarget.name
+    }
+}
+```
+
 The rest of the context, such as the `db.statement` will be determined by the first compressed span, which is turned into a composite span.
 
 ### Configuration option `span_compression_same_kind_max_duration`

--- a/specs/agents/tracing-instrumentation-db.md
+++ b/specs/agents/tracing-instrumentation-db.md
@@ -227,7 +227,7 @@ The Elasticsearch cluster name is not always available in ES clients, as a resul
 | MySQL                | `mysql`     |
 | MariaDB              | `mariadb`   |
 | PostgreSQL           | `postgresql`|
-| Microsoft SQL server | `sqlserver` |
+| Microsoft SQL server | `mssql`     |
 | Oracle               | `oracle`    |
 | IBM Db2              | `db2`       |
 

--- a/specs/agents/tracing-spans-destination.md
+++ b/specs/agents/tracing-spans-destination.md
@@ -70,19 +70,21 @@ Same cardinality otherwise.
 
 **API**
 
-Agents SHOULD offer a public API to set this field so that users can customize the value if the generic mapping is not 
-sufficient. If set to `null` or an empty value, agents MUST omit the `span.destination.service` field altogether, thus 
-providing a way to manually disable the automatic setting/inference of this field (e.g. in order to remove a node 
+Agents SHOULD offer a public API to set this field so that users can customize the value if the generic mapping is not
+sufficient. If set to `null` or an empty value, agents MUST omit the `span.destination.service` field altogether, thus
+providing a way to manually disable the automatic setting/inference of this field (e.g. in order to remove a node
 from a service map or an external service from the dependencies table).
 A user-supplied value MUST have the highest precedence, regardless if it was set before or after the automatic setting is invoked.
 
 **Value**
 
-For all [exit spans](tracing-spans.md#exit-spans), unless the `context.destination.service.resource` field was set by the user to `null` or an empty 
+For all [exit spans](tracing-spans.md#exit-spans), unless the `context.destination.service.resource` field was set by the user to `null` or an empty
 string through API, agents MUST infer the value of this field based on properties that are set on the span.
 
-If no value is set to the `context.destination.service.resource` field, the logic for automatically inferring 
+If no value is set to the `context.destination.service.resource` field, the logic for automatically inferring
 it MUST be the following:
+
+Q3: Though above it is says "value should be inferred from `context.service.target.*` fields", this pseudo-code does not consider service.target. Should this be updated to calculate from service.target?
 
 ```groovy
 if (context.db)
@@ -91,20 +93,20 @@ if (context.db)
   else
     subtype ?: type
 else if (context.message)
-  if (context.message.queue?.name) 
+  if (context.message.queue?.name)
     "${subtype ?: type}/${context.message.queue.name}"
   else
     subtype ?: type
 else if (context.http?.url)
-  if (context.http.url.port > 0)  
+  if (context.http.url.port > 0)
     "${context.http.url.host}:${context.http.url.port}"
   else if (context.http.url.host)
     context.http.url.host
-else 
+else
   subtype ?: type
 ```
 
-If an agent API was used to set the `context.destination.service.resource` to `null` or an empty string, agents MUST 
+If an agent API was used to set the `context.destination.service.resource` to `null` or an empty string, agents MUST
 omit the `context.destination.service` field from the reported span event.
 
 The inference of `context.destination.service.resource` SHOULD be implemented in a central place within the agent,
@@ -134,7 +136,7 @@ ES field: [`destination.address`](https://www.elastic.co/guide/en/ecs/current/ec
 
 Address is the destination network address: hostname (e.g. `localhost`), FQDN (e.g. `elastic.co`), IPv4 (e.g. `127.0.0.1`) IPv6 (e.g. `::1`)
 
-Agents MAY offer a public API to set this field so that users can override the automatically discovered one. 
+Agents MAY offer a public API to set this field so that users can override the automatically discovered one.
 This includes the ability to set `null` or empty value in order to unset the automatically-set value.
 A user-supplied value MUST have the highest precedence, regardless of whether it was set before or after the automatic setting is invoked.
 
@@ -144,6 +146,6 @@ ES field: [`destination.port`](https://www.elastic.co/guide/en/ecs/current/ecs-d
 
 Port is the destination network port (e.g. 443)
 
-Agents MAY offer a public API to set this field so that users can override the automnatically discovered one. 
+Agents MAY offer a public API to set this field so that users can override the automnatically discovered one.
 This includes the ability to set a non-positive value in order to unset the automatically-set value.
 A user-supplied value MUST have the highest precedence, regardless of whether it was set before or after the automatic setting is invoked.

--- a/specs/agents/tracing-spans-service-target.md
+++ b/specs/agents/tracing-spans-service-target.md
@@ -136,7 +136,6 @@ if (span.isExit) {
         service_target.name += ":" + port;
       }
     }
-
   }
 } else {
     // non-exit spans should not have service.target.* fields

--- a/specs/agents/tracing-spans-service-target.md
+++ b/specs/agents/tracing-spans-service-target.md
@@ -113,19 +113,21 @@ span = {};
 if (span.isExit) {
   service_target = span.context.service.target;
 
-  if ('type' in service_target) { // if not manually specified, infer type from span type & subtype
-
-    // use sub-type if provided, fallback on type othewise
+  if ('type' in service_target) { // If not manually specified, infer type from span type & subtype.
     service_target.type = span.subtype || span.type;
   }
 
-  if (!service_target.name) { // infer name from span attributes
+  if (!service_target.name) { // If not manually specified, infer name from span attributes.
 
     if (span.context.db) {  // database spans
-      service_target.name = span.context.db.instance;
+      if (span.context.db.instance) {
+        service_target.name = span.context.db.instance;
+      }
 
     } else if (span.context.message) { // messaging spans
-      service_target.name = span.context.message.queue?.name
+      if (span.context.message.queue?.name) {
+        service_target.name = span.context.message.queue?.name
+      }
 
     } else if (context.http?.url) { // http spans
       service_target.name = getHostFromUrl(context.http.url);

--- a/specs/agents/tracing-spans-service-target.md
+++ b/specs/agents/tracing-spans-service-target.md
@@ -117,7 +117,7 @@ if (span.isExit) {
     service_target.type = span.subtype || span.type;
   }
 
-  if (!service_target.name) { // If not manually specified, infer name from span attributes.
+  if ('name' in service_target) { // If not manually specified, infer name from span attributes.
 
     if (span.context.db) {  // database spans
       if (span.context.db.instance) {

--- a/specs/agents/tracing-spans-service-target.md
+++ b/specs/agents/tracing-spans-service-target.md
@@ -90,7 +90,7 @@ Because there are a lots of moving pieces, implementation will be split into mul
 
 (2) Value is always sent by APM agents for compatibility, but they SHOULD NOT rely on it internally.
 
-(3) HTTP spans (and a few other spans) can't have their `resource` value inferred on APM server without relying on a 
+(3) HTTP spans (and a few other spans) can't have their `resource` value inferred on APM server without relying on a
 brittle mapping on span `type` and `subtype` and breaking the breakdown metrics where `type` and `subtype` are not available.
 
 ## Implementation details
@@ -104,29 +104,30 @@ This specification assumes that values for `span.type` and `span.subtype` fit th
 - `span.context.service.target.type` should have the same value as `span.subtype` and fallback to `span.type`.
 - `span.context.service.target.name` depends on the span context attributes
 
-On agents, the following algorithm should be used to infer the values for `span.context.service.target.*` fields. 
+On agents, the following algorithm should be used to infer the values for `span.context.service.target.*` fields.
+
 ```javascript
 // span created on agent
 span = {};
 
 if (span.isExit) {
   service_target = span.context.service.target;
-  
-  if (!service_target.type) { // infer type from span type & subtype
-      
+
+  if ('type' in service_target) { // if not manually specified, infer type from span type & subtype
+
     // use sub-type if provided, fallback on type othewise
     service_target.type = span.subtype || span.type;
   }
-  
+
   if (!service_target.name) { // infer name from span attributes
-      
-    if (span.context.db.instance) {  // database spans
+
+    if (span.context.db) {  // database spans
       service_target.name = span.context.db.instance;
 
     } else if (span.context.message) { // messaging spans
-      service_target.name = span.context.message.queue.name
+      service_target.name = span.context.message.queue?.name
 
-    } else if (context.http.url) { // http spans
+    } else if (context.http?.url) { // http spans
       service_target.name = getHostFromUrl(context.http.url);
       port = getPortFromUrl(context.http.url);
       if (port > 0) {

--- a/specs/agents/tracing-spans-service-target.md
+++ b/specs/agents/tracing-spans-service-target.md
@@ -105,10 +105,7 @@ This specification assumes that values for `span.type` and `span.subtype` fit th
 - `span.context.service.target.name` depends on the span context attributes
 
 On agents, the following algorithm should be used to infer the values for `span.context.service.target.*` fields.
-<<<<<<< HEAD
 
-=======
->>>>>>> main
 ```javascript
 // span created on agent
 span = {};

--- a/specs/agents/tracing-spans-service-target.md
+++ b/specs/agents/tracing-spans-service-target.md
@@ -113,11 +113,11 @@ span = {};
 if (span.isExit) {
   service_target = span.context.service.target;
 
-  if ('type' in service_target) { // If not manually specified, infer type from span type & subtype.
+  if (!('type' in service_target)) { // If not manually specified, infer type from span type & subtype.
     service_target.type = span.subtype || span.type;
   }
 
-  if ('name' in service_target) { // If not manually specified, infer name from span attributes.
+  if (!('name' in service_target)) { // If not manually specified, infer name from span attributes.
 
     if (span.context.db) {  // database spans
       if (span.context.db.instance) {


### PR DESCRIPTION
I have some questions and clarifications on the `service.target.*` backend granularity changes. I'll try to ask them in comments and code-review-comments below.

**Update 2022-09-13:** There was a lot of earlier discussion of Q1 - Q7 on this PR. If you are a new reviewer of this PR, you can probably skip all that earlier discussion and just look at the current file changes. I added some "REVIEW NOTE:" review comments that add context.

# checklist

- [x] Create PR as draft
- [x] Q1: https://github.com/elastic/apm/pull/674#discussion_r948234750
- [x] Q2: https://github.com/elastic/apm/pull/674#discussion_r948247633
- [x] Q3: https://github.com/elastic/apm/pull/674#discussion_r948261082
- [x] Q4: https://github.com/elastic/apm/pull/674#issuecomment-1218331422
- [x] Q5: https://github.com/elastic/apm/pull/674#issuecomment-1218332813
- [x] Q6: https://github.com/elastic/apm/pull/674#issuecomment-1218651417
- [x] Q7: https://github.com/elastic/apm/pull/674#issuecomment-1219784156 (I'll move this discussion of S3 span fields to a separate issue/PR.)
- [x] Approval by at least one other agent
- [x] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [x] Approved by at least 2 agents + PM (if relevant)
- [x] Merge after 7 days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.
- [ ] [Create implementation issues through the meta issue template](https://github.com/elastic/apm/issues/new?assignees=&labels=meta%2C+apm-agents&template=apm-agents-meta.md) (this will automate issue creation for individual agents)
