### PR TITLE
Clarify http(s) default port handling for service.target_name

### DIFF
--- a/specs/agents/tracing-spans-service-target.md
+++ b/specs/agents/tracing-spans-service-target.md
@@ -131,6 +131,9 @@ if (span.isExit) {
 
     } else if (context.http?.url) { // http spans
       service_target.name = getHostFromUrl(context.http.url);
+      //
+      // Note: Default ports (80/http and 443/https) MUST be ignored (e.g. returned as 0 here).
+      //
       port = getPortFromUrl(context.http.url);
       if (port > 0) {
         service_target.name += ":" + port;

--- a/specs/agents/tracing-spans-service-target.md
+++ b/specs/agents/tracing-spans-service-target.md
@@ -132,12 +132,10 @@ if (span.isExit) {
     } else if (context.http?.url) { // http spans
       service_target.name = getHostFromUrl(context.http.url);
       //
-      // Note: Default ports (80/http and 443/https) MUST be ignored (e.g. returned as 0 here).
+      // We always expect a valid port number here (80/443 default).
       //
       port = getPortFromUrl(context.http.url);
-      if (port > 0) {
-        service_target.name += ":" + port;
-      }
+      service_target.name += ":" + port;
     }
   }
 } else {

--- a/tests/agents/json-specs/service_resource_inference.json
+++ b/tests/agents/json-specs/service_resource_inference.json
@@ -130,10 +130,7 @@
           "type": "elasticsearch"
         },
         "http": {
-          "url": {
-            "host": "my-cluster.com",
-            "port": 9200
-          }
+          "url": "https://my-cluster.com:9200"
         }
       }
     },
@@ -153,10 +150,7 @@
           "body": "Text message"
         },
         "http": {
-          "url": {
-            "host": "my-broker.com",
-            "port": 8888
-          }
+          "url": "https://my-broker.com:8888"
         }
       }
     },
@@ -173,10 +167,7 @@
       "subtype": "http",
       "context": {
         "http": {
-          "url": {
-            "host": "my-cluster.com",
-            "port": 9200
-          }
+          "url": "http://my-cluster.com:9200"
         }
       }
     },
@@ -185,7 +176,7 @@
       "type": "http",
       "name": "my-cluster.com:9200"
     },
-    "failure_message": "If `context.http.url` exists, output should be `${context.http.url.host}:${context.http.url.port}"
+    "failure_message": "If `context.http.url` exists, output should be `${context.http.url}`"
   },
   {
     "span": {
@@ -194,19 +185,16 @@
       "subtype": "http",
       "context": {
         "http": {
-          "url": {
-            "host": "my-cluster.com",
-            "port": -1
-          }
+          "url": "https://my-cluster.com"
         }
       }
     },
-    "expected_resource": "my-cluster.com",
+    "expected_resource": "my-cluster.com:443",
     "expected_service_target": {
       "type": "http",
-      "name": "my-cluster.com"
+      "name": "my-cluster.com:443"
     },
-    "failure_message": "Negative `context.http.url.port` should be omitted from output"
+    "failure_message": "`context.http.url` without an explicit default HTTPS port, output should be reported as `${context.http.url}:443`"
   },
   {
     "span": {
@@ -215,18 +203,16 @@
       "subtype": "http",
       "context": {
         "http": {
-          "url": {
-            "host": "my-cluster.com"
-          }
+          "url": "http://my-cluster.com"
         }
       }
     },
-    "expected_resource": "my-cluster.com",
+    "expected_resource": "my-cluster.com:80",
     "expected_service_target": {
       "type": "http",
-      "name": "my-cluster.com"
+      "name": "my-cluster.com:80"
     },
-    "failure_message": "If `context.http.url.port` does not exist, output should be `${context.http.url.host}`"
+    "failure_message": "`context.http.url` without an explicit default HTTP port, output should be reported as `${context.http.url}:80`"
   },
   {
     "span": {


### PR DESCRIPTION
When working on https://github.com/elastic/apm-agent-dotnet/issues/1836 (span service inference tests) I encountered this:

While our JSON test spec is very [explicit](https://github.com/elastic/apm/blob/main/tests/agents/json-specs/service_resource_inference.json#L229) about the presence of ports, the pseudo-code in https://github.com/elastic/apm/blob/main/specs/agents/tracing-spans-service-target.md#implementation-details only refers to a helper function `getPortFromUrl` that does not specify how to handle default HTTP ports (80/443).

Assuming that the test spec is the authoritative source, the `expected_resource` is clearly **without** a (default) port number, ~~so I think we should also state this in the pseudo-code~~.

```json
{
  "span": {
    "exit": "true",
    "type": "external",
    "subtype": "http",
    "context": {
      "http": {
        "url": {
          "host": "my-cluster.com"
        }
      }
    }
  },
  "expected_resource": "my-cluster.com",
  "expected_service_target": {
    "type": "http",
    "name": "my-cluster.com"
  },
  "failure_message": "If `context.http.url.port` does not exist, output should be `${context.http.url.host}`"
}
```

## Update (28.10.2022)

After discussing this some more on #703 and in the agent weekly, I changed the direction of this PR to making the ports **mandatory**.

* The pseude code algorithm reflects this now.
* The test cases also expect ports now.

For that, I also changed the format of the `http` input data, as the existing format had a few shortcomings:

* It included no URL scheme
* Some test cases (e.g. `"port" : -1`) were hypothetical.

Before:

```json
"http": {
  "url": {
    "host": "my-cluster.com",
    "port": 9200
}
```

Now:

```json
"http": {
  "url": "https://my-cluster.com:9200"
}
```
