### PR TITLE
Add `wrapper` service.agent.activation_method for python

### DIFF
--- a/specs/agents/metadata.md
+++ b/specs/agents/metadata.md
@@ -169,6 +169,9 @@ Java:
 - `profiler`: when the agent was installed via the CLR Profiler.
 - `startup-hook`: when the agent relies on the `DOTNET_STARTUP_HOOKS` mechanism to install the agent.
 
+Python:
+- `wrapper`: when the agent was invoked with the wrapper script, `elasticapm-run`
+
 ### Cloud Provider Metadata
 
 [Cloud provider metadata](https://github.com/elastic/apm-server/blob/main/docs/spec/v2/metadata.json)


### PR DESCRIPTION
Added to Python agent in https://github.com/elastic/apm-agent-python/pull/1743

- [x] Create PR as draft
- [x] Approval by at least one other agent
- [x] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [ ] Merge after 2 business days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.
