### PR TITLE
Change default APM server_url to 'http://127.0.0.1:8200' to avoid IPv6 ambiguity

### DIFF
--- a/specs/agents/configuration.md
+++ b/specs/agents/configuration.md
@@ -77,7 +77,7 @@ Also known as "central configuration". Agents can query the APM Server for confi
 
 Agents should poll the APM Server for config periodically by sending an HTTP request to the `/config/v1/agents` endpoint. Agents must specify their service name, and optionally environment. The server will use these to filter the configuration down to the relevant service and environment. There are two methods for sending these parameters:
 
-1. Using the `GET` method, pass them as query parameters: `http://localhost:8200/config/v1/agents?service.name=opbeans&service.environment=production`
+1. Using the `GET` method, pass them as query parameters: `http://127.0.0.1:8200/config/v1/agents?service.name=opbeans&service.environment=production`
 2. Using the `POST` method, encode the parameters as a JSON object in the body, e.g. `{"service": {"name": "opbeans", "environment": "production"}}`
 
 The server will respond with a JSON object, where each key maps a config attribute to a string value. The string value should be interpreted the same as if it were passed in via an environment variable. Upon receiving these config changes, the agent will update its configuration dynamically, overriding any config previously specified. That is, config via Kibana takes highest precedence.
@@ -139,7 +139,7 @@ To decrease onboarding friction,
 APM agents MUST not require any configuration to send data to a local APM Server.
 After onboarding, users can customize settings for which the defaults aren't appropriate.
 
-By default, agents MUST send data to the APM Server at `http://localhost:8200/`.
+By default, agents MUST send data to the APM Server at `http://127.0.0.1:8200/`.
 If possible, agents SHOULD detect sensible defaults for `service.name` and `service.version`.
 In any case agents MUST include `service.name` - if discovering it is not possible then the default value: `unknown-${service.agent.name}-service` MUST be used.
 This naming pattern allows the UI to display inline help on how to manually configure the name.


### PR DESCRIPTION
The current default APM server URL -- 'http://localhost:8200' -- is ambiguous. "localhost" can resolve to a '127.0.0.1' (IPv4) or '[::1]' (IPv6).

At least in Node v17 the default `dns.lookup()` ordering of results was changed to no longer explicitly sort IPv4 addresses first.  That means that on systems where the default resolver returns '[::1]' first for "localhost" will result in a broken attempt to talk to a default-configured local APM server:
  https://github.com/elastic/apm-agent-nodejs/issues/3045
This is because APM server only binds to the IPv4 port:
  https://github.com/elastic/apm-server/issues/1405


# Checklist

- May the instrumentation collect sensitive information, such as secrets or PII (ex. in headers)?
  - [ ] Yes
    - [ ] Add a section to the spec how agents should apply sanitization (such as `sanitize_field_names`)
  - [ ] No
    - [ ] Why?
  - [x] n/a
- [x] Create PR as draft
- [x] Approval by at least one other agent
- [x] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [x] Approved by at least 2 agents + PM (if relevant)
- [ ] Merge after 7 days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.
- [ ] [Create implementation issues through the meta issue template](https://github.com/elastic/apm/issues/new?assignees=&labels=meta%2C+apm-agents&template=apm-agents-meta.md) (this will automate issue creation for individual agents)
- [ ] If this spec adds a new dynamic config option, [add it to central config](../specs/agents/configuration.md#adding-a-new-configuration-option).

/schedule 2022-12-13
