### PR TITLE
Spec config to enable/disable OTel bridge

### DIFF
--- a/specs/agents/tracing-api-otel.md
+++ b/specs/agents/tracing-api-otel.md
@@ -5,6 +5,8 @@
 Agents MAY provide a bridge implementation of OpenTelemetry Tracing API following this specification.
 When available, implementation MUST be configurable and should be disabled by default when marked as `experimental`.
 
+Agents MAY add an explicit agent configuration to enable/disable the bridge. If an agent implements such a configuration, the configuration name MUST be `ELASTIC_APM_OPENTELEMETRY_BRIDGE_ENABLED`.
+
 The bridge implementation relies on APM Server version 7.16 or later. Agents SHOULD recommend this minimum version to users in bridge documentation.
 
 Bridging here means that for each OTel span created with the API, a native span/transaction will be created and sent to APM server.

--- a/specs/agents/tracing-api-otel.md
+++ b/specs/agents/tracing-api-otel.md
@@ -5,7 +5,7 @@
 Agents MAY provide a bridge implementation of OpenTelemetry Tracing API following this specification.
 When available, implementation MUST be configurable and should be disabled by default when marked as `experimental`.
 
-Agents MAY add an explicit agent configuration to enable/disable the bridge. If an agent implements such a configuration, the configuration name MUST be `ELASTIC_APM_OPENTELEMETRY_BRIDGE_ENABLED`.
+Agents MAY add an explicit agent configuration to enable/disable the bridge. If an agent implements such a configuration, the configuration name MUST be `opentelemetry_bridge_enabled`.
 
 The bridge implementation relies on APM Server version 7.16 or later. Agents SHOULD recommend this minimum version to users in bridge documentation.
 


### PR DESCRIPTION
Specify the `ELASTIC_APM_OPENTELEMETRY_BRIDGE_ENABLED` config in the OTel bridge spec.

This config is not relevant for all agents, but some (I know about [Node.js](https://www.elastic.co/guide/en/apm/agent/nodejs/current/configuration.html#opentelemetry-bridge-enabled) and .NET) have an explicit config to enable/disable the OTel bridge. Goal of the PR is to make sure all agents use the same config name.

Discussion from .NET: https://github.com/elastic/apm-agent-dotnet/pull/1966#discussion_r1060551833. The name is taken from the Node.js implementation. So far the only agent which needs to adapt is .NET that I know of.

- [x] Create PR as draft
- [x] Approval by at least one other agent
- [x] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [ ] Merge after 2 business days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.

