### PR TITLE
Capture FQDN in APM agents

### DIFF
--- a/specs/agents/metadata.md
+++ b/specs/agents/metadata.md
@@ -43,7 +43,7 @@ if os == windows
 else 
   hostname = exec "uname -n"                          // or any equivalent *
   if (hostname == null || hostname.length == 0)
-    hostname = exec "hostname --fqdn"                 // or any equivalent *
+    hostname = exec "hostname -f"                     // or any equivalent *
   if (hostname == null || hostname.length == 0)
     hostname = env.get("HOSTNAME")
   if (hostname == null || hostname.length == 0)

--- a/specs/agents/metadata.md
+++ b/specs/agents/metadata.md
@@ -1,6 +1,6 @@
 ## Metadata
 
-As mentioned above, the first "event" in each ND-JSON stream contains metadata to fold into subsequent events. The metadata that agents should collect includes are described in the following sub-sections.
+As mentioned above, the first "event" in each ND-JSON stream contains metadata to fold into subsequent events. The metadata that agents should collect includes is are described in the following sub-sections.
 
  - service metadata
  - global labels (requires APM Server 7.2 or greater)

--- a/specs/agents/metadata.md
+++ b/specs/agents/metadata.md
@@ -33,6 +33,8 @@ Agents SHOULD implement this hostname discovery algorithm wherever possible:
 ```
 var hostname;
 if os == windows
+  // https://stackoverflow.com/questions/12268885/powershell-get-fqdn-hostname
+  // https://learn.microsoft.com/en-us/dotnet/api/system.net.dns.gethostentry
   hostname = exec "powershell.exe [System.Net.Dns]::GetHostEntry($env:computerName).HostName" // or any equivalent *
   if (hostname == null || hostname.length == 0)
     hostname = exec "cmd.exe /c hostname"               // or any equivalent *

--- a/specs/agents/metadata.md
+++ b/specs/agents/metadata.md
@@ -25,47 +25,34 @@ System metadata relates to the host/container in which the service being monitor
 #### Hostname
 
 This hostname reported by the agent is mapped by the APM Server to the 
-[`host.hostname` ECS field](https://www.elastic.co/guide/en/ecs/current/ecs-host.html#field-host-hostname), which should 
-typically contain what the `hostname` command returns on the host machine. However, since we rely on this field for 
-our integration with beats data, we should attempt to follow a similar logic to the `os.Hostname()` Go API, which beats 
-relies one. While `os.Hostname()` contains some complex OS-specific logic to cover all sorts of edge cases, our 
-algorithm should be simpler. It relies on the execution of external commands with a fallback to standard environment 
-variables. Agents SHOULD implement this hostname discovery algorithm wherever possible:
+[`host.hostname` ECS field](https://www.elastic.co/guide/en/ecs/current/ecs-host.html#field-host-hostname).
+
+Agents SHOULD return the lower-cased FQDN whenever possible, which might require a DNS query.
+
+Agents SHOULD implement this hostname discovery algorithm wherever possible:
 ```
 var hostname;
 if os == windows
-  hostname = exec "cmd /c hostname"                   // or any equivalent *
+  hostname = exec "powershell.exe [System.Net.Dns]::GetHostEntry($env:computerName).HostName" // or any equivalent *
+  if (hostname == null || hostname.length == 0)
+    hostname = exec "cmd.exe /c hostname"               // or any equivalent *
   if (hostname == null || hostname.length == 0)
     hostname = env.get("COMPUTERNAME")
-  domain = env.get("USERDNSDOMAIN")
-  if (domain != null && domain.length >0)
-    hostname += "." + domain
 else 
-  hostname = exec "uname -n"                          // or any equivalent *
-  if (hostname == null || hostname.length == 0)
-    hostname = exec "hostname -f"                     // or any equivalent *
+  hostname = exec "hostname -f"                         // or any equivalent *
   if (hostname == null || hostname.length == 0)
     hostname = env.get("HOSTNAME")
   if (hostname == null || hostname.length == 0)
     hostname = env.get("HOST")
 
 if hostname != null
