### PR TITLE
Mobile crash events

### DIFF
--- a/specs/agents/mobile/events.md
+++ b/specs/agents/mobile/events.md
@@ -8,10 +8,10 @@ Event names will be recording using the `event.name`
 These event represents the occurrence of app entering the foreground or background or other application lifecycle states.
 The precise names of these events are still to be determined. They may mirror the lifecycle events their respective mobile platforms.
 
-| Name           | Type   | Values   | Description                                        |
-|----------------|--------|----------|----------------------------------------------------|
-| `event.name`   | String | tbd      | The name of the event                              |
-| `event.domain` | String | `device` | The lifecycle state the app is transitioning to.   | 
+| Name           | Type   | Values   | Description              |
+|----------------|--------|----------|--------------------------|
+| `event.name`   | String | tbd      | The name of the event.   |
+| `event.domain` | String | `device` | The domain of the event. | 
 
 
 
@@ -19,18 +19,21 @@ The precise names of these events are still to be determined. They may mirror th
 This event represents the occurrence of an 'ANR' error reported by the Android OS.
 
 #### Attributes
-| Name           | Type | Value | Description |
-|----------------|------|-------|-------------|
-| `event.name`   |   String   |   `anr`    |      The app's UI thread has been blocked for longer than it should.      |
+| Name           | Type   | Value    | Description                                                     |
+|----------------|--------|----------|-----------------------------------------------------------------|
+| `event.name`   | String | `anr`    | The app's UI thread has been blocked for longer than it should. |
+| `event.domain` | String | `device` | The domain of the event.                                        | 
 
 ### `Breadcrumbs`
 
 An event that allows customers to add events to a common `Event` that allows them to retrace users' steps. 
 
 #### Attributes
-| Name           | Type    | Value        | Description            |
-|----------------|---------|--------------|------------------------|
-| `event.name`   | String  | `breadcrumb` | The name of the Event  |
+| Name           | Type   | Value        | Description              |
+|----------------|--------|--------------|--------------------------|
+| `event.name`   | String | `breadcrumb` | The name of the event.   |
+| `event.domain` | String | `device`     | The domain of the event. | 
+              
 
 ### Crashes
 
@@ -38,10 +41,13 @@ This event represent a crash event
 
 #### Attributes
 
-| Name           | Type    | Values  | Description       |
-|----------------|---------|---------|-------------------|
-| `event.name`   | String  | `crash` | The event name    | 
-| `event.domain` | String | `device` | the event domain  |
-| `stacktrace`   | String  | N/A     | A Stacktrace      |
+| Name                   | Type   | Values               | Description            |
+|------------------------|--------|----------------------|------------------------|
+| `event.name`           | String | `crash`              | The event name.        | 
+| `event.domain`         | String | `device`             | the event domain.      |
+| `exception.message`    | String | `Division by zero`   | The exception message. |  
+| `exception.stacktrace` | String |                      | A Stacktrace.          |
+| `exception.type`       | String | `OSError`, `SIGSEGV` | The exception type.    |
+
 
 

--- a/specs/agents/mobile/events.md
+++ b/specs/agents/mobile/events.md
@@ -8,11 +8,11 @@ Event names will be recording using the `event.name`
 This event represents the occurrence of app entering the foreground or background or other application lifecycle states.
 
 #### Attributes
-| Name         | Type   | Units | Description            |
-|--------------|--------|-------|------------------------|
-| `event.name` | String | N/A   | `ApplicationLifecycle` |
-| `state`      | String | N/A   | `foreground`           |
-| `state.last` | String | N/A   | `background`           |
+| Name         | Type   | Values                 | Description                                        |
+|--------------|--------|------------------------|----------------------------------------------------|
+| `event.name` | String | `ApplicationLifecycle` | The name of the event                              |
+| `state`      | String | `foreground`           | The lifecycle state the app is transitioning to.   | 
+| `state.last` | String | `background`           | The lifecycle state the app is transitioning from. | 
 
 
 
@@ -20,7 +20,7 @@ This event represents the occurrence of app entering the foreground or backgroun
 This event represents the occurrence of an 'ANR' error reported by the Android OS.
 
 #### Attributes
-| Name           | Type | Units | Description |
+| Name           | Type | Value | Description |
 |----------------|------|-------|-------------|
 | `event.name`   |      |       |             |
 
@@ -29,24 +29,25 @@ This event represents the occurrence of an 'ANR' error reported by the Android O
 An event that allows customers to add events to a common `Event` that allows them to retrace users' steps. 
 
 #### Attributes
