### PR TITLE
Fix copy-paste error in cloud metadata collection

### DIFF
--- a/specs/agents/metadata.md
+++ b/specs/agents/metadata.md
@@ -209,7 +209,7 @@ curl -X GET "http://metadata.google.internal/computeMetadata/v1/?recursive=true"
 
 From the returned metadata, the following fields are useful
 
-| Cloud metadata field  | AWS Metadata field  |
+| Cloud metadata field  | GCP Metadata field  |
 | --------------------  | ------------------- |
 | `instance.id`         | `instance.id`       |
 | `instance.name`       | `instance.name`     |
@@ -235,7 +235,7 @@ curl -X GET "http://169.254.169.254/metadata/instance/compute?api-version=2019-0
 
 From the returned metadata, the following fields are useful
 
-| Cloud metadata field  | AWS Metadata field  |
+| Cloud metadata field  | Azure Metadata field|
 | --------------------  | ------------------- |
 | `account.id`          | `subscriptionId`    |
 | `instance.id`         | `vmId`              |


### PR DESCRIPTION
Noticed this while looking at another PR. Those `AWS Metadata field` headers in the GCP and Azure sections seem to be copy-paste leftovers. Fixing it in this PR.

- [x] Create PR as draft
- [x] Approval by at least one other agent
- [x] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [ ] Merge after 2 business days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.
