### PR TITLE
add mongodb_capture_statement_commands config option

### DIFF
--- a/specs/agents/tracing-instrumentation-db.md
+++ b/specs/agents/tracing-instrumentation-db.md
@@ -202,7 +202,7 @@ Statement capture SHOULD be disabled by default to avoid performance overhead an
 
 Examples:
 - capture all MongoDB statements: `*`
-- capture common read operations: `aggregate,count,distinct,mapReduce`
+- capture common read operations: `find,aggregate,count,distinct,mapReduce`
 
 ### Redis
 

--- a/specs/agents/tracing-instrumentation-db.md
+++ b/specs/agents/tracing-instrumentation-db.md
@@ -173,7 +173,7 @@ If they don't, they MUST use a hard-coded list of URLs that correspond with the 
 |`action`|e.g. `find` , `insert`, etc.| The MongoDB command executed with this action. |
 | __**context.db._**__  |<hr/>|<hr/>|
 |`_.instance`| e.g. `customers` | Database name, if available |
-|`_.statement`| e.g. <pre lang="json">find({status: {$in: ["A","D"]}})</pre> | The MongoDB command encoded as MongoDB Extended JSON, if `mongodb_capture_statement` is set to `true` |
+|`_.statement`| e.g. <pre lang="json">find({status: {$in: ["A","D"]}})</pre> | The MongoDB command encoded as MongoDB Extended JSON, if `mongodb_capture_statement_commands` is set |
 |`_.type`|`mongodb`|
 |`_.user`| :heavy_minus_sign: |
 |`_.link`| :heavy_minus_sign: |
@@ -188,17 +188,21 @@ If they don't, they MUST use a hard-coded list of URLs that correspond with the 
 |`_.type`| `mongodb` | |
 |`_.name`| e.g. `customers` | Database name, same as `db.instance` if available  |
 
-#### `mongodb_capture_statement` configuration
+#### `mongodb_capture_statement_commands` configuration
 
 Agents that support capturing MongoDB statements SHOULD implement this option.
 
 Statement capture SHOULD be disabled by default to avoid performance overhead and capturing potentially sensitive data.
 
-|                |           |
-|----------------|-----------|
-| Type           | `boolean` |
-| Default        | `false`   |
-| Central config | `false`   |
+|                |  |
+|----------------|--|
+| Type           | `List<`[`WildcardMatcher`](../../tests/agents/json-specs/wildcard_matcher_tests.json)`>` |
+| Default        | `""` (empty) |
+| Central config | `false` |
+
+Examples:
+- capture all MongoDB statements: `*`
+- capture common read operations: `aggregate,count,distinct,mapReduce`
 
 ### Redis
 

--- a/specs/agents/tracing-instrumentation-db.md
+++ b/specs/agents/tracing-instrumentation-db.md
@@ -190,9 +190,7 @@ If they don't, they MUST use a hard-coded list of URLs that correspond with the 
 
 #### `mongodb_capture_statement_commands` configuration
 
-Agents that support capturing MongoDB statements SHOULD implement this option.
-
-Statement capture SHOULD be disabled by default to avoid performance overhead and capturing potentially sensitive data.
+Agents that support capturing MongoDB statements MUST implement this option.
 
 |                |  |
 |----------------|--|
@@ -202,7 +200,7 @@ Statement capture SHOULD be disabled by default to avoid performance overhead an
 
 Examples:
 - capture all statements: `*`
-- capture common read operations: `find,aggregate,count,distinct,mapReduce`
+- capture common read commands: `find,aggregate,count,distinct,mapReduce`
 - capture no statement : `""` (empty)
 
 ### Redis

--- a/specs/agents/tracing-instrumentation-db.md
+++ b/specs/agents/tracing-instrumentation-db.md
@@ -193,7 +193,7 @@ If they don't, they MUST use a hard-coded list of URLs that correspond with the 
 The `mongodb_capture_statement` (experimental, default: `false`)  configuration option allows to
 enable capture MongoDB requests statements.
 
-Statement capture is disabled by default to avoid performance overhead and capturing potentially sensitive data.
+Statement capture SHOULD be disabled by default to avoid performance overhead and capturing potentially sensitive data.
 
 ### Redis
 

--- a/specs/agents/tracing-instrumentation-db.md
+++ b/specs/agents/tracing-instrumentation-db.md
@@ -173,7 +173,7 @@ If they don't, they MUST use a hard-coded list of URLs that correspond with the 
 |`action`|e.g. `find` , `insert`, etc.| The MongoDB command executed with this action. |
 | __**context.db._**__  |<hr/>|<hr/>|
 |`_.instance`| e.g. `customers` | Database name, if available |
-|`_.statement`| e.g. <pre lang="json">find({status: {$in: ["A","D"]}})</pre> | The MongoDB command encoded as MongoDB Extended JSON.|
+|`_.statement`| e.g. <pre lang="json">find({status: {$in: ["A","D"]}})</pre> | The MongoDB command encoded as MongoDB Extended JSON, if `mongodb_capture_statement` is set to `true` |
 |`_.type`|`mongodb`|
 |`_.user`| :heavy_minus_sign: |
 |`_.link`| :heavy_minus_sign: |
