### PR TITLE
Specify agent logging preamble

### DIFF
--- a/specs/agents/logging.md
+++ b/specs/agents/logging.md
@@ -99,7 +99,7 @@ Additionally, agents SHOULD report information about their environment (e.g. hos
 | Framework | Name and version of the instrumented framework. | `Django 4.1.3`, `ASP.NET 4.8.4494.0`|
 
 [1]: Due to privacy concerns in the past (see e.g. [here](https://github.com/elastic/apm-agent-nodejs/issues/1916)),
-agents may decided to not log this information.
+agents may decide to not log this information.
 
 **CPU Architecture:**
 

--- a/specs/agents/logging.md
+++ b/specs/agents/logging.md
@@ -145,7 +145,7 @@ For each configuration option its **source** SHOULD be reported. These sources c
 * `environment`: Environment variable
 * `file`: Configuration file
 * `central`: Central Configuration
-  * **Note:** Agents MAY print their configuration block again on changed in the central configuration.
+  * **Note:** Agents MAY print their configuration block again on changes in the central configuration.
 
 Example:
 

--- a/specs/agents/logging.md
+++ b/specs/agents/logging.md
@@ -104,7 +104,7 @@ Additionally, agents SHOULD report information about their environment (e.g. hos
 
 The start of the configuration block MUST be denoted as such (e.g. `Agent Configuration:`).
 
-If a configuration file was used in the configuration process, its fully-qualified path
+If configuration files are used in the configuration process, their fully-qualified paths
 SHOULD be logged.
 
 Configuration item names MUST be provided in normalized (lower-case, snake_case) notation.
@@ -132,7 +132,10 @@ For each configuration option its **source** SHOULD be reported. These sources c
 Example:
 
 ```text
-Agent Configuration (file: '/path/to/some/config.json'):
+Agent Configuration:
+- configuration files used:
+  - '/path/to/some/config.json'
+  - '/path/to/some/other/config.xml'
 - server_url: 'http://localhost:8200' (default)
 - secret_token: [MASKED] (environment)
 - service_name: `unknown-dotnet-service` (default)

--- a/specs/agents/logging.md
+++ b/specs/agents/logging.md
@@ -48,7 +48,7 @@ The agent logging preamble consists of 3 blocks:
 
 * **Agent**: This block is mandatory and contains basic version and build date information.
 * **Environment**: This block is optional but for supportability reasons it should be provided.
-* **Configuration**: This block mandatory and contains a minimum set of relevant configuration values.
+* **Configuration**: This block is mandatory and contains a minimum set of relevant configuration values.
 
 **Note** that this specification does not prescribe a specific format to be used for creating 
 the log messages. It is up to the implementing agent to chose a format (e.g. ecs-logging format).

--- a/specs/agents/logging.md
+++ b/specs/agents/logging.md
@@ -125,7 +125,7 @@ Configuration value strings MUST be printed in quotes (so accidental leading or 
 
 Agents SHOULD log all configuration items that do not have default values.
 At the very minimum, agents MUST provide information about following essential configuration items.
-Items denoted as *"Log always* MUST be logged in any case (i.e. having a default value or a custom one).
+Items denoted as *"Log always"* MUST be logged in any case (i.e. having a default value or a custom one).
 
 | Item | Needs masking | Log Always | Example |
 | - | - | - | - |

--- a/specs/agents/logging.md
+++ b/specs/agents/logging.md
@@ -75,7 +75,7 @@ or pre-release build) and report that fact using the `warning` logging level.
 Example:
 
 ```text
-This a pre-release version and not intended for use in production environments!
+This is a pre-release version and not intended for use in production environments!
 ```
 
 ### Environment
@@ -86,12 +86,15 @@ Additionally, agents SHOULD report information about their environment (e.g. hos
 | - | - | - |
 | Process ID | The Process ID in decimal format. | `83606` |
 | Process Name | The executable image name or the full path to it.  | `w3wp.exe`, `/usr/local/share/dotnet/dotnet` |
-| Command Line | The full command line used to launch this process as available to the runtime. | `/Users/acme/some_app/bin/Debug/net7.0/some_app.dll foo=bar` |
+| Command Line | The full command line used to launch this process as available to the runtime. [1]  | `/Users/acme/some_app/bin/Debug/net7.0/some_app.dll foo=bar` |
 | Operating System | OS name and version in a human-readable format. | `macOS Version 12.6.1 (build 21G217)` |
 | CPU architecture | See table below. | `arm64` |
 | Host | The (optionally fully-qualified) host name. | `MacBook-Pro.localdomain` |
 | Time zone | The local time zone in UTC-offset notation. | `UTC+0200` |
 | Runtime | Name and version of the executing runtime. | `.NET Framework 4.8.4250.0`|
+
+[1]: Due to privacy concerns in the past (see e.g. [here](https://github.com/elastic/apm-agent-nodejs/issues/1916)),
+agents may decided to not log this information.
 
 **CPU Architecture:**
 
@@ -121,15 +124,20 @@ Configuration item names SHOULD be provided in normalized (lower-case, snake_cas
 Configuration value strings MUST be printed in quotes (so accidental leading or trailing whitespace can be spotted).
 
 Agents SHOULD log all configuration items that do not have default values.
-At the very minimum, agents MUST provide information about following essential configuration items:
+At the very minimum, agents MUST provide information about following essential configuration items.
+Items denoted as *"Log always* MUST be logged in any case (i.e. having a default value or a custom one).
 
-| Item | Needs masking | Example |
+| Item | Needs masking | Log Always | Example |
 | - | - | - | - |
-| `server_url` | no | `http://localhost:8200` |
-| `secret_token` | yes | `[REDACTED]` |
-| `api_key` | yes | `[REDACTED]` |
-| `service_name` | no | `foo` |
-| `log_level` | no | `warning` |
+| `server_url` | no | yes | `http://localhost:8200` [2] |
+| `service_name` | no | yes | `foo` |
+| `service_version` | no | yes | `42` |
+| `log_level` | no | yes | `warning` |
+| `secret_token` | yes | no | `[REDACTED]` |
+| `api_key` | yes | no | `[REDACTED]` |
+
+[2]: Agents MAY decide to mask potential sensitive data (e.g. basic authentication information)
+that could be part of this URL.
 
 For each configuration option its **source** SHOULD be reported. These sources can be:
 

--- a/specs/agents/logging.md
+++ b/specs/agents/logging.md
@@ -94,6 +94,7 @@ Additionally, agents SHOULD report information about their environment (e.g. hos
 | Host | The (optionally fully-qualified) host name. | `MacBook-Pro.localdomain` |
 | Time zone | The local time zone in UTC-offset notation. | `UTC+0200` |
 | Runtime | Name and version of the executing runtime. | `.NET Framework 4.8.4250.0`|
+| Framework | Name and version of the instrumented framework. | `Django 4.1.3`, `ASP.NET 4.8.4494.0`|
 
 [1]: Due to privacy concerns in the past (see e.g. [here](https://github.com/elastic/apm-agent-nodejs/issues/1916)),
 agents may decided to not log this information.

--- a/specs/agents/logging.md
+++ b/specs/agents/logging.md
@@ -41,10 +41,12 @@ Also, the documentation should not mention the old log levels going forward.
 
 ## Logging Preamble
 
-For supportability reasons, all agents MUST print this preamble on startup.
+The intention of this logging preamble is to ensure agent supportability. Relevant
+data about an agent (e.g. version) and the environment it is running in (e.g. host,
+operating system) should be provided in it.
 
-All log messages described in this section MUST be printed using the `info` logging level
-unless a different level is explicitly mentioned.
+All agents MUST print this preamble on startup using the `info` logging level unless
+a different level is explicitly mentioned.
 
 The agent logging preamble consists of 3 blocks:
 

--- a/specs/agents/logging.md
+++ b/specs/agents/logging.md
@@ -50,6 +50,9 @@ The agent logging preamble consists of 3 blocks:
 * **Environment**: This block is optional but for supportability reasons it should be provided.
 * **Configuration**: This block mandatory and contains a minimum set of relevant configuration values.
 
+**Note** that this specification does not prescribe a specific format to be used for creating 
+the log messages. It is up to the implementing agent to chose a format (e.g. ecs-logging format).
+
 ### Agent
 
 On startup, all APM agents MUST log basic information regarding their technology (language, runtime),
@@ -63,8 +66,8 @@ Example:
 Elastic APM .NET Agent, version: 1.19.1-preview, build date: 2022-10-27 10:55:42 UTC
 ```
 
-Agents SHOULD also report when they are running in a **non-production** scenario (e.g. a debug
-or pre-release build) using the `warning` logging level.
+Agents SHOULD also detect when they are running in a non-final version (e.g. a debug
+or pre-release build) and report that fact using the `warning` logging level.
 
 Example:
 
@@ -82,12 +85,16 @@ Additionally, agents SHOULD report information about their environment (e.g. hos
 | Process Name | The executable image name or the full path to it.  | `w3wp.exe`, `/usr/local/share/dotnet/dotnet` |
 | Command Line | The full command line used to launch this process as available to the runtime. | `/Users/acme/some_app/bin/Debug/net7.0/some_app.dll foo=bar` |
 | Operating System | OS name and version in a human-readable format. | `macOS Version 12.6.1 (build 21G217)` |
-| CPU architecture | One of the well-known values from the table below. | `arm64` |
+| CPU architecture | See table below. | `arm64` |
 | Host | The (optionally fully-qualified) host name. | `MacBook-Pro.localdomain` |
 | Time zone | The local time zone in UTC-offset notation. | `UTC+0200` |
 | Runtime | Name and version of the executing runtime. | `.NET Framework 4.8.4250.0`|
 
 **CPU Architecture:**
+
+This table provides an exemplary list of well-known values for reporting the CPU architecture.
+An agent can decide to use different values that might be readily availalbe to their language/runtime
+ecosystem (e.g. Node.js' `os.arch()`).
 
 | Value | Description |
 | - | - |
@@ -115,7 +122,8 @@ Agents MUST provide information about following essential configuration items:
 | Item | Needs masking | Example |
 | - | - | - | - |
 | `server_url` | no | `http://localhost:8200` |
-| `secret_token` | yes | `*****` |
+| `secret_token` | yes | `[REDACTED]` |
+| `api_key` | yes | `[REDACTED]` |
 | `service_name` | no | `foo` |
 | `log_level` | no | `warning` |
 
@@ -137,7 +145,8 @@ Agent Configuration:
   - '/path/to/some/config.json'
   - '/path/to/some/other/config.xml'
 - server_url: 'http://localhost:8200' (default)
-- secret_token: [MASKED] (environment)
+- secret_token: [REDACTED] (environment)
+- api_key: [REDACTED] (default)
 - service_name: `unknown-dotnet-service` (default)
 - log_level: info (file)
 - disable_metrics: '*' (file)

--- a/specs/agents/logging.md
+++ b/specs/agents/logging.md
@@ -99,7 +99,7 @@ agents may decided to not log this information.
 **CPU Architecture:**
 
 This table provides an exemplary list of well-known values for reporting the CPU architecture.
-An agent can decide to use different values that might be readily availalbe to their language/runtime
+An agent can decide to use different values that might be readily available to their language/runtime
 ecosystem (e.g. Node.js' `os.arch()`).
 
 | Value | Description |

--- a/specs/agents/logging.md
+++ b/specs/agents/logging.md
@@ -41,6 +41,8 @@ Also, the documentation should not mention the old log levels going forward.
 
 ## Logging Preamble
 
+For supportability reasons, all agents MUST print this preamble on startup.
+
 All log messages described in this section MUST be printed using the `info` logging level
 unless a different level is explicitly mentioned.
 

--- a/specs/agents/logging.md
+++ b/specs/agents/logging.md
@@ -1,6 +1,6 @@
-## Agent logging
+# Agent logging
 
-### `log_level` configuration
+## `log_level` configuration
 
 Sets the logging level for the agent.
 
@@ -17,8 +17,7 @@ Note that this default is not enforced among all agents.
 If an agent development team thinks that a different default should be used
 (such as `warning`), that is acceptable.
 
-### Mapping to native log levels
-
+## Mapping to native log levels
 
 Not all logging frameworks used by the different agents can natively work with these levels.
 Thus, agents will need to translate them, using their best judgment for the mapping.
@@ -31,7 +30,7 @@ agents can treat that as a synonym for `error` or `fatal`.
 
 The `off` level is a switch to completely turn off logging.
 
-### Backwards compatibility
+## Backwards compatibility
 
 Most agents have already implemented `log_level`,
 accepting a different set of levels.
@@ -39,3 +38,104 @@ Those agents should still accept their "native" log levels to preserve backwards
 However, in central config,
 there will only be a dropdown with the levels that are consistent across agents.
 Also, the documentation should not mention the old log levels going forward.
+
+## Logging Preamble
+
+All log messages described in this section MUST be printed using the `info` logging level
+unless a different level is explicitly mentioned.
+
+The agent logging preamble consists of 3 blocks:
+
+* **Agent**: This block is mandatory and contains basic version and build date information.
+* **Environment**: This block is optional but for supportability reasons it should be provided.
+* **Configuration**: This block mandatory and contains a minimum set of relevant configuration values.
+
+### Agent
+
+On startup, all APM agents MUST log basic information regarding their technology (language, runtime),
+version information, and build date in a format chosen by the respective agent.
+
+This SHOULD be the very first log message that is created by an agent.
+
+Example:
+
+```text
+Elastic APM .NET Agent, version: 1.19.1-preview, build date: 2022-10-27 10:55:42 UTC
+```
+
+Agents SHOULD also report when they are running in a **non-production** scenario (e.g. a debug
+or pre-release build) using the `warning` logging level.
+
+Example:
+
+```text
+This a pre-release version and not intended for use in production environments!
+```
+
+### Environment
+
+Additionally, agents SHOULD report information about their environment (e.g. host, process, runtime).
+
+| Item | Description | Example |
+| - | - | - |
+| Process ID | The Process ID in decimal format. | `83606` |
+| Process Name | The executable image name or the full path to it.  | `w3wp.exe`, `/usr/local/share/dotnet/dotnet` |
+| Command Line | The full command line used to launch this process as available to the runtime. | `/Users/acme/some_app/bin/Debug/net7.0/some_app.dll foo=bar` |
+| Operating System | OS name and version in a human-readable format. | `macOS Version 12.6.1 (build 21G217)` |
+| CPU architecture | One of the well-known values from the table below. | `arm64` |
+| Host | The (optionally fully-qualified) host name. | `MacBook-Pro.localdomain` |
+| Time zone | The local time zone in UTC-offset notation. | `UTC+0200` |
+| Runtime | Name and version of the executing runtime. | `.NET Framework 4.8.4250.0`|
+
+**CPU Architecture:**
+
+| Value | Description |
+| - | - |
+| `amd64` | AMD64 |
+| `arm32` |ARM32 |
+| `arm64` |ARM64 |
+| `ia64` | Itanium |
+| `ppc32` | 32-bit PowerPC |
+| `ppc64` | 64-bit PowerPC |
+| `s390x` | IBM z/Architecture |
+| `x86` | 32-bit x86 |
+
+### Configuration
+
+The start of the configuration block MUST be denoted as such (e.g. `Agent Configuration:`).
+
+If a configuration file was used in the configuration process, its fully-qualified path
+SHOULD be logged.
+
+Configuration item names MUST be provided in normalized (lower-case, snake_case) notation.
+Configuration value strings MUST be printed in quotes (so accidental leading or trailing whitespace can be spotted).
+
+Agents MUST provide information about following essential configuration items:
+
+| Item | Needs masking | Example |
+| - | - | - | - |
+| `server_url` | no | `http://localhost:8200` |
+| `secret_token` | yes | `*****` |
+| `service_name` | no | `foo` |
+| `log_level` | no | `warning` |
+
+Additional configurations items MAY be logged after that as well.
+
+For each configuration option its **source** SHOULD be reported. These sources can be:
+
+* `default`
+* `environment`: Environment variable
+* `file`: Configuration file
+* `central`: Central Configuration
+  * **Note:** Agents MAY print their configuration block again on changed in the central configuration.
+
+Example:
+
+```text
+Agent Configuration (file: '/path/to/some/config.json'):
+- server_url: 'http://localhost:8200' (default)
+- secret_token: [MASKED] (environment)
+- service_name: `unknown-dotnet-service` (default)
+- log_level: info (file)
+- disable_metrics: '*' (file)
+```

--- a/specs/agents/logging.md
+++ b/specs/agents/logging.md
@@ -56,7 +56,10 @@ the log messages. It is up to the implementing agent to chose a format (e.g. ecs
 ### Agent
 
 On startup, all APM agents MUST log basic information regarding their technology (language, runtime),
-version information, and build date in a format chosen by the respective agent.
+and version information.
+This log message MUST provide sufficient data to uniquely identify the agent build that generated the
+log message. Hence, if e.g. the version information is not sufficient, agents
+MUST include further information (e.g. build timestamp, git hash) that uniquely identifies an agent build.
 
 This SHOULD be the very first log message that is created by an agent.
 
@@ -114,10 +117,11 @@ The start of the configuration block MUST be denoted as such (e.g. `Agent Config
 If configuration files are used in the configuration process, their fully-qualified paths
 SHOULD be logged.
 
-Configuration item names MUST be provided in normalized (lower-case, snake_case) notation.
+Configuration item names SHOULD be provided in normalized (lower-case, snake_case) notation.
 Configuration value strings MUST be printed in quotes (so accidental leading or trailing whitespace can be spotted).
 
-Agents MUST provide information about following essential configuration items:
+Agents SHOULD log all configuration items that do not have default values.
+At the very minimum, agents MUST provide information about following essential configuration items:
 
 | Item | Needs masking | Example |
 | - | - | - | - |
@@ -126,8 +130,6 @@ Agents MUST provide information about following essential configuration items:
 | `api_key` | yes | `[REDACTED]` |
 | `service_name` | no | `foo` |
 | `log_level` | no | `warning` |
-
-Additional configurations items MAY be logged after that as well.
 
 For each configuration option its **source** SHOULD be reported. These sources can be:
 


### PR DESCRIPTION
In a recent discussion regarding supportability, we identified the need for logging configuration options in a more systematic way. Especially a configuration item's source (environment, config file, ...) was found to be useful in the agent log file.

This led to the idea of having a common "logging preamble" across APM agents.

PTAL, let me know what you think, and I'm happy to accommodate further suggestions regarding useful logging information in this PR.

<!--
Agent spec PR checklist

Delete all of this if the PR is not changing the agent spec.
Delete sections that don't apply to this PR.
If a specific checkbox doesn't apply, ~strike through~ and check it instead of deleting it.
-->

<!--
Use this section if the spec requires changes in more than two agents.

This extended template ensures that we have a meta issue and tracking issues so that we don't forget about implementing the changes in all affected agents.
-->

- [x] Create PR as draft
- [x] Approval by at least one other agent
- [x] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [x] Approved by at least 2 agents + PM (if relevant)
- [ ] Merge after 7 days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.
- [ ] [Create implementation issues through the meta issue template](https://github.com/elastic/apm/issues/new?assignees=&labels=meta%2C+apm-agents&template=apm-agents-meta.md) (this will automate issue creation for individual agents)
