### PR TITLE
logs dataset naming constraints

### DIFF
--- a/specs/agents/log-reformatting.md
+++ b/specs/agents/log-reformatting.md
@@ -99,6 +99,9 @@ A good example is in the Java agent, where `event.dataset` is set to
 `${service.name}.${appender.name}`, where `appender.name` is the name of the
 log appender.
 
+The `event.dataset` values need to remain compatible with [`data_stream.dataset`](https://www.elastic.co/guide/en/ecs/master/ecs-data_stream.html#field-data-stream-dataset)
+and thus have the same naming restrictions as index names.
+
 If an agent doesn't have reasonable options for this field, it should be set
 to `${service.name}`.
 

--- a/specs/agents/log-sending.md
+++ b/specs/agents/log-sending.md
@@ -57,5 +57,5 @@ When the agent starts, agent log events might require some limited buffering unt
 This allows to capture the early log messages when the agent initializes which often provide details about the agent
 setup and configuration which are required for support.
 
-For the `event.dataset` field, the `${service.name}.apm-agent` value should be used to allow keeping application logs
+For the `event.dataset` field, the `${service.name}.apm_agent` value should be used to allow keeping application logs
 and agent logs separate if needed.


### PR DESCRIPTION
The specification for logging currently allows to have values in `event.dataset` that do not fit the `data_stream.dataset`.
There are two places where this is mentionned:
- In log sending when the agent is sending its own logs: https://github.com/elastic/apm/blob/main/specs/agents/log-sending.md#agent-log with the `${service.name}.apm-agent` value.
- In log reformatting when agent reformats the application logs: https://github.com/elastic/apm/blob/main/specs/agents/log-reformatting.md#eventdataset

### Checklist
- [ ] do we have an existing normalization in place for `service.name` to ensure those constraints ?
- [ ] find if we can define (or link existing) normalization: replacing with underscores seems a relevant option.
- [ ] in case ECS logging is used, should we make the APM agents automatically normalize the values provided by the application ?

-------
<!--
Agent spec PR checklist

Delete all of this if the PR is not changing the agent spec.
Delete sections that don't apply to this PR.
If a specific checkbox doesn't apply, ~strike through~ and check it instead of deleting it.
-->

<!--
Use this section if the spec requires changes in at most two agents.

Examples:
- Typos or clarifications without semantic changes
- Changes in a spec before it has been implemented
- Features that are only implemented in two agents
-->

- [x] Create PR as draft
- [ ] Approval by at least one other agent
- [ ] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [ ] Merge after 2 business days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.

<!--
Use this section if the spec requires changes in more than two agents.

This extended template ensures that we have a meta issue and tracking issues so that we don't forget about implementing the changes in all affected agents.
-->

- May the instrumentation collect sensitive information, such as secrets or PII (ex. in headers)?
  - [ ] Yes
    - [ ] Add a section to the spec how agents should apply sanitization (such as `sanitize_field_names`)
  - [ ] No
    - [ ] Why?
  - [ ] n/a
- [ ] Create PR as draft
- [ ] Approval by at least one other agent
- [ ] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [ ] Approved by at least 2 agents + PM (if relevant)
- [ ] Merge after 7 days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.
- [ ] [Create implementation issues through the meta issue template](https://github.com/elastic/apm/issues/new?assignees=&labels=meta%2C+apm-agents&template=apm-agents-meta.md) (this will automate issue creation for individual agents)
- [ ] If this spec adds a new dynamic config option, [add it to central config](https://github.com/elastic/apm/blob/main/specs/agents/configuration.md#adding-a-new-configuration-option).
