### PR TITLE
Fix CODEOWNERS so the mobile teams actually own the mobile folder

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # Raising a PR against the agent spec folder will automatically request reviews from all agent teams
 # If the PR is not ready for review, create a draft PR instead
 # See also /.github/pull_request_template.md
-/specs/agents @elastic/apm-agent-go @elastic/apm-agent-java @elastic/apm-agent-net @elastic/apm-agent-node-js @elastic/apm-agent-php @elastic/apm-agent-python @elastic/apm-agent-ruby @elastic/apm-agent-rum @elastic/apm-pm
+/specs/agents @elastic/apm-agent-go @elastic/apm-agent-java @elastic/apm-agent-net @elastic/apm-agent-node-js @elastic/apm-agent-php @elastic/apm-agent-python @elastic/apm-agent-ruby @elastic/apm-agent-rum @elastic/apm-pm @elastic/apm-agent-ios @elastic/apm-agent-android
 /specs/agents/mobile @elastic/apm-agent-ios @elastic/apm-agent-android
 /.github/pull_request_template.md @elastic/apm-agent-go @elastic/apm-agent-java @elastic/apm-agent-net @elastic/apm-agent-node-js @elastic/apm-agent-php @elastic/apm-agent-python @elastic/apm-agent-ruby @elastic/apm-agent-rum @elastic/apm-pm

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # Raising a PR against the agent spec folder will automatically request reviews from all agent teams
 # If the PR is not ready for review, create a draft PR instead
 # See also /.github/pull_request_template.md
-/specs/agents/mobile @elastic/apm-agent-ios @elastic/apm-agent-android
 /specs/agents @elastic/apm-agent-go @elastic/apm-agent-java @elastic/apm-agent-net @elastic/apm-agent-node-js @elastic/apm-agent-php @elastic/apm-agent-python @elastic/apm-agent-ruby @elastic/apm-agent-rum @elastic/apm-pm
+/specs/agents/mobile @elastic/apm-agent-ios @elastic/apm-agent-android
 /.github/pull_request_template.md @elastic/apm-agent-go @elastic/apm-agent-java @elastic/apm-agent-net @elastic/apm-agent-node-js @elastic/apm-agent-php @elastic/apm-agent-python @elastic/apm-agent-ruby @elastic/apm-agent-rum @elastic/apm-pm


### PR DESCRIPTION
CODEOWNERS should be written from general to specific. As you can see from the last two lines of [this example](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file), the lines are processed in order, and as a result the `mobile` line doesn't actually do anything. I think this is why https://github.com/elastic/apm/pull/704 pinged the wrong teams.