### PR TITLE
Simplify heuristic for ES cluster name

### DIFF
--- a/specs/agents/tracing-instrumentation-db.md
+++ b/specs/agents/tracing-instrumentation-db.md
@@ -145,10 +145,10 @@ In addition to [the usual error capture specification](./error-tracking.md), the
 #### Cluster name
 
 The Elasticsearch cluster name is not always available in ES clients, as a result the following strategy should be used (by order of priority):
-- Call internal API in the client library to get cached cluster name.
-- Use `x-found-handling-cluster` HTTP response header value.
-- Instrument `_node/http` calls and cache the result in the agent with `host:port` as key.
-- execute a request to Elasticsearch and cache the result in the agent with `host:port` as key.
+- Use `x-found-handling-cluster` HTTP response header value, this is provided for ES cloud deployments thanks to the cloud proxy.
+- execute a `GET /` request to Elasticsearch to retrieve `cluster_name` in response. Value must be cached in the agent and request should be avoided in the following cases:
+    - Client is using a cloud ES instance and HTTP header should be available.
+    - Application is deployed in a FAAS/Lambda environment where the number of ES queries is assumed to be minimal.
 
 #### `elasticsearch_capture_body_urls` configuration
 

--- a/specs/agents/tracing-instrumentation-db.md
+++ b/specs/agents/tracing-instrumentation-db.md
@@ -144,12 +144,8 @@ In addition to [the usual error capture specification](./error-tracking.md), the
 
 #### Cluster name
 
-The Elasticsearch cluster name is not available in Elasticsearch clients, as a result the following strategy should be used (by order of priority):
-- Use `x-found-handling-cluster` HTTP response header value, this is provided for ES cloud deployments thanks to the cloud proxy.
-- Optionally execute a `GET /` request to Elasticsearch to retrieve `cluster_name` in response when `elasticsearch_fetch_cluster_name` is set to `true`.
-
-Agents MAY offer the `elasticsearch_fetch_cluster_name` configuration option set to `false` by default. If they don't
-then the extra query to Elasticsearch should be avoided.
+The Elasticsearch cluster name is not available in Elasticsearch clients.
+When using an Elastic Cloud deployment, the name of the Elasticsearch cluster is provided by the `x-found-handling-cluster` HTTP response header.
 
 #### `elasticsearch_capture_body_urls` configuration
 

--- a/specs/agents/tracing-instrumentation-db.md
+++ b/specs/agents/tracing-instrumentation-db.md
@@ -144,11 +144,12 @@ In addition to [the usual error capture specification](./error-tracking.md), the
 
 #### Cluster name
 
-The Elasticsearch cluster name is not always available in ES clients, as a result the following strategy should be used (by order of priority):
+The Elasticsearch cluster name is not available in Elasticsearch clients, as a result the following strategy should be used (by order of priority):
 - Use `x-found-handling-cluster` HTTP response header value, this is provided for ES cloud deployments thanks to the cloud proxy.
-- execute a `GET /` request to Elasticsearch to retrieve `cluster_name` in response. Value must be cached in the agent and request should be avoided in the following cases:
-    - Client is using a cloud ES instance and HTTP header should be available.
-    - Application is deployed in a FAAS/Lambda environment where the number of ES queries is assumed to be minimal.
+- Optionally execute a `GET /` request to Elasticsearch to retrieve `cluster_name` in response when `elasticsearch_fetch_cluster_name` is set to `true`.
+
+Agents MAY offer the `elasticsearch_fetch_cluster_name` configuration option set to `false` by default. If they don't
+then the extra query to Elasticsearch should be avoided.
 
 #### `elasticsearch_capture_body_urls` configuration
 


