### PR TITLE
Include OTEL environment variables for ECS logging

### DIFF
--- a/specs/agents/log-correlation.md
+++ b/specs/agents/log-correlation.md
@@ -41,25 +41,32 @@ When using ECS logging, they might be set by the application in ECS logging conf
   - must be provided even if there is no active transaction
   - Configuration source (in order of precedence):
     - Configured value
+    - `ELASTIC_APM_SERVICE_NAME`
     - `OTEL_SERVICE_NAME`
     - `OTEL_RESOURCE_ATTRIBUTES` value for `service.name`
-    - `ELASTIC_APM_SERVICE_NAME`
     - Default from Elastic Agent (if available)
 - `service.version`:
   - only used for service metadata correlation
   - must be provided even if there is no active transaction
   - Configuration source (in order of precedence):
     - Configured value
-    - `OTEL_RESOURCE_ATTRIBUTES` value for `service.version`
     - `ELASTIC_APM_SERVICE_VERSION`
+    - `OTEL_RESOURCE_ATTRIBUTES` value for `service.version`
     - Default from Elastic Agent (if available)
 - `service.environment`:
   - allows to filter/link log messages to a given service/environment.
   - must be provided even if there is no active transaction
   - Configuration source (in order of precedence):
     - Configured value
-    - `OTEL_RESOURCE_ATTRIBUTES` value for `deployment.environment`
     - `ELASTIC_APM_ENVIRONMENT`
+    - `OTEL_RESOURCE_ATTRIBUTES` value for `deployment.environment`
+    - Default from Elastic Agent (if available)
+- `service.node.name`:
+  - must be provided even if there is no active transaction
+  - Configuration source (in order of precedence):
+    - Configured value
+    - `ELASTIC_APM_SERVICE_NODE_NAME`
+    - `OTEL_RESOURCE_ATTRIBUTES` value for `service.instance.id`
     - Default from Elastic Agent (if available)
 
 

--- a/specs/agents/log-correlation.md
+++ b/specs/agents/log-correlation.md
@@ -39,12 +39,28 @@ When using ECS logging, they might be set by the application in ECS logging conf
 - `service.name`:
   - used to filter/link log messages to a given service.
   - must be provided even if there is no active transaction
+  - Configuration source (in order of precedence):
+    - Configured value
+    - `OTEL_SERVICE_NAME`
+    - `OTEL_RESOURCE_ATTRIBUTES` value for `service.name`
+    - `ELASTIC_APM_SERVICE_NAME`
+    - Default from Elastic Agent (if available)
 - `service.version`:
   - only used for service metadata correlation
   - must be provided even if there is no active transaction
+  - Configuration source (in order of precedence):
+    - Configured value
+    - `OTEL_RESOURCE_ATTRIBUTES` value for `service.version`
+    - `ELASTIC_APM_SERVICE_VERSION`
+    - Default from Elastic Agent (if available)
 - `service.environment`:
   - allows to filter/link log messages to a given service/environment.
   - must be provided even if there is no active transaction
+  - Configuration source (in order of precedence):
+    - Configured value
+    - `OTEL_RESOURCE_ATTRIBUTES` value for `deployment.environment`
+    - `ELASTIC_APM_ENVIRONMENT`
+    - Default from Elastic Agent (if available)
 
 
 The `container.id` field can also be used as a fallback to provide service-level correlation in UI, however agents ARE NOT expected to set it:


### PR DESCRIPTION
This PR amends the log correlation spec to include details on where defaults might be configured.

This adds `OTEL_*` environment variables as a source of configuration for logging.

The reason for this is that the `ecs-logging` libraries are likely to be used in conjunction with OTEL SDKs (including our own).


We could use this also as a jumping off point to discuss allowing these
configuration options to take precedence in general agent configuration.
