### PR TITLE
Spec service.environment for logs

### DIFF
--- a/specs/agents/log-correlation.md
+++ b/specs/agents/log-correlation.md
@@ -46,9 +46,11 @@ When using ECS logging, they might be set by the application in ECS logging conf
   - allows to filter/link log messages to a given service/environment.
   - must be provided even if there is no active transaction
 
-In addition, the `container.id` can be used as a fallback when `service.name` is not avaiable on the log documents.
-However, the APM agents are not expected to set it. It is expected to be set by filebeat when ingesting log
-documents through auto-discover feature (which captures logs from containers and provides the value).
+
+The `container.id` field can also be used as a fallback to provide service-level correlation in UI, however agents ARE NOT expected to set it:
+
+- log collector (filebeat) is expected to do that when ingesting logs.
+- all data sent through agent intake implicitly provides `container.id` through metadata, which also includes the log events that may be sent to apm-server.
 
 ### Trace correlation fields
 

--- a/specs/agents/log-correlation.md
+++ b/specs/agents/log-correlation.md
@@ -2,7 +2,7 @@
 
 Agents should provide instrumentation/hooks for popular logging libraries in order to decorate structured log records with trace context.
 In particular, logging that occurs within the context of a transaction should add the fields `trace.id` and `transaction.id`;
-logging that occurs within a span should add the fields `trace.id`, `span.id`, and optionally `transaction.id`.
+logging that occurs within a span should add the fields `trace.id` and optionally `transaction.id`.
 
 By adding trace context to log records, users will be able to move between the APM UI and Logs UI.
 

--- a/specs/agents/log-correlation.md
+++ b/specs/agents/log-correlation.md
@@ -9,26 +9,15 @@ By adding trace context to log records, users will be able to move between the A
 Logging frameworks and libraries may provide an MDC (Message Diagnostic Context) that allow to also
 reuse those fields in log message formats (for example in plain text).
 
