### PR TITLE
Added s3-prefix to S3 destination.service.resource

### DIFF
--- a/specs/agents/tracing-instrumentation-db.md
+++ b/specs/agents/tracing-instrumentation-db.md
@@ -83,7 +83,7 @@ The following fields are relevant for database and datastore spans. Where possib
 |`_.port`|e.g. `443`| Not available in some cases. Only set if the actual connection is available. |
 |`_.service.name`| `s3` | DEPRECATED, use `service.target.{type,name}`
 |`_.service.type`|`storage`| DEPRECATED, use `service.target.{type,name}`
-|`_.service.resource`| e.g. `my-bucket`, `accesspoint/myendpointslashes`, or `accesspoint:myendpointcolons`| DEPRECATED, use `service.target.{type,name}` |
+|`_.service.resource`| e.g. `s3/my-bucket`, `s3/accesspoint/myendpointslashes`, or `s3/accesspoint:myendpointcolons`| DEPRECATED, use `service.target.{type,name}` |
 |`_.cloud.region`| e.g. `us-east-1` | The AWS region where the bucket is. |
 | __**service.target._**__ |<hr/>|<hr/>|
 |`_.type`| `s3` ||


### PR DESCRIPTION
This PR is essentially a followup of #683 regarding the second point in [this comment](https://github.com/elastic/apm/pull/674#issuecomment-1219784156):
>- Should `context.destination.service.resource` be changed to include an 's3/' prefix?
  Currently the S3 spec has `service.target = { type: 's3', name: '$bucketNameIfAvailable' }`. This means that following the usual inference of `context.destination.service.resource` from `context.service.target` we would expect "s3/$bucketName" (or "s3" if there is no bucket name, e.g. for the "ListBuckets" API call) rather than the currently specified "$bucketNameIfAvailable".
  
The reason why this issue came back on the table is that @AlexanderWert encountered it in form of a defect in the UI (see elastic/apm-agent-java#2849).

Even though `context.destination.service.resource` is deprecated, it is likely to stay around for a while and impact UI features. Therefore we need to still fix it imo.

To my knowledge, adding the `s3/` would have the following negative consequences:
 * It would break the history of the S3-Spans / metrics for customers relying on `context.destination.service.resource`
 * If users happen to run agents both with and without this fix (for same or different languages), the same S3-buckets can appear twice in the service map (with and without s3-prefix)

This list might not be exhaustive, feel free to comment if you come up with additional concerns.

In my opinion these negative consequences are acceptable, because I would classify this change as a bugfix.
We should however explicitly highlight this change in the agent changelogs when implementing this spec update.

- May the instrumentation collect sensitive information, such as secrets or PII (ex. in headers)?
  - [ ] Yes
    - [ ] Add a section to the spec how agents should apply sanitization (such as `sanitize_field_names`)
  - [x] No
    - [x] Why? -> Diff says it all
  - [ ] n/a
- [x] Create PR as draft
- [x] Approval by at least one other agent
- [x] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [x] Approved by at least 2 agents + PM (if relevant)
- [x] Merge after 7 days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.
- [ ] [Create implementation issues through the meta issue template](https://github.com/elastic/apm/issues/new?assignees=&labels=meta%2C+apm-agents&template=apm-agents-meta.md) (this will automate issue creation for individual agents)
- [ ] ~~If this spec adds a new dynamic config option, [add it to central config](https://github.com/elastic/apm/blob/main/specs/agents/configuration.md#adding-a-new-configuration-option).~~
