### PR TITLE
Ignore *principal* headers by default

### DIFF
--- a/specs/agents/sanitization.md
+++ b/specs/agents/sanitization.md
@@ -16,7 +16,7 @@ how an agent will sanitize data.
 |                |   |
 |----------------|---|
 | Type           | `List<`[`WildcardMatcher`](../../tests/agents/json-specs/wildcard_matcher_tests.json)`>` |
-| Default        | `password, passwd, pwd, secret, *key, *token*, *session*, *credit*, *card*, *auth*, set-cookie` |
+| Default        | `password, passwd, pwd, secret, *key, *token*, *session*, *credit*, *card*, *auth*, set-cookie, *principal*` |
 | Dynamic        | `true` |
 | Central config | `true` |
 
@@ -25,7 +25,7 @@ how an agent will sanitize data.
 Agents MUST provide a minimum default configuration of
 
     [ 'password', 'passwd', 'pwd', 'secret', '*key', '*token*', '*session*',
-      '*credit*','*card*', '*auth*', 'set-cookie']
+      '*credit*','*card*', '*auth*', 'set-cookie', '*principal*' ]
 
 for the `sanitize_field_names` configuration value.  Agent's MAY include the
 following extra fields in their default configuration to avoid breaking changes


### PR DESCRIPTION
Discovered while testing APM agent deployment in Azure with Azure-provided SSO.

Because agents capture all HTTP headers by default, the following headers are being captured when Azure SSO:
- `X-Ms-Client-Principal` which is a base64 encoding of the JSON payload that the application receives from the SSO
- `Ms-Client-Principal-Id` : seems a technical UUID, but that could be a PII too.
- `X-Ms-Client-Principal-Idp`: value is `aad` thus seems related to ActiveDirectory
- `X-Ms-Client-Principal-Name`: the end-user name, which is definitely part of PII depending on the context.

While the user name might be captured by some APM agents automatically, there is no need to capture those by default, plus all the fields that are part of the JSON payload might expose other PII.

We currently do not have a way to just ignore those headers, thus the proposal is to just redact them by default.

-----

- May the instrumentation collect sensitive information, such as secrets or PII (ex. in headers)?
  - [x] No
    - [x] Why? this PR adds removing already captured headers
- [x] Create PR as draft
- [x] Approval by at least one other agent
- [x] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [x] Approved by at least 2 agents + PM (if relevant)
- [ ] Merge after 7 days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.
- [ ] [Create implementation issues through the meta issue template](https://github.com/elastic/apm/issues/new?assignees=&labels=meta%2C+apm-agents&template=apm-agents-meta.md) (this will automate issue creation for individual agents)

/schedule 2022-09-19