### PR TITLE
Add description on how to add options to central config

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -44,3 +44,4 @@ This extended template ensures that we have a meta issue and tracking issues so 
 - [ ] Merge after 7 days passed without objections \
       To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.
 - [ ] [Create implementation issues through the meta issue template](https://github.com/elastic/apm/issues/new?assignees=&labels=meta%2C+apm-agents&template=apm-agents-meta.md) (this will automate issue creation for individual agents)
+- [ ] If this spec adds a new dynamic config option, [add it to central config](../specs/agents/configuration.md#adding-a-new-configuration-option).

--- a/specs/agents/configuration.md
+++ b/specs/agents/configuration.md
@@ -176,8 +176,15 @@ See this example PR on how to add an option: https://github.com/elastic/kibana/p
 
 Agent devs are not expected to set up a local Kibana development environment.
 Just create a draft PR using your best judgement given the examples on how to add the configuration option.
+By the time you're adding the configuration option, chances are that no agent has implemented the option, yet.
+Therefore, set `includeAgents: []` in the option declaration.
+When an agent implements the option, they just need to add the agent name to this section, without having to test the changes.
+Please manually add a checkbox to all the implementation issues to make sure agents don't forget that step.
+
 Add the labels `release_note:enhancement`, `Team:APM`, `v<next minor stack release>`, and [`ci:cloud-deploy`](https://github.com/elastic/kibana/labels/ci%3Acloud-deploy).
 After the build succeeds, there will be a link where you can test out the PR in cloud.
 To test the changes, just try out whether the option is rendered as expected and triple-check that the option name matches the one in the spec.
+For testing purposes, add at least one agent to the `includeAgents` declaration and remember to remove it after testing if the agent didn't actually implement the option, yet.
+
 If everything works smoothly, request a review from the [apm-ui](https://github.com/orgs/elastic/teams/apm-ui) team.
 If you need help, drop a message in the #apm-dev channel so that agent devs that did this before or UI devs can chime in.

--- a/specs/agents/configuration.md
+++ b/specs/agents/configuration.md
@@ -176,7 +176,6 @@ However, sometimes it might not be feasible if agents need to read the value at 
 
 When adding a centrally configurable option,
 the spec owner is expected to create a pull request in the Kibana repository to add the option to central configuration.
-As all the configuration options are added declaratively, this is no rocket science.
 
 To make sure the tests are passing and to update some generated files, you need a local clone of Kibana and execute the build.
 Follow [Kibana's contribution guide](https://github.com/elastic/kibana/blob/main/CONTRIBUTING.md) to get a local environment running.

--- a/specs/agents/configuration.md
+++ b/specs/agents/configuration.md
@@ -150,7 +150,7 @@ This naming pattern allows the UI to display inline help on how to manually conf
 
 When adding a new configuration option to the spec, please use the following template:
 
-```
+```markdown
 ### <option_name_in_central_config_notation> configuration
 
 The description of the option.

--- a/specs/agents/configuration.md
+++ b/specs/agents/configuration.md
@@ -177,19 +177,23 @@ However, sometimes it might not be feasible if agents need to read the value at 
 When adding a centrally configurable option,
 the spec owner is expected to create a pull request in the Kibana repository to add the option to central configuration.
 As all the configuration options are added declaratively, this is no rocket science.
-See this example PR on how to add an option: https://github.com/elastic/kibana/pull/84678.
 
-Agent devs are not expected to set up a local Kibana development environment.
-Just create a draft PR using your best judgement given the examples on how to add the configuration option.
+To make sure the tests are passing and to update some generated files, you need a local clone of Kibana and execute the build.
+Follow [Kibana's contribution guide](https://github.com/elastic/kibana/blob/main/CONTRIBUTING.md) to get a local environment running.
+
+Add the configuration option(s) using this [example PR](https://github.com/elastic/kibana/pull/143668) as a reference.
 By the time you're adding the configuration option, chances are that no agent has implemented the option, yet.
 Therefore, set `includeAgents: []` in the option declaration.
 When an agent implements the option, they just need to add the agent name to this section, without having to test the changes.
 Please manually add a checkbox to all the implementation issues to make sure agents don't forget that step.
 
-Add the labels `release_note:enhancement`, `Team:APM`, `v<next minor stack release>`, and [`ci:cloud-deploy`](https://github.com/elastic/kibana/labels/ci%3Acloud-deploy).
-After the build succeeds, there will be a link where you can test out the PR in cloud.
-To test the changes, just try out whether the option is rendered as expected and triple-check that the option name matches the one in the spec.
-For testing purposes, add at least one agent to the `includeAgents` declaration and remember to remove it after testing if the agent didn't actually implement the option, yet.
+Before creating a PR, execute the [jest tests and update the generated snapshot files](https://github.com/elastic/kibana/blob/main/x-pack/plugins/apm/dev_docs/testing.md#unit-tests-jest).
+For testing purposes, comment out the `includeAgents` declaration and remember add it back in after testing.
+This ensures that you can just select `all` services and `all` environments in the central configuration UI.  
+To test the changes, run Elasticsearch and Kibana as described in the contribution guide.
+Just try out whether the option is rendered as expected and triple-check that the option name matches the one in the spec.
+
+When creating the PR, add the labels `release_note:enhancement`, `Team:APM`, and `v<next minor stack release>`.
 
 If everything works smoothly, request a review from the [apm-ui](https://github.com/orgs/elastic/teams/apm-ui) team.
 If you need help, drop a message in the #apm-dev channel so that agent devs that did this before or UI devs can chime in.

--- a/specs/agents/configuration.md
+++ b/specs/agents/configuration.md
@@ -143,3 +143,41 @@ By default, agents MUST send data to the APM Server at `http://localhost:8200/`.
 If possible, agents SHOULD detect sensible defaults for `service.name` and `service.version`.
 In any case agents MUST include `service.name` - if discovering it is not possible then the default value: `unknown-${service.agent.name}-service` MUST be used.
 This naming pattern allows the UI to display inline help on how to manually configure the name.
+
+### Adding a new configuration option
+
+When adding a new configuration option to the spec, please use the following template:
+
+#### <option_name_in_central_config_notation> configuration
+
+The description of the option.
+Try to phrase it in a way that lets agents easily copy/paste the description into their configuration documentation page.
+This should also match the description in the [central configuration](https://github.com/elastic/kibana/blob/main/x-pack/plugins/apm/common/agent_configuration/setting_definitions/general_settings.ts) in the APM UI.
+
+|                |                                                                         |
+|----------------|-------------------------------------------------------------------------|
+| Type           | See the [Configuration Value Types](#configuration-value-types) section |
+| Default        | `<default value>`                                                       |
+| Central config | `<true/false>`                                                          |
+
+Additional description of the option that should not be part of the documentation.
+For example, whether agents SHOULD or MUST implement the option.
+
+#### Adding to central configuration
+
+One of the things to determine when proposing to add a new configuration option is whether it should be added to central configuration.
+In general, we should try to make the majority of options available in central configuration.
+However, sometimes it might not be feasible if agents need to read the value at startup and changing the value at runtime is very difficult to achieve.
+
+When adding a centrally configurable option,
+the spec owner is expected to create a pull request in the Kibana repository to add the option to central configuration.
+As all the configuration options are added declaratively, this is no rocket science.
+See this example PR on how to add an option: https://github.com/elastic/kibana/pull/84678.
+
+Agent devs are not expected to set up a local Kibana development environment.
+Just create a draft PR using your best judgement given the examples on how to add the configuration option.
+Add the labels `release_note:enhancement`, `Team:APM`, `v<next minor stack release>`, and [`ci:cloud-deploy`](https://github.com/elastic/kibana/labels/ci%3Acloud-deploy).
+After the build succeeds, there will be a link where you can test out the PR in cloud.
+To test the changes, just try out whether the option is rendered as expected and triple-check that the option name matches the one in the spec.
+If everything works smoothly, request a review from the [apm-ui](https://github.com/orgs/elastic/teams/apm-ui) team.
+If you need help, drop a message in the #apm-dev channel so that agent devs that did this before or UI devs can chime in.

--- a/specs/agents/configuration.md
+++ b/specs/agents/configuration.md
@@ -146,22 +146,27 @@ This naming pattern allows the UI to display inline help on how to manually conf
 
 ### Adding a new configuration option
 
+#### Configuration option spec template
+
 When adding a new configuration option to the spec, please use the following template:
 
-#### <option_name_in_central_config_notation> configuration
+```
+### <option_name_in_central_config_notation> configuration
 
 The description of the option.
 Try to phrase it in a way that lets agents easily copy/paste the description into their configuration documentation page.
 This should also match the description in the [central configuration](https://github.com/elastic/kibana/blob/main/x-pack/plugins/apm/common/agent_configuration/setting_definitions/general_settings.ts) in the APM UI.
 
-|                |                                                                         |
-|----------------|-------------------------------------------------------------------------|
-| Type           | See the [Configuration Value Types](#configuration-value-types) section |
-| Default        | `<default value>`                                                       |
-| Central config | `<true/false>`                                                          |
+|                |                                           |
+|----------------|-------------------------------------------|
+| Type           | See the Configuration Value Types section |
+| Default        | `<default value>`                         |
+| Central config | `<true/false>`                            |
 
 Additional description of the option that should not be part of the documentation.
 For example, whether agents SHOULD or MUST implement the option.
+
+```
 
 #### Adding to central configuration
 


### PR DESCRIPTION
Makes sure we don't forget adding new dynamic options to central config.


We're currently missing a bunch of config options in central config:

Cross-agent options
```
capture_body_content_types
dedot_custom_metrics
exit_span_min_duration
ignore_message_queues
span_compression_enabled
span_compression_exact_match_max_duration
span_compression_same_kind_max_duration
trace_continuation_strategy
transaction_ignore_user_agents
transaction_name_groups
use_path_as_transaction_name
```

Java specific options:
```
capture_jmx_metrics
ignore_exceptions
trace_methods
unnest_exceptions
```

Also, central config only has the deprecated `span_frames_min_duration ` instead of the new `span_stack_trace_min_duration` option.

<!--
Agent spec PR checklist

Delete all of this if the PR is not changing the agent spec.
Delete sections that don't apply to this PR.
If a specific checkbox doesn't apply, ~strike through~ and check it instead of deleting it.
-->

<!--
Use this section if the spec requires changes in at most two agents.

Examples:
- Typos or clarifications without semantic changes
- Changes in a spec before it has been implemented
- Features that are only implemented in two agents
-->

- [x] Create PR as draft
- [x] Approval by at least one other agent
- [x] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [ ] Merge after 2 business days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.

/schedule 2022-10-28