### PR TITLE
Correct field name for agent activation method

### DIFF
--- a/specs/agents/metadata.md
+++ b/specs/agents/metadata.md
@@ -138,13 +138,13 @@ Services running on AWS Lambda [require specific values](tracing-instrumentation
 
 #### Activation method
 
-Most of the APM Agents can be activated in several ways. Agents SHOULD collect information about the used activation method and send it in the `service.agent.activation.method` field within the metadata.
+Most of the APM Agents can be activated in several ways. Agents SHOULD collect information about the used activation method and send it in the `service.agent.activation_method` field within the metadata.
 
 The intention of this field is to drive telemetry so there is a way to know which activation methods are commonly used. This field MUST produce data with very low cardinality, therefore agents SHOULD use one of the values defined below.
 
 If the agent is unable to infer the activation method, it SHOULD send `unknown`.
 
-There are some well-known activation methods which can be used by multiple agents. In those cases, agents SHOULD send the following values in `service.agent.activation.method`:
+There are some well-known activation methods which can be used by multiple agents. In those cases, agents SHOULD send the following values in `service.agent.activation_method`:
 
 - `aws-lambda-layer`: when the agent was installed as a Lambda layer.
 - `k8s-attach`: when the agent is attached via [the K8s webhook](https://github.com/elastic/apm-mutating-webhook).


### PR DESCRIPTION
The field name that apm-server added used an underscore.

Refs: https://github.com/elastic/apm-server/pull/9850
Refs: https://github.com/elastic/apm/pull/732