-Log correlation is implemented by adding the following fields to a log document:
-- `service.name`:
-  - used to filter/link log messages to a given service.
-  - must be provided even if there is no active transaction
-- `service.version`:
-  - only used for service metadata correlation
-  - must be provided even if there is no active transaction
-- `service.environment`:
-  - allows to filter/link log messages to a given service/environment.
-  - must be provided even if there is no active transaction
-- `trace.id` and `transaction.id`
-  - allows to correlate with the APM trace/transaction.
-  - should be added to the MDC
-- `error.id`:
-  - allows to correlate with an Error.
-  - should be added to the MDC
-
-In addition, the `container.id` can be used as a fallback when `service.name` is not avaiable on the log documents.
-However, the APM agents are not expected to set it. It is expected to be set by filebeat when ingesting log
-documents through auto-discover feature (which captures logs from containers and provides the value).
+Log correlation relies on two sets of fields:
+- [metadata fields](#metadata-fields)
+  - They allow to build the per-service logs view in UI.
+  - They are implicitly provided when using log-sending by the agent metadata.
+  - When using ECS logging, they might be set by the application.
+- [per-log-event fields](#per-log-event-fields): `trace.id`, `transaction.id` and `error.id`
+  - They allow to build the per-trace/transaction/error logs view in UI.
+  - They are added to the MDC
+  - They must be written in each log event document
 
 The values for those fields can be set in two places:
 - when using [ecs-logging](https://github.com/elastic/ecs-logging) directly in the application
@@ -41,5 +30,33 @@ In case the values set in the application and agent configuration differ, the re
 messages won't correlate to the expected service in UI. In order to prevent such inconsistencies
 agents may issue a warning when there is a mis-configuration.
 
-See also the [log-reformatting](log-reformatting.md) spec.
+### Metadata fields
 
+They allow to build the per-service logs view in UI.
+They are implicitly provided when using log-sending by the agent metadata.
+When using ECS logging, they might be set by the application in ECS logging configuration.
+
+- `service.name`:
+  - used to filter/link log messages to a given service.
+  - must be provided even if there is no active transaction
+- `service.version`:
+  - only used for service metadata correlation
+  - must be provided even if there is no active transaction
+- `service.environment`:
+  - allows to filter/link log messages to a given service/environment.
+  - must be provided even if there is no active transaction
+
+In addition, the `container.id` can be used as a fallback when `service.name` is not avaiable on the log documents.
+However, the APM agents are not expected to set it. It is expected to be set by filebeat when ingesting log
+documents through auto-discover feature (which captures logs from containers and provides the value).
+
+### Per log event fields
+
+They allow to build the per-trace/transaction/error logs view in UI.
+They allow to navigate from the log event to the trace/transaction/error in UI.
+They should added to the MDC.
+They must be written in each log event document they relate to, either reformatted or sent by the agent.
+
+- `trace.id`
+- `transaction.id`
+- `error.id`

--- a/specs/agents/log-correlation.md
+++ b/specs/agents/log-correlation.md
@@ -26,6 +26,10 @@ Log correlation is implemented by adding the following fields to a log document:
   - allows to correlate with an Error.
   - should be added to the MDC
 
+In addition, the `container.id` can be used as a fallback when `service.name` is not avaiable on the log documents.
+However, the APM agents are not expected to set it. It is expected to be set by filebeat when ingesting log
+documents through auto-discover feature (which captures logs from containers and provides the value).
+
 The values for those fields can be set in two places:
 - when using [ecs-logging](https://github.com/elastic/ecs-logging) directly in the application
 - when the agent reformats a log event

--- a/specs/agents/log-correlation.md
+++ b/specs/agents/log-correlation.md
@@ -30,7 +30,7 @@ In case the values set in the application and agent configuration differ, the re
 messages won't correlate to the expected service in UI. In order to prevent such inconsistencies
 agents may issue a warning when there is a mis-configuration.
 
-### Metadata fields
+### Service correlation fields
 
 They allow to build the per-service logs view in UI.
 They are implicitly provided when using log-sending by the agent metadata.
@@ -50,7 +50,7 @@ In addition, the `container.id` can be used as a fallback when `service.name` is
 However, the APM agents are not expected to set it. It is expected to be set by filebeat when ingesting log
 documents through auto-discover feature (which captures logs from containers and provides the value).
 
-### Per log event fields
+### Trace correlation fields
 
 They allow to build the per-trace/transaction/error logs view in UI.
 They allow to navigate from the log event to the trace/transaction/error in UI.

--- a/specs/agents/log-correlation.md
+++ b/specs/agents/log-correlation.md
@@ -1,7 +1,41 @@
 ## Log correlation
 
-Agents should provide instrumentation/hooks for popular logging libraries in order to decorate structured log records with trace context. In particular, logging that occurs within the context of a transaction should add the fields `trace.id` and `transaction.id`; logging that occurs within a span should add the fields `trace.id`, `span.id`, and optionally `transaction.id`.
+Agents should provide instrumentation/hooks for popular logging libraries in order to decorate structured log records with trace context.
+In particular, logging that occurs within the context of a transaction should add the fields `trace.id` and `transaction.id`;
+logging that occurs within a span should add the fields `trace.id`, `span.id`, and optionally `transaction.id`.
 
 By adding trace context to log records, users will be able to move between the APM UI and Logs UI.
 
+Logging frameworks and libraries may provide an MDC (Message Diagnostic Context) that allow to also
+reuse those fields in log message formats (for example in plain text).
+
+Log correlation is implemented by adding the following fields to a log document:
+- `service.name`:
+  - used to filter/link log messages to a given service.
+  - must be provided even if there is no active transaction
+- `service.version`:
+  - only used for service metadata correlation
+  - must be provided even if there is no active transaction
+- `service.environment`:
+  - allows to filter/link log messages to a given service/environment.
+  - must be provided even if there is no active transaction
+- `trace.id` and `transaction.id`
+  - allows to correlate with the APM trace/transaction.
+  - should be added to the MDC
+- `error.id`:
+  - allows to correlate with an Error.
+  - should be added to the MDC
+
+The values for those fields can be set in two places:
+- when using [ecs-logging](https://github.com/elastic/ecs-logging) directly in the application
+- when the agent reformats a log event
+
+The values set at the application level have higher priority than the values set by agents.
+Agents must provide fallback values if they are not explicitly set by the application.
+
+In case the values set in the application and agent configuration differ, the resulting log
+messages won't correlate to the expected service in UI. In order to prevent such inconsistencies
+agents may issue a warning when there is a mis-configuration.
+
 See also the [log-reformatting](log-reformatting.md) spec.
+

--- a/specs/agents/log-correlation.md
+++ b/specs/agents/log-correlation.md
@@ -6,17 +6,17 @@ logging that occurs within a span should add the fields `trace.id`, `span.id`, a
 
 By adding trace context to log records, users will be able to move between the APM UI and Logs UI.
 
-Logging frameworks and libraries may provide an MDC (Message Diagnostic Context) that allow to also
-reuse those fields in log message formats (for example in plain text).
+Logging frameworks and libraries may provide a way to inject key-value pairs in log messages,
+this allows to reuse those fields in log message formats (for example in plain text).
 
 Log correlation relies on two sets of fields:
-- [metadata fields](#metadata-fields)
+- [metadata fields](#service-correlation-fields)
   - They allow to build the per-service logs view in UI.
   - They are implicitly provided when using log-sending by the agent metadata.
   - When using ECS logging, they might be set by the application.
-- [per-log-event fields](#per-log-event-fields): `trace.id`, `transaction.id` and `error.id`
+- [per-log-event fields](#trace-correlation-fields): `trace.id`, `transaction.id` and `error.id`
   - They allow to build the per-trace/transaction/error logs view in UI.
-  - They are added to the MDC
+  - They are added to the log event
   - They must be written in each log event document
 
 The values for those fields can be set in two places:
@@ -54,7 +54,7 @@ documents through auto-discover feature (which captures logs from containers and
 
 They allow to build the per-trace/transaction/error logs view in UI.
 They allow to navigate from the log event to the trace/transaction/error in UI.
-They should added to the MDC.
+They should be added to the log event.
 They must be written in each log event document they relate to, either reformatted or sent by the agent.
 
 - `trace.id`

--- a/specs/agents/log-reformatting.md
+++ b/specs/agents/log-reformatting.md
@@ -65,26 +65,17 @@ The following fields are required:
 
 ## Recommended fields
 
-The following fields are important for a good user experience in Kibana,
-but will not cause errors if they are omitted:
-
 ### `service.name`
 
-Agents should always populate `service.name` even if there is not an active transaction.
-
-When using [ecs-logging](https://github.com/elastic/ecs-logging) directly in the application, the logs are already
-written to ECS format, however the agent has to provide a fallback value if `service.name` is not set by the application.
-
-The `service.name` is used to be able to add a logs tab to the service view in
-the UI. This lets users quickly get a stream of all logs for a particular
-service.
+See [Log correlation](log-correlation.md)
 
 ### `service.version`
 
-Agents may populate the `service.version` if a value is set in the agent configuration.
+See [Log correlation](log-correlation.md)
 
-When using [ecs-logging](https://github.com/elastic/ecs-logging) directly in the application, the logs are already
-written to ECS format, however the agent should provide a fallback value if `service.version` is not set by the application.
+### `service.environment`
+
+See [Log correlation](log-correlation.md)
 
 ### `event.dataset`
 

--- a/specs/agents/logging.md
+++ b/specs/agents/logging.md
@@ -43,7 +43,7 @@ Also, the documentation should not mention the old log levels going forward.
 
 Agents may provide the following log-related features:
 
-- [Log correlation](log-correlation.md): inject current service/trace/transaction/error ID into logs.
+- [Log correlation](log-correlation.md): inject service metadata, trace IDs and error IDs in log events.
 - [Log reformatting](log-reformatting.md): reformat plain-text logs to ECS, equivalent to using [ecs logging](https://github.com/elastic/ecs-logging) 
 without modifying the application nor its dependencies.
 - [Log sending](log-sending.md): send logs directly to APM server.

--- a/specs/agents/logging.md
+++ b/specs/agents/logging.md
@@ -43,7 +43,7 @@ Also, the documentation should not mention the old log levels going forward.
 
 Agents may provide the following log-related features:
 
-- [Log correlation](log-correlation.md): inject current trace/transaction/error ID into logs.
+- [Log correlation](log-correlation.md): inject current service/trace/transaction/error ID into logs.
 - [Log reformatting](log-reformatting.md): reformat plain-text logs to ECS, equivalent to using [ecs logging](https://github.com/elastic/ecs-logging) 
 without modifying the application nor its dependencies.
 - [Log sending](log-sending.md): send logs directly to APM server.


### PR DESCRIPTION
- add `service.environment` to the fields used for log correlation
- move log correlation fields from log-reformatting to log-correlation
- clarify the expected behavior when ECS logging is used in the application and agent providing fallback values.

Relates to https://github.com/elastic/apm/issues/765

Follow-up tasks
- [ ] open PR to add this to documentation

-----

- May the instrumentation collect sensitive information, such as secrets or PII (ex. in headers)?
  - [x] n/a: only relates to log-correlation, which does not deal with sensitive data.
- [x] Create PR as draft
- [x] Approval by at least one other agent
- [x] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [x] Approved by at least 2 agents + PM (if relevant)
- [x] Merge after 7 days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.
- [ ] [Create implementation issues through the meta issue template](https://github.com/elastic/apm/issues/new?assignees=&labels=meta%2C+apm-agents&template=apm-agents-meta.md) (this will automate issue creation for individual agents)
- [x] ~~If this spec adds a new dynamic config option, [add it to central config](https://github.com/elastic/apm/blob/main/specs/agents/configuration.md#adding-a-new-configuration-option).~~ n/a
