### PR TITLE
Update target path for json-specs in apm-agent-dotnet

### DIFF
--- a/.ci/.jenkins-agents.yml
+++ b/.ci/.jenkins-agents.yml
@@ -2,7 +2,7 @@
 agents:
   - REPO: "apm-agent-dotnet"
     FEATURES_PATH: "test/Elastic.Apm.Feature.Tests/Features"
-    JSON_SPECS_PATH: "test/Elastic.Apm.Tests/TestResources/json-specs"
+    JSON_SPECS_PATH: "test/Elastic.Apm.Tests.Utilities/TestResources/json-specs"
   - REPO: "apm-agent-go"
     FEATURES_PATH: "features"
     JSON_SPECS_PATH: "internal/testdata/json-specs"


### PR DESCRIPTION
Synchronize the `json_specs` tests into the `Elastic.Apm.Tests.Utilities` project (instead of `Elastic.Apm.Tests`).

This makes using these input data easier since all/most test projects already have a dependency on `Utilities` and we don't need to introduce artificial dependencies to `Elastic.Apm.Tests`.