### PR TITLE
Removing `span.context.message.body` from long-field spec

### DIFF
--- a/specs/agents/field-limits.md
+++ b/specs/agents/field-limits.md
@@ -2,19 +2,29 @@
 
 The maximum length of metadata, transaction, span, et al fields are determined
 by the [APM Server Events Intake API schema](https://www.elastic.co/guide/en/apm/server/current/events-api.html).
-Fields that are names or identifiers of some resource of typically limited to
-1024 unicode characters.
+Except for special cases, fields are typically limited to 1024 unicode characters. 
+Unless listed below as knowm "long fields", agents SHOULD truncate filed values to 1024 characters, as specified [below](#truncating-field-values).
 
-### `long_field_max_length` configuration
+### Long fields
 
-Some APM event fields are not limited in the APM server intake API schema.
-Agents SHOULD limit the maximum length of the following fields by truncating.
+Some APM event fields are not limited in the APM server intake API schema. 
+Such fields are considered "long fields".
+
+Agents SHOULD treat the following fields as long fields:
 
 - `transaction.context.request.body`, `error.context.request.body`
 - `transaction.context.message.body`, `error.context.message.body`
 - `span.context.db.statement`
+
+In addition, agents MAY treat the following fields as long fields:
+
 - `error.exception.message`
 - `error.log.message`
+
+Agents SHOULD limit the maximum length of long fields by [truncating](#truncating-field-values) them to 10,000 unicode characters, 
+or based on user configuration for long field length, as specified [below](#long_field_max_length-configuration).
+
+### `long_field_max_length` configuration
 
 Agents MAY support the `long_field_max_length` configuration option to allow
 the user to configure this maximum length. This option defines a maximum number
@@ -29,3 +39,8 @@ of unicode characters for each field.
 
 Ultimately the maximum length of any field is limited by the [`max_event_size`](https://www.elastic.co/guide/en/apm/server/current/configuration-process.html#max_event_size)
 configured for the receiving APM server.
+
+### Truncating field values
+
+When field values exceed the maximum allowed number of unicode characters, agents SHOULD truncate the valiues to fit the maximum allowed length, 
+replacing the last character of the eventual value with the ellipsis chracter (unicode character `U+2026`: "&#x2026;").

--- a/specs/agents/field-limits.md
+++ b/specs/agents/field-limits.md
@@ -11,7 +11,7 @@ Some APM event fields are not limited in the APM server intake API schema.
 Agents SHOULD limit the maximum length of the following fields by truncating.
 
 - `transaction.context.request.body`, `error.context.request.body`
-- `transaction.context.message.body`, `span.context.message.body`, `error.context.message.body`
+- `transaction.context.message.body`, `error.context.message.body`
 - `span.context.db.statement`
 - `error.exception.message`
 - `error.log.message`

--- a/specs/agents/field-limits.md
+++ b/specs/agents/field-limits.md
@@ -42,5 +42,5 @@ configured for the receiving APM server.
 
 ### Truncating field values
 
-When field values exceed the maximum allowed number of unicode characters, agents SHOULD truncate the valiues to fit the maximum allowed length, 
-replacing the last character of the eventual value with the ellipsis chracter (unicode character `U+2026`: "&#x2026;").
+When field values exceed the maximum allowed number of unicode characters, agents SHOULD truncate the values to fit the maximum allowed length, 
+replacing the last character of the eventual value with the ellipsis character (unicode character `U+2026`: "&#x2026;").


### PR DESCRIPTION
In our [messaging spec](https://github.com/elastic/apm/blob/main/specs/agents/tracing-instrumentation-messaging.md#transaction-context-fields) we only talk about capturing message bodies for transactions and not spans.