### PR TITLE
Update metadata spec with host domain name information

### DIFF
--- a/specs/agents/metadata.md
+++ b/specs/agents/metadata.md
@@ -1,6 +1,6 @@
 ## Metadata
 
-As mentioned above, the first "event" in each ND-JSON stream contains metadata to fold into subsequent events. The metadata that agents should collect includes are described in the following sub-sections.
+As mentioned above, the first "event" in each ND-JSON stream contains metadata to fold into subsequent events. The metadata that agents should collect are described in the following sub-sections.
 
  - service metadata
  - global labels (requires APM Server 7.2 or greater)
@@ -76,6 +76,24 @@ hostname if `configured_hostname` is not provided.
 
 Agents that are APM-Server-version-aware, or that are compatible only with versions >= 7.4, should 
 use the new fields wherever applicable.
+
+#### Host domain name
+
+ECS 8.7 [updated](https://github.com/elastic/ecs/pull/2122) the definition of `host.name`, recommending using the 
+lowercase fully qualified domain name (FQDN) for the host name. All Elastic ECS producers should populate the 
+`host.name` field with the lowercased FQDN from here forward. This change is behind a 
+[feature flag](https://www.elastic.co/guide/en/fleet/current/elastic-agent-standalone-feature-flags.html#elastic-agent-standalone-feature-flag-settings) 
+on the Elastic agent to avoid breaking changes for users. Since APM agents do not know about the feature flag, 
+this decision must happen on the APM server. To support this, APM agents should collect and send the host domain name 
+(when available) to enable the APM server to construct the FQDN for `host.name` when the feature flag is enabled.
+
+When the `system.configured_hostname` is not set through the `ELASTIC_APM_HOSTNAME` config option, APM agents should 
+attempt to detect the host domain name, in addition to the hostname. When detected, the lowercase domain name of the 
+host should be used to set the `system.detected_domain_name` field. This will be combined with the `detected_hostname` 
+to form the final FQDN.
+
+When a `system.configured_hostname` is available, this will be preferred. It is the responsibility of the user to determine if 
+they wish to configure this with the FQDN or just the hostname.
 
 #### Container/Kubernetes metadata
 

--- a/specs/agents/metadata.md
+++ b/specs/agents/metadata.md
@@ -77,6 +77,8 @@ hostname if `configured_hostname` is not provided.
 Agents that are APM-Server-version-aware, or that are compatible only with versions >= 7.4, should 
 use the new fields wherever applicable.
 
+> **_NOTE:_** We recently established that the various agents handle hostnames differently, with some sending an FQDN (when available) and others (such as the .NET agent) sending a simple hostname. To avoid breaking consumers, agents should continue sending the hostname as they already do. Logic will be introduced to split the hostname from an FQDN, when required, based on the configured feature flag. See below in the "Host domain name" section for further details of the proposed logic.
+
 #### Host domain name
 
 ECS 8.7 [updated](https://github.com/elastic/ecs/pull/2122) the definition of `host.name`, recommending using the 
@@ -93,6 +95,8 @@ to form the final FQDN.
 
 When a `system.configured_hostname` is available, this will be preferred. It is the responsibility of the user to determine if 
 they wish to configure this with the FQDN or just the hostname.
+
+> **_NOTE:_** As some agents may already send an FQDN for the `detected_hostname` field, logic will be required to extract the required components. When the `detected_hostname` includes the `detected_domain_name`, the `detected_domain_name` string can be removed, along with any remaining separators, to determine the simple `hostname`. If required, the hostname and domain name can later be re-combined by the feature flag configuration. For agents that already send a simple hostname for `detected_hostname`, that hostname will not include the `detected_hostname` and can safely be combined with the `detected_domain_name` (if present) when the configuration requires an FQDN to be stored for ECS `host.name`.
 
 #### Container/Kubernetes metadata
 

--- a/specs/agents/metadata.md
+++ b/specs/agents/metadata.md
@@ -1,6 +1,6 @@
 ## Metadata
 
-As mentioned above, the first "event" in each ND-JSON stream contains metadata to fold into subsequent events. The metadata that agents should collect are described in the following sub-sections.
+As mentioned above, the first "event" in each ND-JSON stream contains metadata to fold into subsequent events. The metadata that agents should collect is described in the following sub-sections.
 
  - service metadata
  - global labels (requires APM Server 7.2 or greater)

--- a/specs/agents/metadata.md
+++ b/specs/agents/metadata.md
@@ -87,8 +87,7 @@ on the Elastic agent to avoid breaking changes for users. Since APM agents do no
 this decision must happen on the APM server. To support this, APM agents should collect and send the host domain name 
 (when available) to enable the APM server to construct the FQDN for `host.name` when the feature flag is enabled.
 
-When the `system.configured_hostname` is not set through the `ELASTIC_APM_HOSTNAME` config option, APM agents should 
-attempt to detect the host domain name, in addition to the hostname. When detected, the lowercase domain name of the 
+APM agents should attempt to detect the host domain name, in addition to the hostname. When detected, the lowercase domain name of the 
 host should be used to set the `system.detected_domain_name` field. This will be combined with the `detected_hostname` 
 to form the final FQDN.
 

--- a/specs/agents/metadata.md
+++ b/specs/agents/metadata.md
@@ -93,10 +93,10 @@ APM agents should attempt to detect the host domain name, in addition to the hos
 host should be used to set the `system.detected_domain_name` field. This will be combined with the `detected_hostname` 
 to form the final FQDN.
 
-When a `system.configured_hostname` is available, this will be preferred. It is the responsibility of the user to determine if 
+When a `system.configured_hostname` is configured, it is the responsibility of the user to determine if 
 they wish to configure this with the FQDN or just the hostname.
 
-> **_NOTE:_** As some agents may already send an FQDN for the `detected_hostname` field, logic will be required to extract the required components. When the `detected_hostname` includes the `detected_domain_name`, the `detected_domain_name` string can be removed, along with any remaining separators, to determine the simple `hostname`. If required, the hostname and domain name can later be re-combined by the feature flag configuration. For agents that already send a simple hostname for `detected_hostname`, that hostname will not include the `detected_hostname` and can safely be combined with the `detected_domain_name` (if present) when the configuration requires an FQDN to be stored for ECS `host.name`.
+> **_NOTE:_** As some agents may already send an FQDN for the `detected_hostname` field, logic will be required to extract the required components. When the `detected_hostname` includes the `detected_domain_name`, the `detected_domain_name` string can be removed, along with any remaining separators, to determine the simple `hostname`. If required, the hostname and domain name can later be re-combined by the feature flag configuration. For agents that already send a simple hostname for `detected_hostname`, that hostname will not include the domain name and can safely be combined with the `detected_domain_name` (if present) when the configuration requires an FQDN to be stored for ECS `host.name`.
 
 #### Container/Kubernetes metadata
 


### PR DESCRIPTION
Per #793 - "ECS changed the definition of `host.name` and encourages to use the fully qualified domain name for the host name". This PR updates the metadata spec with a proposed section detailing how clients should send the domain information required by APM server.

- May the instrumentation collect sensitive information, such as secrets or PII (ex. in headers)?
  - [ ] Yes
    - [ ] Add a section to the spec how agents should apply sanitization (such as `sanitize_field_names`)
  - [x] No
    - [ ] Why? The domain name of the host does not hold personal information.
  - [ ] n/a
- [x] Create PR as draft
- [x] Approval by at least one other agent
- [x] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [ ] Approved by at least 2 agents + PM (if relevant)
- [ ] Merge after 7 days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.
- [ ] [Create implementation issues through the meta issue template](https://github.com/elastic/apm/issues/new?assignees=&labels=meta%2C+apm-agents&template=apm-agents-meta.md) (this will automate issue creation for individual agents)
- [ ] If this spec adds a new dynamic config option, [add it to central config](https://github.com/elastic/apm/blob/main/specs/agents/configuration.md#adding-a-new-configuration-option).

Closes #794 