### PR TITLE
Extend json-specs tests with cgroup-parsing

### DIFF
--- a/specs/agents/metadata.md
+++ b/specs/agents/metadata.md
@@ -110,6 +110,8 @@ On Linux, the container ID and some of the Kubernetes metadata can be extracted 
 
 If the Kubernetes pod name is not the hostname, it can be overridden by the `KUBERNETES_POD_NAME` environment variable, using the [Downward API](https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/). In a similar manner, you can inform the agent of the node name and namespace, using the environment variables `KUBERNETES_NODE_NAME` and `KUBERNETES_NAMESPACE`.
 
+*Note:* [cgroup_parsing.json](../../tests/agents/json-specs/cgroup_parsing.json) provides test cases for parsing cgroup lines.
+
 ### Process metadata
 
 Process level metadata relates to the process running the service being monitored:

--- a/tests/agents/json-specs/cgroup_parsing.json
+++ b/tests/agents/json-specs/cgroup_parsing.json
@@ -1,0 +1,22 @@
+{
+	"testUnderscores": {
+		"groupLine": "1:name=systemd:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod90d81341_92de_11e7_8cf2_507b9d4141fa.slice/crio-2227daf62df6694645fee5df53c1f91271546a9560e8600a525690ae252b7f63.scope",
+		"containerId": "2227daf62df6694645fee5df53c1f91271546a9560e8600a525690ae252b7f63",
+		"podId": "90d81341-92de-11e7-8cf2-507b9d4141fa"
+	},
+	"testOpenshiftForm": {
+		"groupLine": "9:freezer:/kubepods.slice/kubepods-pod22949dce_fd8b_11ea_8ede_98f2b32c645c.slice/docker-b15a5bdedd2e7645c3be271364324321b908314e4c77857bbfd32a041148c07f.scope",
+		"containerId": "b15a5bdedd2e7645c3be271364324321b908314e4c77857bbfd32a041148c07f",
+		"podId": "22949dce-fd8b-11ea-8ede-98f2b32c645c"
+	},
+	"testUbuntuCGroup": {
+		"groupLine": "1:name=systemd:/user.slice/user-1000.slice/user@1000.service/apps.slice/apps-org.gnome.Terminal.slice/vte-spawn-75bc72bd-6642-4cf5-b62c-0674e11bfc84.scope",
+		"containerId": null,
+		"podId": null
+	},
+	"testAwsEcsCGroup": {
+		"groupLine": "1:name=systemd:/ecs/03752a671e744971a862edcee6195646/03752a671e744971a862edcee6195646-4015103728",
+		"containerId": "03752a671e744971a862edcee6195646-4015103728",
+		"podId": null
+	}
+}

--- a/tests/agents/json-specs/cgroup_parsing.json
+++ b/tests/agents/json-specs/cgroup_parsing.json
@@ -1,22 +1,22 @@
 {
-	"testUnderscores": {
-		"groupLine": "1:name=systemd:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod90d81341_92de_11e7_8cf2_507b9d4141fa.slice/crio-2227daf62df6694645fee5df53c1f91271546a9560e8600a525690ae252b7f63.scope",
-		"containerId": "2227daf62df6694645fee5df53c1f91271546a9560e8600a525690ae252b7f63",
-		"podId": "90d81341-92de-11e7-8cf2-507b9d4141fa"
-	},
-	"testOpenshiftForm": {
-		"groupLine": "9:freezer:/kubepods.slice/kubepods-pod22949dce_fd8b_11ea_8ede_98f2b32c645c.slice/docker-b15a5bdedd2e7645c3be271364324321b908314e4c77857bbfd32a041148c07f.scope",
-		"containerId": "b15a5bdedd2e7645c3be271364324321b908314e4c77857bbfd32a041148c07f",
-		"podId": "22949dce-fd8b-11ea-8ede-98f2b32c645c"
-	},
-	"testUbuntuCGroup": {
-		"groupLine": "1:name=systemd:/user.slice/user-1000.slice/user@1000.service/apps.slice/apps-org.gnome.Terminal.slice/vte-spawn-75bc72bd-6642-4cf5-b62c-0674e11bfc84.scope",
-		"containerId": null,
-		"podId": null
-	},
-	"testAwsEcsCGroup": {
-		"groupLine": "1:name=systemd:/ecs/03752a671e744971a862edcee6195646/03752a671e744971a862edcee6195646-4015103728",
-		"containerId": "03752a671e744971a862edcee6195646-4015103728",
-		"podId": null
-	}
+  "testUnderscores": {
+    "groupLine": "1:name=systemd:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod90d81341_92de_11e7_8cf2_507b9d4141fa.slice/crio-2227daf62df6694645fee5df53c1f91271546a9560e8600a525690ae252b7f63.scope",
+    "containerId": "2227daf62df6694645fee5df53c1f91271546a9560e8600a525690ae252b7f63",
+    "podId": "90d81341-92de-11e7-8cf2-507b9d4141fa"
+  },
+  "testOpenshiftForm": {
+    "groupLine": "9:freezer:/kubepods.slice/kubepods-pod22949dce_fd8b_11ea_8ede_98f2b32c645c.slice/docker-b15a5bdedd2e7645c3be271364324321b908314e4c77857bbfd32a041148c07f.scope",
+    "containerId": "b15a5bdedd2e7645c3be271364324321b908314e4c77857bbfd32a041148c07f",
+    "podId": "22949dce-fd8b-11ea-8ede-98f2b32c645c"
+  },
+  "testUbuntuCGroup": {
+    "groupLine": "1:name=systemd:/user.slice/user-1000.slice/user@1000.service/apps.slice/apps-org.gnome.Terminal.slice/vte-spawn-75bc72bd-6642-4cf5-b62c-0674e11bfc84.scope",
+    "containerId": null,
+    "podId": null
+  },
+  "testAwsEcsCGroup": {
+    "groupLine": "1:name=systemd:/ecs/03752a671e744971a862edcee6195646/03752a671e744971a862edcee6195646-4015103728",
+    "containerId": "03752a671e744971a862edcee6195646-4015103728",
+    "podId": null
+  }
 }


### PR DESCRIPTION
This is a follow-up of #678 as suggested by @felixbarny in https://github.com/elastic/apm/pull/678#issuecomment-1240263646.
The [existing tests](https://github.com/elastic/apm-agent-dotnet/blob/02341468dd97726162048502bb651811d401ae6f/test/Elastic.Apm.Tests/SystemInfoHelperTests.cs#L64) in `apm-agent-dotnet` served as the source for these `json-specs` test data.
Once this PR is merged, `apm-dotnet-agent` will also switch to using `json-specs` as input (FYI @gregkalapos).