### PR TITLE
Remove context.db from S3 spans: S3 isn't a database

### DIFF
--- a/specs/agents/tracing-instrumentation-db.md
+++ b/specs/agents/tracing-instrumentation-db.md
@@ -78,13 +78,6 @@ The following fields are relevant for database and datastore spans. Where possib
 |`type`|`storage`|
 |`subtype`|`s3`|
 |`action`| e.g. `GetObject` | The operation name in PascalCase. |
-| __**context.db._**__  |<hr/>|<hr/>|
-|`_.instance`| e.g. `us-east-1` | The AWS region where the bucket is. |
-|`_.statement`| :heavy_minus_sign: |  |
-|`_.type`|`s3`|
-|`_.user`| :heavy_minus_sign: |
-|`_.link`| :heavy_minus_sign: |
-|`_.rows_affected`| :heavy_minus_sign: |
 | __**context.destination._**__ |<hr/>|<hr/>|
 |`_.address`|e.g. `s3.amazonaws.com`| Not available in some cases. Only set if the actual connection is available. |
 |`_.port`|e.g. `443`| Not available in some cases. Only set if the actual connection is available. |
@@ -153,7 +146,7 @@ The Elasticsearch cluster name is not always available in ES clients, as a resul
 #### `elasticsearch_capture_body_urls` configuration
 
 The URL patterns for which the agent is capturing the request body for Elasticsearch clients.
- 
+
 Agents MAY offer this configuration option.
 If they don't, they MUST use a hard-coded list of URLs that correspond with the default value of this option.
 
@@ -161,7 +154,7 @@ If they don't, they MUST use a hard-coded list of URLs that correspond with the 
 |----------------|------------|
 | Type           | `List<`[`WildcardMatcher`](../../tests/agents/json-specs/wildcard_matcher_tests.json)`>` |
 | Default        | `*/_search, */_search/template, */_msearch, */_msearch/template, */_async_search, */_count, */_sql, */_eql/search`|
-| Central config | `false`     
+| Central config | `false`
 
 ### MongoDB
 


### PR DESCRIPTION
S3 isn't a DB. It is specified to have `span.type == "storage"`, not `"db"`.
I believe `context.db.*` was added to the spec for S3 spans *by accident* (see below).
I propose that we (a) drop `context.db.*` from the spec for S3 spans and (b) possibly move the "S3" spec section out of "tracing-instrumentation-db.md" (either back to the AWS spec file, or a new "storage" spec file).

By comparison, our spec for other "storage" spans -- [Azure Blob Storage](https://github.com/elastic/apm/blob/main/specs/agents/tracing-instrumentation-azure.md#blob-storage), Azure Files, Azure Storage Table -- do not specify adding `context.db.*`.

Current (experimental) [OTel semantic conventions for AWS SDK](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/instrumentation/aws-sdk.md) do not provide any details specific to S3 that we might want to align with.

Currently S3 `context.db.instance` is specified to be the target region. A better field for the target region is the [ECS `cloud.target.region` field](https://www.elastic.co/guide/en/ecs/current/ecs-cloud.html#field-cloud-region). We already specify `span.context.destination.cloud.region` for this. We just need to (a) get the intake API to use it and (b) move the ECS field to Stage 3 (as discussed here: https://github.com/elastic/ecs/issues/1282). (Arguably we could drop `context.db.instance = $region` from the *DynamoDB* spec as well.)


# Open questions

- Does dropping `context.db.*` for S3 spans impact APM UI? I don't think so, but I might have missed something.


# History of "context.db" for S3 spans

I believe #420 may have *accidentally* added `context.db` to the spec for S3 as part of a refactor. That change refactored DynamoDB and S3 specs from "tracing-instrumentation-aws.md" to "specs/agents/tracing-instrumentation-db.md". In the process, `context.db.*` fields were added for S3... copying the values from the DynamoDB section:

```
| __**context.db._**__  |<hr/>|<hr/>|
|`_.instance`| e.g. `us-east-1` | The AWS region where the table is. |
|`_.statement`| - |  |
|`_.type`|`dynamodb`|
```

PR #451 followed up later to fix the copypasta:

```
| __**context.db._**__  |<hr/>|<hr/>|
|`_.instance`| e.g. `us-east-1` | The AWS region where the bucket is. |
|`_.statement`| - |  |
|`_.type`|`s3`|
```

From the discussion on #420, I don't see that there was specific intent to add `context.db` for S3 spans.



# checklist 

- May the instrumentation collect sensitive information, such as secrets or PII (ex. in headers)?
  - [ ] Yes
    - [ ] Add a section to the spec how agents should apply sanitization (such as `sanitize_field_names`)
  - [ ] No
    - [ ] Why?
  - [x] n/a
- [x] Create PR as draft
- [x] Approval by at least one other agent
- [x] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [x] Approved by at least 2 agents + PM (if relevant)
- [x] Merge after 7 days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.
- [ ] [Create implementation issues through the meta issue template](https://github.com/elastic/apm/issues/new?assignees=&labels=meta%2C+apm-agents&template=apm-agents-meta.md) (this will automate issue creation for individual agents)
