### PR TITLE
docs: add some OTel attributes for DynamoDB spec

### DIFF
--- a/specs/agents/tracing-instrumentation-db.md
+++ b/specs/agents/tracing-instrumentation-db.md
@@ -69,6 +69,10 @@ The following fields are relevant for database and datastore spans. Where possib
 | __**service.target._**__ |<hr/>|<hr/>|
 |`_.type`| `dynamodb` ||
 |`_.name`| e.g. `us-east-1` | Use same value as `context.db.instance` |
+| __**otel.attributes._**__ |<hr/>|<hr/>|
+TODO
+|`_["aws.dynamodb.table_names"]`| `[ MyTable ]` | The table names, if available. See [OTel Semantic Conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.23.0/specification/trace/semantic_conventions/instrumentation/aws-sdk.md). Note: this must be a single dotted string key in the `otel.attributes` mapping -- for example `{"otel": {"attributes": {"aws.dynamodb.table_names": "[ MyTable ]"}}}` -- and *not* a nested object. |
+|`_["aws.dynamodb.projection"]`| `Field1, Field2` | The value of the `ProjectionExpression` request parameter, if available. See [OTel Semantic Conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.23.0/specification/trace/semantic_conventions/instrumentation/aws-sdk.md). Note: this must be a single dotted string key in the `otel.attributes` mapping -- for example `{"otel": {"attributes": {"aws.dynamodb.projection": "Field1, Field2"}}}` -- and *not* a nested object. |
 
 ### AWS S3
 


### PR DESCRIPTION
This PR adds a couple of OTel attributes in DynamoDB instrumentation. These attributes are:
- [table_names](https://github.com/open-telemetry/opentelemetry-specification/blob/8ae0f6fb1d752abfd780a73b6abb351608231d91/specification/trace/semantic_conventions/instrumentation/aws-sdk.md?plain=1#L68C20-L68C20) which is used in all commands affecting tables (putItem, deleteItem, updateItem, createTable, updateTable, deleteTable, ...)
- [select](https://github.com/open-telemetry/opentelemetry-specification/blob/8ae0f6fb1d752abfd780a73b6abb351608231d91/specification/trace/semantic_conventions/instrumentation/aws-sdk.md?plain=1#L154) which is present in query and scan commands

<!--
Use this section if the spec requires changes in more than two agents.

This extended template ensures that we have a meta issue and tracking issues so that we don't forget about implementing the changes in all affected agents.
-->

May the instrumentation collect sensitive information, such as secrets or PII (ex. in headers)?
- [ ] Yes
  - [ ] Add a section to the spec how agents should apply sanitization (such as `sanitize_field_names`)
- [x] No
  - [x] Why? table names and query projection does not contain PII


- [x] Create PR as draft
- [ ] Approval by at least one other agent
- [ ] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [ ] Approved by at least 2 agents + PM (if relevant)
- [ ] Merge after 7 days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.
- [ ] [Create implementation issues through the meta issue template](https://github.com/elastic/apm/issues/new?assignees=&labels=meta%2C+apm-agents&template=apm-agents-meta.md) (this will automate issue creation for individual agents)
- [ ] ~If this spec adds a new dynamic config option, [add it to central config]~(https://github.com/elastic/apm/blob/main/specs/agents/configuration.md#adding-a-new-configuration-option).