@@ -187,6 +187,13 @@ If they don't, they MUST use a hard-coded list of URLs that correspond with the 
 | __**service.target._**__ |<hr/>|<hr/>|
 |`_.type`| `mongodb` | |
 |`_.name`| e.g. `customers` | Database name, same as `db.instance` if available  |
+
+#### Statement capture
+
+The `mongodb_capture_statement` (experimental, default: `false`)  configuration option allows to
+enable capture MongoDB requests statements.
+
+Statement capture is disabled by default to avoid performance overhead and capturing potentially sensitive data.
 
 ### Redis
 

--- a/specs/agents/tracing-instrumentation-db.md
+++ b/specs/agents/tracing-instrumentation-db.md
@@ -197,12 +197,13 @@ Statement capture SHOULD be disabled by default to avoid performance overhead an
 |                |  |
 |----------------|--|
 | Type           | `List<`[`WildcardMatcher`](../../tests/agents/json-specs/wildcard_matcher_tests.json)`>` |
-| Default        | `""` (empty) |
+| Default        | `"find,aggregate,count,distinct,mapReduce"` |
 | Central config | `false` |
 
 Examples:
-- capture all MongoDB statements: `*`
+- capture all statements: `*`
 - capture common read operations: `find,aggregate,count,distinct,mapReduce`
+- capture no statement : `""` (empty)
 
 ### Redis
 

--- a/specs/agents/tracing-instrumentation-db.md
+++ b/specs/agents/tracing-instrumentation-db.md
@@ -173,7 +173,7 @@ If they don't, they MUST use a hard-coded list of URLs that correspond with the 
 |`action`|e.g. `find` , `insert`, etc.| The MongoDB command executed with this action. |
 | __**context.db._**__  |<hr/>|<hr/>|
 |`_.instance`| e.g. `customers` | Database name, if available |
-|`_.statement`| e.g. <pre lang="json">find({status: {$in: ["A","D"]}})</pre> | The MongoDB command encoded as MongoDB Extended JSON, if `mongodb_capture_statement_commands` is set |
+|`_.statement`| e.g. <pre lang="json">find({status: {$in: ["A","D"]}})</pre> | The MongoDB command encoded as MongoDB Extended JSON, if the command name matches `mongodb_capture_statement_commands`. |
 |`_.type`|`mongodb`|
 |`_.user`| :heavy_minus_sign: |
 |`_.link`| :heavy_minus_sign: |
@@ -190,6 +190,7 @@ If they don't, they MUST use a hard-coded list of URLs that correspond with the 
 
 #### `mongodb_capture_statement_commands` configuration
 
+This config var specifies the MongoDB command names for which the agent will capture the statement.
 Agents that support capturing MongoDB statements MUST implement this option.
 
 |                |  |
@@ -199,7 +200,7 @@ Agents that support capturing MongoDB statements MUST implement this option.
 | Central config | `false` |
 
 Examples:
-- capture all statements: `*`
+- capture for all commands: `*` (This should be discouraged, because it can lead to capturing sensitive information in `insert` and `update` commands.)
 - capture common read commands: `find,aggregate,count,distinct,mapReduce`
 - capture no statement : `""` (empty)
 

--- a/specs/agents/tracing-instrumentation-db.md
+++ b/specs/agents/tracing-instrumentation-db.md
@@ -188,12 +188,17 @@ If they don't, they MUST use a hard-coded list of URLs that correspond with the 
 |`_.type`| `mongodb` | |
 |`_.name`| e.g. `customers` | Database name, same as `db.instance` if available  |
 
-#### Statement capture
+#### `mongodb_capture_statement` configuration
 
-The `mongodb_capture_statement` (experimental, default: `false`)  configuration option allows to
-enable capture MongoDB requests statements.
+Agents that support capturing MongoDB statements SHOULD implement this option.
 
 Statement capture SHOULD be disabled by default to avoid performance overhead and capturing potentially sensitive data.
+
+|                |           |
+|----------------|-----------|
+| Type           | `boolean` |
+| Default        | `false`   |
+| Central config | `false`   |
 
 ### Redis
 


### PR DESCRIPTION
Add `mongodb_capture_statement_commands` configuration option to allow opt-in MongoDB statement capture.

----

- May the instrumentation collect sensitive information, such as secrets or PII (ex. in headers)?
  - [x] No
    - [x] Why: it disables by default our ability to capture sensitive information.
- [x] Create PR as draft
- [x] Approval by at least one other agent
- [x] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [x] Approved by at least 2 agents + PM (if relevant)
- [x] Merge after 7 days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.
- [x] [Create implementation issues through the meta issue template](https://github.com/elastic/apm/issues/new?assignees=&labels=meta%2C+apm-agents&template=apm-agents-meta.md) (this will automate issue creation for individual agents) : https://github.com/elastic/apm/issues/715
