### PR TITLE
docs: add OTel attributes to S3 triggered Lambda functions

### DIFF
--- a/specs/agents/tracing-instrumentation-aws-lambda.md
+++ b/specs/agents/tracing-instrumentation-aws-lambda.md
@@ -350,7 +350,7 @@ Field | Value | Description | Source
 `context.cloud.origin.service.name` | `s3` | Constant value for S3. | -
 `context.cloud.origin.region` | e.g. `us-east-1` | S3 bucket region. | `record.awsRegion`
 `context.cloud.origin.provider` | `aws` | Use `aws` as constant value. | -
-__**otel.attributes._**__ |<hr/>|<hr/>
+__**otel.attributes._**__ |<hr/>|<hr/>|<hr/>
 `_["aws.s3.bucket"]`| `mybucket` | S3 bucket name, if available. See [OTel Semantic Conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/semantic_conventions/trace/instrumentation/aws-sdk.yml#L435). Note: this must be a single dotted string key in the `otel.attributes` mapping -- for example `{"otel": {"attributes": {"aws.s3.bucket": "mybucket"}}}` -- and *not* a nested object. | `record.s3.bucket.name`
 `_["aws.s3.key"]`| `my/key/path` | S3 object key, if applicable. See [OTel Semantic Conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/semantic_conventions/trace/instrumentation/aws-sdk.yml#L435). Note: this must be a single dotted string key in the `otel.attributes` mapping and *not* a nested object. | `record.s3.object.key`
 

--- a/specs/agents/tracing-instrumentation-aws-lambda.md
+++ b/specs/agents/tracing-instrumentation-aws-lambda.md
@@ -351,8 +351,8 @@ Field | Value | Description | Source
 `context.cloud.origin.region` | e.g. `us-east-1` | S3 bucket region. | `record.awsRegion`
 `context.cloud.origin.provider` | `aws` | Use `aws` as constant value. | -
 __**otel.attributes._**__ |<hr/>|<hr/>
-`_["aws.s3.bucket"]`| `mybucket` | S3 bucket name, if available. See [OTel Semantic Conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/semantic_conventions/trace/instrumentation/aws-sdk.yml#L435) | `record.s3.bucket.name`
-`_["aws.s3.key"]`| `my/key/path` | S3 object key, if applicable. See [OTel Semantic Conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/semantic_conventions/trace/instrumentation/aws-sdk.yml#L435) | `record.s3.object.key`
+`_["aws.s3.bucket"]`| `mybucket` | S3 bucket name, if available. See [OTel Semantic Conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/semantic_conventions/trace/instrumentation/aws-sdk.yml#L435). Note: this must be a single dotted string key in the `otel.attributes` mapping -- for example `{"otel": {"attributes": {"aws.s3.bucket": "mybucket"}}}` -- and *not* a nested object. | `record.s3.bucket.name`
+`_["aws.s3.key"]`| `my/key/path` | S3 object key, if applicable. See [OTel Semantic Conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/semantic_conventions/trace/instrumentation/aws-sdk.yml#L435). Note: this must be a single dotted string key in the `otel.attributes` mapping and *not* a nested object. | `record.s3.object.key`
 
 ## Data Flushing
 Lambda functions are immediately frozen as soon as the handler method ends. In case APM data is sent in an asyncronous way (as most of the agents do by default) data can get lost if not sent before the lambda function ends.

--- a/specs/agents/tracing-instrumentation-aws-lambda.md
+++ b/specs/agents/tracing-instrumentation-aws-lambda.md
@@ -354,6 +354,49 @@ __**otel.attributes._**__ |<hr/>|<hr/>
 `_["aws.s3.bucket"]`| `mybucket` | S3 bucket name, if available. See [OTel Semantic Conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/semantic_conventions/trace/instrumentation/aws-sdk.yml#L435). Note: this must be a single dotted string key in the `otel.attributes` mapping -- for example `{"otel": {"attributes": {"aws.s3.bucket": "mybucket"}}}` -- and *not* a nested object. | `record.s3.bucket.name`
 `_["aws.s3.key"]`| `my/key/path` | S3 object key, if applicable. See [OTel Semantic Conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/semantic_conventions/trace/instrumentation/aws-sdk.yml#L435). Note: this must be a single dotted string key in the `otel.attributes` mapping and *not* a nested object. | `record.s3.object.key`
 
+An example S3 event:
+
+```
+{
+  "Records": [
+    {
+      "eventVersion": "2.1",
+      "eventSource": "aws:s3",
+      "awsRegion": "us-east-2",
+      "eventTime": "2019-09-03T19:37:27.192Z",
+      "eventName": "ObjectCreated:Put",
+      "userIdentity": {
+        "principalId": "AWS:AIDAINPONIXQXHT3IKHL2"
+      },
+      "requestParameters": {
+        "sourceIPAddress": "205.255.255.255"
+      },
+      "responseElements": {
+        "x-amz-request-id": "D82B88E5F771F645",
+        "x-amz-id-2": "vlR7PnpV2Ce81l0PRw6jlUpck7Jo5ZsQjryTjKlc5aLWGVHPZLj5NeC6qMa0emYBDXOo6QBU0Wo="
+      },
+      "s3": {
+        "s3SchemaVersion": "1.0",
+        "configurationId": "828aa6fc-f7b5-4305-8584-487c791949c1",
+        "bucket": {
+          "name": "DOC-EXAMPLE-BUCKET",
+          "ownerIdentity": {
+            "principalId": "A3I5XTEXAMAI3E"
+          },
+          "arn": "arn:aws:s3:::lambda-artifacts-deafc19498e3f2df"
+        },
+        "object": {
+          "key": "b21b84d653bb07b05b1e6b33684dc11b",
+          "size": 1305107,
+          "eTag": "b21b84d653bb07b05b1e6b33684dc11b",
+          "sequencer": "0C0F6F405D6ED209E1"
+        }
+      }
+    }
+  ]
+}
+```
+
 ## Data Flushing
 Lambda functions are immediately frozen as soon as the handler method ends. In case APM data is sent in an asyncronous way (as most of the agents do by default) data can get lost if not sent before the lambda function ends.
 

--- a/specs/agents/tracing-instrumentation-aws-lambda.md
+++ b/specs/agents/tracing-instrumentation-aws-lambda.md
@@ -350,6 +350,9 @@ Field | Value | Description | Source
 `context.cloud.origin.service.name` | `s3` | Constant value for S3. | -
 `context.cloud.origin.region` | e.g. `us-east-1` | S3 bucket region. | `record.awsRegion`
 `context.cloud.origin.provider` | `aws` | Use `aws` as constant value. | -
+__**otel.attributes._**__ |<hr/>|<hr/>
+`_["aws.s3.bucket"]`| `mybucket` | S3 bucket name, if available. See [OTel Semantic Conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/semantic_conventions/trace/instrumentation/aws-sdk.yml#L435) | `record.s3.bucket.name`
+`_["aws.s3.key"]`| `my/key/path` | S3 object key, if applicable. See [OTel Semantic Conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/semantic_conventions/trace/instrumentation/aws-sdk.yml#L435) | `record.s3.object.key`
 
 ## Data Flushing
 Lambda functions are immediately frozen as soon as the handler method ends. In case APM data is sent in an asyncronous way (as most of the agents do by default) data can get lost if not sent before the lambda function ends.


### PR DESCRIPTION
This PR adds OTel attributes for Lambda functions which called by an S3 trigger. In this scenario `bucket` and `object key` could be extracted from the record contained in the event. You can see all record available info in [the docs](https://docs.aws.amazon.com/lambda/latest/dg/with-s3.html)

- May the instrumentation collect sensitive information, such as secrets or PII (ex. in headers)?
  - [ ] Yes
    - [ ] Add a section to the spec how agents should apply sanitization (such as `sanitize_field_names`)
  - [x] No
    - [x] Why? bucket name and object key do not contain personal info
- [x] Create PR as draft
- [x] Approval by at least one other agent
- [x] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [ ] Approved by at least 2 agents + PM (if relevant)
- [ ] Merge after 7 days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.
- [x] [Create implementation issues through the meta issue template](https://github.com/elastic/apm/issues/new?assignees=&labels=meta%2C+apm-agents&template=apm-agents-meta.md) (this will automate issue creation for individual agents)
- [ ] If this spec adds a new dynamic config option, [add it to central config](https://github.com/elastic/apm/blob/main/specs/agents/configuration.md#adding-a-new-configuration-option).
