### PR TITLE
Add span name to span spec

### DIFF
--- a/specs/agents/tracing-spans.md
+++ b/specs/agents/tracing-spans.md
@@ -27,6 +27,12 @@ In order to help align all agents on this specification, changing `type` and `su
 to be a _breaking change_, but rather a _potentially breaking change_ if for example existing users rely on values to
 build visualizations. As a consequence, modification of those values is not limited to major versions.
 
+### Span Name
+
+Each span will have a `name`, which is a descriptive, low-cardinality string.
+
+If a span is created without a valid `name`, the string `"unnamed"` SHOULD be used.
+
 ### Span outcome
 
 The `outcome` property denotes whether the span represents a success or failure, it is used to compute error rates


### PR DESCRIPTION
[The APM data spec lists span.name as required](https://github.com/elastic/apm-data/blob/534660e4a1517a6bc2fbc58b1df22e92bcce7180/input/elasticapm/docs/spec/v2/span.json#L876). However, it's missing from this spec.

- [x] Create PR as draft
- [x] Approval by at least one other agent
- [x] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [ ] Approved by at least 2 agents + PM (if relevant)
- [ ] Merge after 7 days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.
