### PR TITLE
Synchronize json-specs into apm-agent-dotnet tests

### DIFF
--- a/.ci/.jenkins-agents.yml
+++ b/.ci/.jenkins-agents.yml
@@ -2,6 +2,7 @@
 agents:
   - REPO: "apm-agent-dotnet"
     FEATURES_PATH: "test/Elastic.Apm.Feature.Tests/Features"
+    JSON_SPECS_PATH: "test/Elastic.Apm.Tests/TestResources/json-specs"
   - REPO: "apm-agent-go"
     FEATURES_PATH: "features"
     JSON_SPECS_PATH: "internal/testdata/json-specs"


### PR DESCRIPTION
Make sure that `json-spec` documents automatically get synchronized into the `apm-agent-dotnet` repo.
(Note: actually using these data in tests will be a dedicated issue/PR.)