### PR TITLE
Otel Tracing Spec: Use netName in messaging target name if it's available

### DIFF
--- a/specs/agents/tracing-api-otel.md
+++ b/specs/agents/tracing-api-otel.md
@@ -221,7 +221,7 @@ if (a['db.system']) {
         netName = parseNetName(a['messaging.url']);
     }
     serviceTargetType = subtype;
-    serviceTargetName = a['messaging.destination'] || null;
+    serviceTargetName = a['messaging.destination'] || netName || null;
 
 } else if (a['rpc.system']) {
     type = 'external';

--- a/tests/agents/gherkin-specs/otel_bridge.feature
+++ b/tests/agents/gherkin-specs/otel_bridge.feature
@@ -201,8 +201,8 @@ Feature: OpenTelemetry bridge
     Examples:
       | messaging.system | messaging.destination | messaging.url         | net.peer.ip | net.peer.name | net.peer.port | resource         | target_service_name |
       | rabbitmq         |                       | amqp://carrot:4444/q1 |             |               |               | rabbitmq         |                     |
-      | rabbitmq         |                       |                       | 127.0.0.1   | carrot-server | 7777          | rabbitmq         |                     |
-      | rabbitmq         |                       |                       |             | carrot-server |               | rabbitmq         |                     |
+      | rabbitmq         |                       |                       | 127.0.0.1   | carrot-server | 7777          | rabbitmq         | carrot-server:7777  |
+      | rabbitmq         |                       |                       |             | carrot-server |               | rabbitmq         | carrot-server       |
       | rabbitmq         |                       |                       | 127.0.0.1   |               |               | rabbitmq         |                     |
       | rabbitmq         | myQueue               | amqp://carrot:4444/q1 |             |               |               | rabbitmq/myQueue | myQueue             |
       | rabbitmq         | myQueue               |                       | 127.0.0.1   | carrot-server | 7777          | rabbitmq/myQueue | myQueue             |


### PR DESCRIPTION
I'm not sure the template applies, as this spec change is more of a clarification, and agents would either not do anything, or have already handle that lack of information.

When handling messaging traces, if there is no `messaging.destination`, we may use `messaging.url`, or `netName` as the target name instead.
We previously had to set `netName`, but it was never used. So this change uses the set value.

cc @SylvainJuge 

---

<!--
Agent spec PR checklist

Delete all of this if the PR is not changing the agent spec.
Delete sections that don't apply to this PR.
If a specific checkbox doesn't apply, ~strike through~ and check it instead of deleting it.
-->

<!--
Use this section if the spec requires changes in at most two agents.

Examples:
- Typos or clarifications without semantic changes
- Changes in a spec before it has been implemented
- Features that are only implemented in two agents
-->

- [ ] Create PR as draft
- [ ] Approval by at least one other agent
- [ ] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [ ] Merge after 2 business days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.

<!--
Use this section if the spec requires changes in more than two agents.

This extended template ensures that we have a meta issue and tracking issues so that we don't forget about implementing the changes in all affected agents.
-->

- May the instrumentation collect sensitive information, such as secrets or PII (ex. in headers)?
  - [ ] Yes
    - [ ] Add a section to the spec how agents should apply sanitization (such as `sanitize_field_names`)
  - [ ] No
    - [ ] Why?
  - [ ] n/a
- [ ] Create PR as draft
- [ ] Approval by at least one other agent
- [ ] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [ ] Approved by at least 2 agents + PM (if relevant)
- [ ] Merge after 7 days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.
- [ ] [Create implementation issues through the meta issue template](https://github.com/elastic/apm/issues/new?assignees=&labels=meta%2C+apm-agents&template=apm-agents-meta.md) (this will automate issue creation for individual agents)
- [ ] If this spec adds a new dynamic config option, [add it to central config](https://github.com/elastic/apm/blob/main/specs/agents/configuration.md#adding-a-new-configuration-option).