### PR TITLE
add minimal server version for activation_method

### DIFF
--- a/specs/agents/metadata.md
+++ b/specs/agents/metadata.md
@@ -139,6 +139,7 @@ Services running on AWS Lambda [require specific values](tracing-instrumentation
 #### Activation method
 
 Most of the APM Agents can be activated in several ways. Agents SHOULD collect information about the used activation method and send it in the `service.agent.activation_method` field within the metadata.
+This field should only be sent when APM server version is at least `8.7.1`, and MUST be ommited in `8.7.0` due to a bug in APM server.
 
 The intention of this field is to drive telemetry so there is a way to know which activation methods are commonly used. This field MUST produce data with very low cardinality, therefore agents SHOULD use one of the values defined below.
 


### PR DESCRIPTION
APM Server version 8.7.0 contains a bug that prevents agents from sending metrics when the `service.agent.activation_method` is present in metadata.

In addition of some error messages in APM server logs, the most visible impact is the lack of metrics in Kibana UI for the service.

Related APM Server issue: https://github.com/elastic/apm-server/issues/10551

This should be fixed for 8.7.1 with https://github.com/elastic/apm-server/pull/10552

As a way to mitigate extra support issues, making the agents only send this field for newer apm-server versions (8.7.1 and later) is required.

----

- May the instrumentation collect sensitive information, such as secrets or PII (ex. in headers)?
  - [x] n/a
- [x] Create PR as draft
- [x] Approval by at least one other agent
- [x] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [ ] Approved by at least 2 agents + PM (if relevant)
- [ ] Merge after 7 days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.
- [ ] [Create implementation issues through the meta issue template](https://github.com/elastic/apm/issues/new?assignees=&labels=meta%2C+apm-agents&template=apm-agents-meta.md) (this will automate issue creation for individual agents)
- [x] ~~If this spec adds a new dynamic config option, [add it to central config](https://github.com/elastic/apm/blob/main/specs/agents/configuration.md#adding-a-new-configuration-option).~~ N/A
