### PR TITLE
Add option to disable DB statement capture

### DIFF
--- a/specs/agents/tracing-instrumentation-db.md
+++ b/specs/agents/tracing-instrumentation-db.md
@@ -50,7 +50,7 @@ There might be a few use-cases where this capture is not desirable, for example:
 - verbose statements that incur important storage costs
 - added performance overhead in agents due to statement capture, for example with MongoDB BSON documents have to be serialized.
 
-Agents SHOULD provide a `db_statement_capture` configuration option (default value `true`) allowing to disable statement capture in cases where it is not desirable.
+Agents SHOULD provide a `capture_db_statement` configuration option (default value `true`) allowing to disable statement capture in cases where it is not desirable.
 When set to `false`, no value should be captured for the `context.db.statement` field.
 
 ## Specific Databases

--- a/specs/agents/tracing-instrumentation-db.md
+++ b/specs/agents/tracing-instrumentation-db.md
@@ -48,7 +48,7 @@ The `context.db.statement` field contains the database statement and is captured
 There might be a few use-cases where this capture is not desirable, for example:
 - sensitive PII exposed directly in SQL statements when not using prepared statements
 - verbose statements that incur important storage costs
-- added performance overhead in agents due to statement capture, for example with MongoDB BSON documents have to be serialized.
+- added performance overhead in agents due to statement capture, for example when MongoDB BSON documents have to be serialized.
 
 Agents SHOULD provide a `capture_db_statement` configuration option (default value `true`) allowing to disable statement capture in cases where it is not desirable.
 When set to `false`, no value should be captured for the `context.db.statement` field.

--- a/specs/agents/tracing-instrumentation-db.md
+++ b/specs/agents/tracing-instrumentation-db.md
@@ -41,6 +41,17 @@ The following fields are relevant for database and datastore spans. Where possib
 |`service.target.type`| Defines destination service type, the (`type`,`name`) pair replaces deprecated `context.destination.service.resource` | :white_check_mark:|
 |`service.target.name`| Defines destination service name, the (`type`,`name`) pair replaces deprecated `context.destination.service.resource`, for relational databases, the value is equal to `context.db.instance` | :x: |
 
+### Statement capture
+
+The `context.db.statement` field contains the database statement and is captured by default for databases that support it.
+
+There might be a few use-cases where this capture is not desirable, for example:
+- sensitive PII exposed directly in SQL statements when not using prepared statements
+- verbose statements that incur important storage costs
+- added performance overhead in agents due to statement capture, for example with MongoDB BSON documents have to be serialized.
+
+Agents SHOULD provide a `db_statement_capture` configuration option (default value `true`) allowing to disable statement capture in cases where it is not desirable.
+When set to `false`, no value should be captured for the `context.db.statement` field.
 
 ## Specific Databases
 


### PR DESCRIPTION
Closes #162 

Adds definition of `capture_db_statement` configuration option that allows to opt-out of database statement capture.

### Checklist

- [x] Create PR as draft
- [ ] Approval by at least one other agent
- [ ] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [ ] Approved by at least 2 agents + PM (if relevant)
- [ ] Merge after 7 days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.
- [ ] [Create implementation issues through the meta issue template](https://github.com/elastic/apm/issues/new?assignees=&labels=meta%2C+apm-agents&template=apm-agents-meta.md) (this will automate issue creation for individual agents)
