### PR TITLE
specs: dropping runtimes may not be breaking

### DIFF
--- a/specs/agents/breaking-changes.md
+++ b/specs/agents/breaking-changes.md
@@ -8,7 +8,10 @@ Taken strictly, this definition could lead to treating every change in runtime b
 Each agent instruments a number of libraries that are used in their language ecosystem. These libraries themselves may introduce new versions, breaking changes, and deprecate older versions. The APM agents therefore will occasionally introduce changes in their instrumentation of external libraries. The changes that we consider breaking are ones that remove support for older versions. Agents can also continue supporting the instrumentation of a particular older library version but drop its testing of it because of some conflicts in installing test suite dependencies, for example. This change would not be considered breaking as long as it’s properly documented.
 
 ### Language and runtime support
-Similar to library version instrumentation, APM agents will typically support multiple versions of its language. Sometimes it is necessary to drop support for older versions of the languages as they themselves are EOL’ed. It is considered a breaking change when an APM agent drops support for a particular language version.
+Similar to library version instrumentation, APM agents will typically support multiple versions of its language. Sometimes it is necessary to drop support for older versions of the languages as they themselves are EOL’ed.
+
+It is typically considered a breaking change when an APM agent drops support for a particular language version, but this may vary according to the conventions of the language ecosystem.
+For example, it is common practice for Go libraries to follow the Go project's release policy of only supporting the two most recent releases of Go.
 
 ### Configuration changes
 All agents support a set of configuration options and default values. Changes to the configuration offering can be categorized into three types:


### PR DESCRIPTION
Minor change to the breaking changes spec to permit agents to remove support for older runtime versions, without being considered a breaking change.

This is common practice among Go libraries. Although removing support for older Go versions technically may break users, we need to balance this against the maintenance burden of supporting older versions of Go, fitting in with the ecosystem. Performing regular major version bumps will make adoption of the agent painful, as this forces users to change the import paths in their applications.