### PR TITLE
Adding service.build for mobile attrs

### DIFF
--- a/specs/agents/mobile/README.md
+++ b/specs/agents/mobile/README.md
@@ -57,13 +57,13 @@ Here is a list of resource attributes that are relevant for our mobile agents:
 
 The following attributes do not have an OpenTelemetry semantic convention:
 
-| Attribute name                          | Elastic Convention         | Example                          | Required | Comment                            |
-|-----------------------------------------|----------------------------|----------------------------------| ---------| ---------------------------------|
-| `telemetry.sdk.elastic_export_timestamp`| N/A: only relevant for APM server.     | `1658149487000000000` | :white_check_mark: yes | This is required to deal with the time skew on mobile devices. Set this to the timestamp (in nanoseconds) when the span is exported in the OpenTelemetry span processer. |
-| `type` | `transaction.type` | `mobile` :interrobang: | :white_check_mark: yes | :heavy_exclamation_mark: Need to define new values for transactions resulting from mobile interactions. |
-| `session.id`         | :heavy_exclamation_mark: not mapped yet         | `opbeans-swift`                  | :x: no | Some id for a session. This is not specified in OTel, yet. | 
-| `visibility`                         | :heavy_exclamation_mark: not mapped yet         | `foreground/background` | :x: yes                | This will be needed to tell whether the signal happened when the app was visible or in the background. |
-
+| Attribute name                           | Elastic Convention                      | Example                 | Required                          | Comment                                                                                                                                                                  |
+|------------------------------------------|-----------------------------------------|-------------------------|-----------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `telemetry.sdk.elastic_export_timestamp` | N/A: only relevant for APM server.      | `1658149487000000000`   | :white_check_mark: yes            | This is required to deal with the time skew on mobile devices. Set this to the timestamp (in nanoseconds) when the span is exported in the OpenTelemetry span processer. |
+| `type`                                   | `transaction.type`                      | `mobile` :interrobang:  | :white_check_mark: yes            | :heavy_exclamation_mark: Need to define new values for transactions resulting from mobile interactions.                                                                  |
+| `session.id`                             | :heavy_exclamation_mark: not mapped yet | `opbeans-swift`         | :x: no                            | Some id for a session. This is not specified in OTel, yet.                                                                                                               | 
+| `visibility`                             | :heavy_exclamation_mark: not mapped yet | `foreground/background` | :x: yes                           | This will be needed to tell whether the signal happened when the app was visible or in the background.                                                                   |
+| `service.build`                          | N/A                                     | `555`                   | For Android: `yes`, for iOS: `no` | This is the build number (or the versionCode for Android builds).                                                                                                        | 
 
 ### Attributes on outgoing HTTP spans 
 


### PR DESCRIPTION
<!--
Agent spec PR checklist

Delete all of this if the PR is not changing the agent spec.
Delete sections that don't apply to this PR.
If a specific checkbox doesn't apply, ~strike through~ and check it instead of deleting it.
-->

@bryce-b and I were discussing this further, and it seems like in iOS the build number (currently added to the `service.version` between parenthesis, separated by a whitespace from the version) is not mandatory, so it makes the `service.version` format not consistent depending on the case. Whereas for Android it is mandatory, and it'd be used when finding the map file for deobfuscating stacktraces, however, if added to the `service.version`, the format would be very important to get right, otherwise the mapping file might not be found (e.g. in the case the build number isn't separated by a whitespace, or if it's not between parenthesis) which is likely to happen, considering that the `service.version` is configurable at both compile time and runtime, so to avoid confusions around this value, we thought of creating its own attribute, which will always be present on Android signals, and sometimes on iOS's. That way it might be easier to get and use during the ingestion process, as well as it won't clutter the `service.version` with formatting exceptions.

<!--
Use this section if the spec requires changes in at most two agents.

Examples:
- Typos or clarifications without semantic changes
- Changes in a spec before it has been implemented
- Features that are only implemented in two agents
-->

- [x] Create PR as draft
- [x] Approval by at least one other agent
- [x] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [ ] Merge after 2 business days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.