-  hostname = hostname.trim()                          // see details below **
+  hostname = hostname.toLowerCase().trim()              // see details below **
 ```
 `*` this algorithm is using external commands in order to be OS-specific and language-independent, however these 
-may be replaced with language-specific APIs that provide the equivalent result. The main consideration when choosing 
-what to use is to avoid hostname discovery that relies on DNS lookup.
+may be replaced with language-specific APIs that provide the equivalent result.
 
 `**` in this case, `trim()` refers to the removal of all leading and trailing characters of which codepoint is less-than
-or equal to `U+0020` (space).
-
-Agents MAY use alternative approaches, but those need to generally conform to the basic concept. Failing to discover the 
-proper hostname may cause failure in correlation between APM traces and data reported by other clients (e.g. 
-Metricbeat). For example, if the agent uses an API that produces host name (not FQDN), this value is likely to mismatch hostname 
-reported by other clients.
-
-Starting from APM Server 8.9, APM agents should report the fully qualified domain name (FQDN). Before 8.9 APM agents
-should report only the host name (first part of FQDN until the first dot `.`).
+or equal to `U+0020` (space), the `toLowerCase()` refers to the replacement of characters in `A-Z` with their `a-z` equivalents.
 
 In addition to auto-discovery of the hostname, agents SHOULD also expose the `ELASTIC_APM_HOSTNAME` config option that 
 can be used as a manual fallback.

--- a/specs/agents/metadata.md
+++ b/specs/agents/metadata.md
@@ -24,8 +24,9 @@ System metadata relates to the host/container in which the service being monitor
 
 #### Hostname
 
-This hostname reported by the agent is mapped by the APM Server to the 
-[`host.hostname` ECS field](https://www.elastic.co/guide/en/ecs/current/ecs-host.html#field-host-hostname).
+The hostname value(s) reported by the agent are mapped by APM Server to the ECS
+[`host.hostname`](https://www.elastic.co/guide/en/ecs/current/ecs-host.html#field-host-hostname) and
+[`host.name`](https://www.elastic.co/guide/en/ecs/current/ecs-host.html#field-host-name) fields.
 
 Agents SHOULD return the lower-cased FQDN whenever possible, which might require a DNS query.
 
@@ -92,7 +93,7 @@ On Linux, the container ID and some of the Kubernetes metadata can be extracted 
     If there is a match to either expression, the capturing group contains the pod ID. We then unescape underscores 
     (`_`) to hyphens (`-`) in the pod UID.
     If we match a pod UID then we record the hostname as the pod name since, by default, Kubernetes will set the 
-    hostname to the pod name. Finally, we record the basename as the container ID without any further checks.
+    _short_ hostname (not FQDN) to the pod name. Finally, we record the basename as the container ID without any further checks.
 
  4. If we did not match a Kubernetes pod UID above, then we check if the basename matches one of the following regular 
  expressions:

--- a/specs/agents/metadata.md
+++ b/specs/agents/metadata.md
@@ -37,10 +37,13 @@ if os == windows
   hostname = exec "cmd /c hostname"                   // or any equivalent *
   if (hostname == null || hostname.length == 0)
     hostname = env.get("COMPUTERNAME")
+  domain = env.get("USERDNSDOMAIN")
+  if (domain != null && domain.length >0)
+    hostname += "." + domain
 else 
   hostname = exec "uname -n"                          // or any equivalent *
   if (hostname == null || hostname.length == 0)
-    hostname = exec "hostname"                        // or any equivalent *
+    hostname = exec "hostname --fqdn"                 // or any equivalent *
   if (hostname == null || hostname.length == 0)
     hostname = env.get("HOSTNAME")
   if (hostname == null || hostname.length == 0)
@@ -58,8 +61,11 @@ or equal to `U+0020` (space).
 
 Agents MAY use alternative approaches, but those need to generally conform to the basic concept. Failing to discover the 
 proper hostname may cause failure in correlation between APM traces and data reported by other clients (e.g. 
-Metricbeat). For example, if the agent uses an API that produces the FQDN, this value is likely to mismatch hostname 
+Metricbeat). For example, if the agent uses an API that produces host name (not FQDN), this value is likely to mismatch hostname 
 reported by other clients.
+
+Starting from APM Server 8.9, APM agents should report the fully qualified domain name (FQDN). Before 8.9 APM agents
+should report only the host name (first part of FQDN until the first dot `.`).
 
 In addition to auto-discovery of the hostname, agents SHOULD also expose the `ELASTIC_APM_HOSTNAME` config option that 
 can be used as a manual fallback.


### PR DESCRIPTION
### Summary

Specification change for #793 .

APM agents should capture the FQDN instead of just the host name, APM Server will handle compatibility with current behavior through configuration (as it's a breaking change).

Fixes #794

-------
### Checklist

- [x] validate the FQDN heuristic on Windows
  -  powershell heuristic tested on a Windows VM, custom DNS suffix set through `System Properties > Computer Name > Change > More > Primary DNS suffix of this computer`, then reboot. When set the `System Properties > Computer Name` should show the FQDN name in `Full computer name` field.
- [x] compatibility with older APM server versions: keep sending the current `detected_hostname` for APM server < 8.9 for the agents that did not already used the FQDN ?
  - NO: `host.name` is not used very much in APM, thus it's not considered to be a breaking change: [comment](https://github.com/elastic/apm/pull/805#discussion_r1231649403)
- [x] for Windows, should we include the same heuristic described in #795 ?
  - NO: relying on env. variables or currently logged-in user is not reliable

-------

- May the instrumentation collect sensitive information, such as secrets or PII (ex. in headers)?
  - [x] No:
    - [x] Why? hostname and domain name are not sensitive information
- [x] Create PR as draft
- [x] Approval by at least one other agent
- [x] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [x] Approved by at least 2 agents + PM (if relevant)
- [ ] Merge after 7 days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.
- [x] ~~[Create implementation issues through the meta issue template](https://github.com/elastic/apm/issues/new?assignees=&labels=meta%2C+apm-agents&template=apm-agents-meta.md) (this will automate issue creation for individual agents)~~ already created in #793
- [x] ~~If this spec adds a new dynamic config option, [add it to central config](https://github.com/elastic/apm/blob/main/specs/agents/configuration.md#adding-a-new-configuration-option).~~ n/a
