### PR TITLE
chore: update sanitization spec

### DIFF
--- a/specs/agents/sanitization.md
+++ b/specs/agents/sanitization.md
@@ -41,8 +41,14 @@ they use to replace the value so long as it's consistent and does not reveal
 the value it has replaced. The replacement string SHOULD be `[REDACTED]`.
 
 Fields that MUST be sanitized are:
-- HTTP Request and Response headers (except [HTTP/2 pseudo-headers](https://datatracker.ietf.org/doc/html/rfc7540#section-8.1.2.3) which SHOULD NOT be redacted), and
-- form fields in an `application/x-www-form-urlencoded` request body.
+- HTTP Request and Response headers (except [HTTP/2 pseudo-headers](https://datatracker.ietf.org/doc/html/rfc7540#section-8.1.2.3) which SHOULD NOT be redacted),
+- form fields in an `application/x-www-form-urlencoded` request body, and
+- HTTP Request cookies.
+
+Additionally, if cookie headers are parsed into name/value pairs and reported
+to APM Server via the agent (for example, `transaction.context.request.cookies`), the
+values of these pairs MUST be sanitized and the cookie header removed or redacted.
+
 
 The query string and other captured request bodies (such as `application/json`)
 SHOULD NOT be sanitized.


### PR DESCRIPTION
This PR tries to clarify in the spec who the agents are already dealing with request cookie info and sanitization. Also it tries to remove ambiguity on how cookie data is placed into `transaction.context.request` to avoid data redundancy on the payloads sent to APM server

- May the instrumentation collect sensitive information, such as secrets or PII (ex. in headers)?
  - [ ] Yes
    - [ ] Add a section to the spec how agents should apply sanitization (such as `sanitize_field_names`)
  - [ ] No
    - [ ] Why?
  - [x] n/a
- [x] Create PR as draft
- [x] Approval by at least one other agent
- [x] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [ ] Approved by at least 2 agents + PM (if relevant)
- [ ] Merge after 7 days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.
- [ ] [Create implementation issues through the meta issue template](https://github.com/elastic/apm/issues/new?assignees=&labels=meta%2C+apm-agents&template=apm-agents-meta.md) (this will automate issue creation for individual agents)
- [x] ~If this spec adds a new dynamic config option, [add it to central config]~(https://github.com/elastic/apm/blob/main/specs/agents/configuration.md#adding-a-new-configuration-option).