-| Name           | Type    | Units | Description  |
-|----------------|---------|-------|--------------|
-| `event.name`   | String  | N/A   | `Breadcrumb` |
+| Name           | Type    | Value        | Description            |
+|----------------|---------|--------------|------------------------|
+| `event.name`   | String  | `Breadcrumb` | The name of the Event  |
 
 ### Crashes
 
 This event represent a crash event
+
 #### Attributes
-| Name           | Type    | Units | Description |
-|----------------|---------|-------|-------------|
-| `event.name`   | String  | N/A   | `Crash`     |
-| `stacktrace`   | String  | N/A   |             | 
+| Name           | Type    | Values  | Description    |
+|----------------|---------|---------|----------------|
+| `event.name`   | String  | `Crash` | The event name | 
+| `stacktrace`   | String  | N/A     | A Stacktrace   | 
 
 ### `Application Opens`
 
 An event that represents when an app is opened.
 
 #### Attributes
-| Name           | Type   | Units | Description           |
-|----------------|--------|-------|-----------------------|
-| `event.name`   | String | N/A   | `Application Opened`  |
+| Name           | Type   | Value                | Description    |
+|----------------|--------|----------------------|----------------|
+| `event.name`   | String | `Application Opened` | The event name | 

--- a/specs/agents/mobile/events.md
+++ b/specs/agents/mobile/events.md
@@ -1,6 +1,7 @@
 ## Mobile Events
 
 This document describes event used by the Mobile SDKs using the [OpenTelementry Event Api](https://github.com/open-telemetry/opentelemetry-specification/blob/0a4c6656d1ac1261cfe426b964fd63b1c302877d/specification/logs/event-api.md).
+All events collected by the mobile agents should set the `event.domain` to `device`.
 Event names will be recording using the `event.name`
 
 
@@ -22,7 +23,7 @@ This event represents the occurrence of an 'ANR' error reported by the Android O
 #### Attributes
 | Name           | Type | Value | Description |
 |----------------|------|-------|-------------|
-| `event.name`   |      |       |             |
+| `event.name`   |   String   |   `anr`    |      The app's UI thread has been blocked for longer than it should.      |
 
 ### `Breadcrumbs`
 
@@ -31,7 +32,7 @@ An event that allows customers to add events to a common `Event` that allows the
 #### Attributes
 | Name           | Type    | Value        | Description            |
 |----------------|---------|--------------|------------------------|
-| `event.name`   | String  | `Breadcrumb` | The name of the Event  |
+| `event.name`   | String  | `breadcrumb` | The name of the Event  |
 
 ### Crashes
 
@@ -40,7 +41,7 @@ This event represent a crash event
 #### Attributes
 | Name           | Type    | Values  | Description    |
 |----------------|---------|---------|----------------|
-| `event.name`   | String  | `Crash` | The event name | 
+| `event.name`   | String  | `crash` | The event name | 
 | `stacktrace`   | String  | N/A     | A Stacktrace   | 
 
 ### `Application Opens`

--- a/specs/agents/mobile/events.md
+++ b/specs/agents/mobile/events.md
@@ -4,37 +4,6 @@ This document describes event used by the Mobile SDKs using the [OpenTelementry 
 All events collected by the mobile agents should set the `event.domain` to `device`.
 Event names will be recording using the `event.name`
 
-### Application Lifecycle events 
-These event represents the occurrence of app entering the foreground or background or other application lifecycle states.
-The precise names of these events are still to be determined. They may mirror the lifecycle events their respective mobile platforms.
-
-| Name           | Type   | Values   | Description              |
-|----------------|--------|----------|--------------------------|
-| `event.name`   | String | tbd      | The name of the event.   |
-| `event.domain` | String | `device` | The domain of the event. | 
-
-
-
-### Application Non-Responsive (ANR)
-This event represents the occurrence of an 'ANR' error reported by the Android OS.
-
-#### Attributes
-| Name           | Type   | Value    | Description                                                     |
-|----------------|--------|----------|-----------------------------------------------------------------|
-| `event.name`   | String | `anr`    | The app's UI thread has been blocked for longer than it should. |
-| `event.domain` | String | `device` | The domain of the event.                                        | 
-
-### `Breadcrumbs`
-
-An event that allows customers to add events to a common `Event` that allows them to retrace users' steps. 
-
-#### Attributes
-| Name           | Type   | Value        | Description              |
-|----------------|--------|--------------|--------------------------|
-| `event.name`   | String | `breadcrumb` | The name of the event.   |
-| `event.domain` | String | `device`     | The domain of the event. | 
-              
-
 ### Crashes
 
 This event represent a crash event

--- a/specs/agents/mobile/events.md
+++ b/specs/agents/mobile/events.md
@@ -1,0 +1,52 @@
+## Mobile Events
+
+This document describes event used by the Mobile SDKs using the [OpenTelementry Event Api](https://github.com/open-telemetry/opentelemetry-specification/blob/0a4c6656d1ac1261cfe426b964fd63b1c302877d/specification/logs/event-api.md).
+Event names will be recording using the `event.name`
+
+
+### `ApplicationLaunch` 
+This event represents the occurrence of app entering the foreground or background or other application lifecycle states.
+
+#### Attributes
+| Name         | Type   | Units | Description            |
+|--------------|--------|-------|------------------------|
+| `event.name` | String | N/A   | `ApplicationLifecycle` |
+| `state`      | String | N/A   | `foreground`           |
+| `state.last` | String | N/A   | `background`           |
+
+
+
+### Application Non-Responsive (ANR)
+This event represents the occurrence of an 'ANR' error reported by the Android OS.
+
+#### Attributes
+| Name           | Type | Units | Description |
+|----------------|------|-------|-------------|
+| `event.name`   |      |       |             |
+
+### `Breadcrumbs`
+
+An event that allows customers to add events to a common `Event` that allows them to retrace users' steps. 
+
+#### Attributes
+| Name           | Type    | Units | Description  |
+|----------------|---------|-------|--------------|
+| `event.name`   | String  | N/A   | `Breadcrumb` |
+
+### Crashes
+
+This event represent a crash event
+#### Attributes
+| Name           | Type    | Units | Description |
+|----------------|---------|-------|-------------|
+| `event.name`   | String  | N/A   | `Crash`     |
+| `stacktrace`   | String  | N/A   |             | 
+
+### `Application Opens`
+
+An event that represents when an app is opened.
+
+#### Attributes
+| Name           | Type   | Units | Description           |
+|----------------|--------|-------|-----------------------|
+| `event.name`   | String | N/A   | `Application Opened`  |

--- a/specs/agents/mobile/events.md
+++ b/specs/agents/mobile/events.md
@@ -4,16 +4,14 @@ This document describes event used by the Mobile SDKs using the [OpenTelementry 
 All events collected by the mobile agents should set the `event.domain` to `device`.
 Event names will be recording using the `event.name`
 
+### Application Lifecycle events 
+These event represents the occurrence of app entering the foreground or background or other application lifecycle states.
+The precise names of these events are still to be determined. They may mirror the lifecycle events their respective mobile platforms.
 
-### `ApplicationLaunch` 
-This event represents the occurrence of app entering the foreground or background or other application lifecycle states.
-
-#### Attributes
-| Name         | Type   | Values                 | Description                                        |
-|--------------|--------|------------------------|----------------------------------------------------|
-| `event.name` | String | `ApplicationLifecycle` | The name of the event                              |
-| `state`      | String | `foreground`           | The lifecycle state the app is transitioning to.   | 
-| `state.last` | String | `background`           | The lifecycle state the app is transitioning from. | 
+| Name           | Type   | Values   | Description                                        |
+|----------------|--------|----------|----------------------------------------------------|
+| `event.name`   | String | tbd      | The name of the event                              |
+| `event.domain` | String | `device` | The lifecycle state the app is transitioning to.   | 
 
 
 
@@ -39,16 +37,11 @@ An event that allows customers to add events to a common `Event` that allows the
 This event represent a crash event
 
 #### Attributes
-| Name           | Type    | Values  | Description    |
-|----------------|---------|---------|----------------|
-| `event.name`   | String  | `crash` | The event name | 
-| `stacktrace`   | String  | N/A     | A Stacktrace   | 
 
-### `Application Opens`
+| Name           | Type    | Values  | Description       |
+|----------------|---------|---------|-------------------|
+| `event.name`   | String  | `crash` | The event name    | 
+| `event.domain` | String | `device` | the event domain  |
+| `stacktrace`   | String  | N/A     | A Stacktrace      |
 
-An event that represents when an app is opened.
 
-#### Attributes
-| Name           | Type   | Value                | Description    |
-|----------------|--------|----------------------|----------------|
-| `event.name`   | String | `Application Opened` | The event name | 


### PR DESCRIPTION
Pulled the crash event spec out of the larger Mobile Event spec PR. The crash spec is agreed upon, while other events still need some discussion. 

- [ ] Create PR as draft
- [ ] Approval by at least one other agent
- [ ] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [ ] Merge after 2 business days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.

