### PR TITLE
Updated list of examples for SQL Databases spans actions

### DIFF
--- a/specs/agents/tracing-instrumentation-db.md
+++ b/specs/agents/tracing-instrumentation-db.md
@@ -226,7 +226,7 @@ Examples:
 |`name`| e.g. `SELECT FROM products` | For SQL operations we perform a limited parsing the statement, and extract the operation name and outer-most table involved (if any). See more details [here](https://docs.google.com/document/d/1sblkAP1NHqk4MtloUta7tXjDuI_l64sT2ZQ_UFHuytA). |
 |`type`|`db`|
 |`subtype`| e.g. `oracle`, `mysql` | [see below](#database-subtype) |
-|`action`|`query`|
+|`action`| e.g. `query`, `connect`, `ping`, `prepare`, `exec` |
 | __**context.db._**__  |<hr/>|<hr/>|
 |`_.instance`| e.g. `instance-name`| [see below](#database-instance) |
 |`_.statement`| e.g. `SELECT * FROM products WHERE ...`| The full SQL statement. We store up to 10000 Unicode characters per database statement.  |


### PR DESCRIPTION
To clarify that it's not just "query" and that some agent use various values for SQL Databases spans `action`.

- [x] Create PR as draft
- [x] Approval by at least one other agent
- [x] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [x] Merge after 2 business days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.
