### PR TITLE
Revert otel bridge messaging spec change

### DIFF
--- a/specs/agents/tracing-api-otel.md
+++ b/specs/agents/tracing-api-otel.md
@@ -221,7 +221,7 @@ if (a['db.system']) {
         netName = parseNetName(a['messaging.url']);
     }
     serviceTargetType = subtype;
-    serviceTargetName = a['messaging.destination'] || netName || null;
+    serviceTargetName = a['messaging.destination'] || null;
 
 } else if (a['rpc.system']) {
     type = 'external';

--- a/tests/agents/gherkin-specs/otel_bridge.feature
+++ b/tests/agents/gherkin-specs/otel_bridge.feature
@@ -201,8 +201,8 @@ Feature: OpenTelemetry bridge
     Examples:
       | messaging.system | messaging.destination | messaging.url         | net.peer.ip | net.peer.name | net.peer.port | resource         | target_service_name |
       | rabbitmq         |                       | amqp://carrot:4444/q1 |             |               |               | rabbitmq         |                     |
-      | rabbitmq         |                       |                       | 127.0.0.1   | carrot-server | 7777          | rabbitmq         | carrot-server:7777  |
-      | rabbitmq         |                       |                       |             | carrot-server |               | rabbitmq         | carrot-server       |
+      | rabbitmq         |                       |                       | 127.0.0.1   | carrot-server | 7777          | rabbitmq         |                     |
+      | rabbitmq         |                       |                       |             | carrot-server |               | rabbitmq         |                     |
       | rabbitmq         |                       |                       | 127.0.0.1   |               |               | rabbitmq         |                     |
       | rabbitmq         | myQueue               | amqp://carrot:4444/q1 |             |               |               | rabbitmq/myQueue | myQueue             |
       | rabbitmq         | myQueue               |                       | 127.0.0.1   | carrot-server | 7777          | rabbitmq/myQueue | myQueue             |


### PR DESCRIPTION
This reverts commit 047ee08de219d42c7470ef1a703c61d568e68a5a (from PR https://github.com/elastic/apm/pull/787)

Details on the reasons why reverting this is preferable for now are provided [here](https://github.com/elastic/apm/pull/787#issuecomment-1570250881).

- [x] Create PR as draft
- [ ] Approval by at least one other agent
- [ ] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [ ] Merge after 2 business days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.

