### PR TITLE
Specify agent activation methods

### DIFF
--- a/specs/agents/metadata.md
+++ b/specs/agents/metadata.md
@@ -136,21 +136,23 @@ For official Elastic agents, the agent name should just be the name of the langu
 
 Services running on AWS Lambda [require specific values](tracing-instrumentation-aws-lambda.md) for some of the above mentioned fields.
 
-#### Installation method
+#### Activation method
 
-Most of the APM Agents can be installed in several ways. Agents SHOULD collect information about the used installation method and send it in the `service.agent.installation.method` field within the metadata.
+Most of the APM Agents can be activated in several ways. Agents SHOULD collect information about the used activation method and send it in the `service.agent.activation.method` field within the metadata.
 
-The intention of this field is to drive telemetry so there is a way to know which installation methods are commonly used. This field MUST produce data with very low cardinality, therefore agents SHOULD use one of the values defined below.
+The intention of this field is to drive telemetry so there is a way to know which activation methods are commonly used. This field MUST produce data with very low cardinality, therefore agents SHOULD use one of the values defined below.
 
-There are some well-known installation methods which can be used by multiple agents. In those cases, agents SHOULD send the following values in `service.agent.installation.method`:
+If the agent is unable to infer the activation method, it SHOULD send `unknown`.
+
+There are some well-known activation methods which can be used by multiple agents. In those cases, agents SHOULD send the following values in `service.agent.activation.method`:
 
 - `aws-lambda-layer`: when the agent was installed as a Lambda layer.
 - `k8s-attach`: when the agent is attached via [the K8s webhook](https://github.com/elastic/apm-mutating-webhook).
-- `env-attach`: when the agent is installed by setting some environment variables. Only use this if there is a single way to install the agent via an environment variable. If the given runtime offers multiple environment variables to install the agent, use more specific values to avoid ambiguity.
-- `fleet`: when the agent is attached via fleet.
+- `env-attach`: when the agent is activated by setting some environment variables. Only use this if there is a single way to activate the agent via an environment variable. If the given runtime offers multiple environment variables to activate the agent, use more specific values to avoid ambiguity.
+- `fleet`: when the agent is activated via fleet.
 
-Cross agent installation methods defined above have higher priority than agent specific values below.
-If none of the above matches the installation method, agents define specific values for specific scenarios.
+Cross agent activation methods defined above have higher priority than agent specific values below.
+If none of the above matches the activation method, agents define specific values for specific scenarios.
 
 Node.js:
 - `require`

--- a/specs/agents/metadata.md
+++ b/specs/agents/metadata.md
@@ -155,9 +155,9 @@ Cross agent activation methods defined above have higher priority than agent spe
 If none of the above matches the activation method, agents define specific values for specific scenarios.
 
 Node.js:
-- `require`
-- `import`
-- `preload`
+- `require`: when the agent is started via CommonJS `require('elastic-apm-node').start()` or `require('elastic-apm-node/start')`.
+- `import`: when the agent is started via ESM, e.g. `import 'elastic-apm-node/start.js'`.
+- `preload`: when the agent is started via the Node.js `--require` flag, e.g. `node -r elastic-apm-node/start ...`, without using `NODE_OPTIONS`.
 
 Java:
 - `javaagent-flag`: when the agent is attached via the `-javaagent` JVM flag.

--- a/specs/agents/metadata.md
+++ b/specs/agents/metadata.md
@@ -136,6 +136,37 @@ For official Elastic agents, the agent name should just be the name of the langu
 
 Services running on AWS Lambda [require specific values](tracing-instrumentation-aws-lambda.md) for some of the above mentioned fields.
 
+#### Installation method
+
+Most of the APM Agents can be installed in several ways. Agents SHOULD collect information about the used installation method and send it in the `service.agent.installation.method` field within the metadata.
+
+The intention of this field is to drive telemetry so there is a way to know which installation methods are commonly used. This field MUST produce data with very low cardinality, therefore agents SHOULD use one of the values defined below.
+
+There are some well-known installation methods which can be used by multiple agents. In those cases, agents SHOULD send the following values in `service.agent.installation.method`:
+
+- `aws-lambda-layer`: when the agent runs in AWS lambda and uses [the AWS lambda extension](https://github.com/elastic/apm-aws-lambda).
+- `k8s-attach`: when the agent is attached via [the K8s webhook](https://github.com/elastic/apm-mutating-webhook).
+- `env-attach`: when the agent is installed by setting some environment variables.
+- `azure-functions`: when the agent runs within an Azure function.
+- `fleet`: when the agent is attached via fleet.
+
+Cross agent installation methods defined above have higher priority than agent specific values below.
+If none of the above matches the installation method, agents define specific values for specific scenarios.
+
+Node.js:
+- `require`
+- `import`
+- `preload`
+
+Java:
+- `javaagent-flag`
+- `apm-agent-attach-cli`
+- `programmatic-self-attach`
+
+.NET:
+- `nuget`
+- `profiler`
+
 ### Cloud Provider Metadata
 
 [Cloud provider metadata](https://github.com/elastic/apm-server/blob/main/docs/spec/v2/metadata.json)

--- a/specs/agents/metadata.md
+++ b/specs/agents/metadata.md
@@ -144,10 +144,9 @@ The intention of this field is to drive telemetry so there is a way to know whic
 
 There are some well-known installation methods which can be used by multiple agents. In those cases, agents SHOULD send the following values in `service.agent.installation.method`:
 
-- `aws-lambda-layer`: when the agent runs in AWS lambda and uses [the AWS lambda extension](https://github.com/elastic/apm-aws-lambda).
+- `aws-lambda-layer`: when the agent was installed as a Lambda layer.
 - `k8s-attach`: when the agent is attached via [the K8s webhook](https://github.com/elastic/apm-mutating-webhook).
-- `env-attach`: when the agent is installed by setting some environment variables.
-- `azure-functions`: when the agent runs within an Azure function.
+- `env-attach`: when the agent is installed by setting some environment variables. Only use this if there is a single way to install the agent via an environment variable. If the given runtime offers multiple environment variables to install the agent, use more specific values to avoid ambiguity.
 - `fleet`: when the agent is attached via fleet.
 
 Cross agent installation methods defined above have higher priority than agent specific values below.
@@ -159,13 +158,14 @@ Node.js:
 - `preload`
 
 Java:
-- `javaagent-flag`
-- `apm-agent-attach-cli`
-- `programmatic-self-attach`
+- `javaagent-flag`: when the agent is attached via the `-javaagent` JVM flag.
+- `apm-agent-attach-cli`: when the agent is attached via the `apm-agent-attach-cli` tool.
+- `programmatic-self-attach`: when the agent is attached by manually calling the `ElasticApmAttacher` API in user code.
 
 .NET:
-- `nuget`
-- `profiler`
+- `nuget`: when the agent was installed via a NuGet package.
+- `profiler`: when the agent was installed via the CLR Profiler.
+- `startup-hook`: when the agent relies on the `DOTNET_STARTUP_HOOKS` mechanism to install the agent.
 
 ### Cloud Provider Metadata
 


### PR DESCRIPTION
Solves https://github.com/elastic/apm/issues/725

Mainly 2 things here:
1) There are installation methods which are common across agents - the goal is to define those and make sure agents report the same value in those cases (e.g. same value reported for k8s webhook, AWS Lambda extension, etc.). 
2) We should try to list values specific for each agents. These values are very much dependent on the given agent and that part should be driven by the specific agent team. I added the values I'm aware of - please look at this part for your agent and  suggest changes to this part if needed.

- May the instrumentation collect sensitive information, such as secrets or PII (ex. in headers)?
  - [ ] Yes
    - [ ] Add a section to the spec how agents should apply sanitization (such as `sanitize_field_names`)
  - [x] No
    - [ ] Why? - Agent installation method is isn't sensitive.
  - [ ] n/a
- [x] Create PR as draft
- [x] Approval by at least one other agent
- [x] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [x] Approved by at least 2 agents + PM (if relevant)
- [x] Merge after 7 days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.
- [ ] [Create implementation issues through the meta issue template](https://github.com/elastic/apm/issues/new?assignees=&labels=meta%2C+apm-agents&template=apm-agents-meta.md) (this will automate issue creation for individual agents)
- [ ] If this spec adds a new dynamic config option, [add it to central config](../specs/agents/configuration.md#adding-a-new-configuration-option).
