### PR TITLE
Add spec for 'span.sync' field

### DIFF
--- a/specs/agents/tracing-spans.md
+++ b/specs/agents/tracing-spans.md
@@ -33,6 +33,16 @@ Each span will have a `name`, which is a descriptive, low-cardinality string.
 
 If a span is created without a valid `name`, the string `"unnamed"` SHOULD be used.
 
+### Span `sync`
+
+Span execution within a transaction or span can be synchronous (the caller waits for completion), or asynchronous (the caller does not wait
+for completion).
+
+In UI
+- when `sync` field is not present or `null`, we assume it's the platform default and no badge is shown.
+- when `sync` field is set to `true`, a `blocking` badge is shown in traces.
+- when `sync` field is set to `false`, an `async` badge is shown in traces.
+
 ### Span outcome
 
 The `outcome` property denotes whether the span represents a success or failure, it is used to compute error rates

--- a/specs/agents/tracing-spans.md
+++ b/specs/agents/tracing-spans.md
@@ -38,10 +38,11 @@ If a span is created without a valid `name`, the string `"unnamed"` SHOULD be us
 Span execution within a transaction or span can be synchronous (the caller waits for completion), or asynchronous (the caller does not wait
 for completion).
 
-In UI
+In UI:
+
 - when `sync` field is not present or `null`, we assume it's the platform default and no badge is shown.
-- when `sync` field is set to `true`, a `blocking` badge is shown in traces.
-- when `sync` field is set to `false`, an `async` badge is shown in traces.
+- when `sync` field is set to `true`, a `blocking` badge is shown in traces where the platform default is `async`: `nodejs`, `rum` and `javascript`
+- when `sync` field is set to `false`, an `async` badge is shown in traces where the platform default is `blocking`: other agents
 
 ### Span outcome
 


### PR DESCRIPTION
Adds a small spec for `span.sync` field.

This is more a "specification of how it works currently" rather than "specification of how it should work", so feel free to provide input if any agent implementation does not fit what is described here.

- [x] Create PR as draft
- [x] Approval by at least one other agent
- [x] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [x] Merge after 2 business days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.