### PR DESCRIPTION
/!\ Update: the current state of the proposal is summarized [in this comment below](https://github.com/elastic/apm/pull/688#issuecomment-1275733539).

-----

Initial idea was to capture Elasticsearch cluster name using [this strategy](https://github.com/elastic/apm/blob/main/specs/agents/tracing-instrumentation-db.md#cluster-name).
- (1) use cluster name stored in ES clients if there is such (as of now, no such thing exists)
- (2) use value of `x-found-handling-cluster` HTTP response header which is provided in Cloud
- (3) passively capture the cluster_name in one of the client responses.
- (4) lazily execute a request to ES to retrieve cluster name through an explicit call to ES

However, after doing a PoC with Java agent (https://github.com/elastic/apm-agent-java/pull/2796) and talking with @swallez (ES clients team):
The `cluster_name` defaults to `elasticsearch` , but is usually set by the user for on-premises deployments, in cloud it is a random hex string like `3a29c1a34e2fba92d245020741e38977`.
- While not really "user-friendly" for cloud, it at least provide a stable value we can rely on for cardinality
- One instance of an ES client only communicates with a single cluster, it is thus safe to cache it at the client level.
- Alternatively we could also rely on the cloud deployment name which is available through explicit queries on ES, for example with `GET /_cluster/settings`.

For (1), if there was such storage it would be added only in newer clients
- It would only work for newer clients, we still have to rely on (2,3,4) for existing clients
- Implementation would be similar as (2,3,4), with the difference that it would be included in the client. One downside though is that client does not have any direct use for this and thus guarding against regressions might be tricky over time.
- For context, in Java, there is a total of 3 clients, REST "high-level", REST "low-level" (the one our agent instruments), and the "new Java client" which code is now 99% generated and relies on the REST "low-level"
- For Java, because we instrument the REST low level client, we would have to propagate the "cluster_name" from an high-level client, which might be tricky to cross 2/3 intermediate layers.

For (2), the implementation is trivial, the only downside is that it's not available outside cloud.
- For context, this header is used by the cloud proxy to route the request/response to the right cluster. It seems to be even possible to avoid using the dedicated DNS of the cluster and directly use the cloud proxy with this as a request HTTP header.

For (3), in order to be relevant, it would assume that the application does make a call to GET / or similar, which is very unlikely on most applications.
- For java, there are a few technical complications: it requires extra buffering of the response and avoid side effects, it would not work if agent is attached at runtime after the request/response is complete. So complexity with low probability of relevance means it's probably not worth it for Java.
	
For (4), it seems to be an acceptable compromise in most cases, but there are caveats
- using `GET /` is enough to get the `cluster_name`
- When a request to ES is made, the agent has to "borrow" credentials from the application request to issue its own request.
	- For Java, due to having both synchronous/asynchronous variants, it's easier to execute the extra request before the application request for access to HTTP headers, doing so when the response is available implies extra complexity. On top of that, because the response header is not yet available before the request executes it means the agent would always execute the extra request, unless we can detect using cloud and assume the HTTP response header will be available.
	- Making an extra request is not without side-effects, we should provide a way to opt-out
		- History: In 7.14 clients, an extra "product check" request `GET /` was executed once on the first client request, with 8.x this is replaced by a fancy content-type header in response. One issue this approach was with lambda/faas when a single query to ES is made, it would simply double the number of queries. This is of course less an issue with regular backend applications.
		- If we could reliably detect running in an Lambda/faas then disabling automatically this feature could be relevant.

## Proposal
- A) remove option (1) as it provide little benefit/cost ratio (same impl as other options + not covering existing clients)
- B) remove option (3) as it is quite likely not relevant for most applications (telemetry on ES span names could help us here, but I don't see why applications would explicitly perform this type of query on a regular basis)
- C) add to option (4) that the extra querying should be avoided in following cases:
	- When lambda/faas deployment is used. Can we reliably detect this and how ?
	- When using a cloud ES instance, the response header should be used. Can we reliably detect this and how ? (this might be quite specific to Java agent, but I assume that any asynchronous client might have the same issue).

## Things to clarify/discuss

- [x] can we reliably detect cloud ES deployment at runtime and disable extra query ?
  - Answer: NO, we can't guess it from either the request headers or URLs, even if most share a suffix.
- [x] can we reliably detect FAAS execution context and disable extra query ?
  - Answer: YES, this will likely be done through env. variables and we already populate related fields in `faas` agent protocol property.
  - Update: this is not required anymore after switching to opt-in rather than opt-out, this extra request will not be issued by default in FAAS environments.
- [x] do we need to add an option to opt-out of this feature as fallback ?
  - Yes, following [this feedback](https://github.com/elastic/apm/pull/688#issuecomment-1255626646) switching to opt-in rather than opt-out is preferable.
--------

- May the instrumentation collect sensitive information, such as secrets or PII (ex. in headers)?
  - [x] n/a
- [x] Create PR as draft
- [ ] Approval by at least one other agent
- [ ] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [ ] Approved by at least 2 agents + PM (if relevant)
- [ ] Merge after 7 days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.
- [ ] [Create implementation issues through the meta issue template](https://github.com/elastic/apm/issues/new?assignees=&labels=meta%2C+apm-agents&template=apm-agents-meta.md) (this will automate issue creation for individual agents)
