### PR TITLE
Add baggage specification

### DIFF
--- a/specs/agents/tracing-distributed-tracing.md
+++ b/specs/agents/tracing-distributed-tracing.md
@@ -181,7 +181,7 @@ So, the following rules should be used to decode/encode context propagation head
 Encoding:
  * Add a `elasticapmtraceparent` header with the binary specification above for backwards compatibility
  * Add the textual `traceparent` and `tracestate` headers, encode their values via UTF8
-  
+
 Decoding:
  * If a `traceparent` header is present, use the `traceparent` and `tracestate` headers as textual with UTF8 decoding of the values
  * If no `traceparent` header is present, use the `elasticapmtraceparent` with the binary specification above. `tracestate` is ignored.
@@ -198,43 +198,45 @@ To propagate distributed context, we implement the [W3C Baggage](https://www.w3.
 Agents MUST parse, validate, and attach the `baggage` header according [to the W3C specification](https://www.w3.org/TR/baggage/).
 
 In addition to the W3C specification, agents also SHOULD offer users 2 ways to use the values propagated via baggage:
-- Offer an Baggage API to manually manipulate and read baggage values.
+- Offer a Baggage API to manually manipulate and read baggage values - this is preferable the OpenTelemetry API.
 - Offer baggage related configuration to automatically store baggage values on events.
 
 #### Baggage API
 
-Agents SHOULD offer an API with the following functionalities:
+Agents SHOULD integrate with the existing OpenTelemetry API. Users should be able to use the OpenTelemetry API to interact with the baggage maintained by the agent. The primary way to interact with baggage SHOULD be the OpenTelemetry API.
+
+In case using the OpenTelemetry API isn't feasible in a given language, the agent SHOULD extend the proprietary agent API to interact with baggage.
+
+This API MUST offer the following functionalities:
 - Adding a new baggage item
 - Changing an existing baggage item
 - Removing an existing baggage item
 - Reading a specific baggage item
 - Reading all baggage items
 
-In case the given language already offers this API as port of the standard library, the agent MUST integrate with the existing library and it MUST avoid adding a proprietary API. In case there is no such API in the standard library, the agent MUST add this API to the proprietary agent API.
-
 #### Baggage related configurations
 
-The following configurations enable users to automatically store baggage items on a given event without any code change. Baggage items with matching keys are always stored as labels.
+The following configurations enable users to automatically store baggage items on a given event without any code change. Baggage items with matching keys are stored in `otel.attributes`, except on errors.
 
 `baggage_to_attach_on_transactions` configuration
 
-A list of baggage keys which are automatically attached to the transaction. When a transaction is created, the agent iterates through all baggage items currently available and stores the ones with keys that match one of the items from the configured wildcard matcher list on the newly created transaction as a label.
+A list of baggage keys which are automatically attached to the transaction. When a transaction is created, the agent iterates through all baggage items currently available and stores the ones with keys that match one of the items from the configured wildcard matcher list on the newly created transaction as an item in `otel.attributes`.
 
 |                |   |
 |----------------|---|
 | Type           | `List<`[`WildcardMatcher`](../../tests/agents/json-specs/wildcard_matcher_tests.json)`>` |
-| Default        | empty list|
+| Default        | `*`    |
 | Dynamic        | `true` |
 | Central config | `true` |
 
 `baggage_to_attach_on_spans` configuration
 
-A list of baggage keys which are automatically attached to the span. When a span is created, the agent iterates through all baggage items currently available and stores the ones with keys that match one of the items from the configured wildcard matcher list on the newly created span as a label.
+A list of baggage keys which are automatically attached to the span. When a span is created, the agent iterates through all baggage items currently available and stores the ones with keys that match one of the items from the configured wildcard matcher list on the newly created span as an item in `otel.attributes`.
 
 |                |   |
 |----------------|---|
 | Type           | `List<`[`WildcardMatcher`](../../tests/agents/json-specs/wildcard_matcher_tests.json)`>` |
-| Default        | empty list|
+| Default        | `*`    |
 | Dynamic        | `true` |
 | Central config | `true` |
 
@@ -245,7 +247,7 @@ A list of baggage keys which are automatically attached to the error. When an er
 |                |   |
 |----------------|---|
 | Type           | `List<`[`WildcardMatcher`](../../tests/agents/json-specs/wildcard_matcher_tests.json)`>` |
-| Default        | empty list|
+| Default        | `*`    |
 | Dynamic        | `true` |
 | Central config | `true` |
 

--- a/specs/agents/tracing-distributed-tracing.md
+++ b/specs/agents/tracing-distributed-tracing.md
@@ -214,35 +214,13 @@ This API MUST offer the following functionalities:
 - Reading a specific baggage item
 - Reading all baggage items
 
-#### Baggage related configurations
+#### Baggage related configuration
 
-The following configurations enable users to automatically store baggage items on a given event without any code change. Baggage items with matching keys are stored in `otel.attributes`, except on errors.
+The following configuration enables users to automatically store baggage items on a given event without any code change. Baggage items with matching keys are stored in `otel.attributes`, except on errors, since there is no `otel.attributes` on errors. Keys of baggage items lifted by the agent from baggage into attributes/labels MUST be prefixed with `baggage.`.
 
-`baggage_to_attach_on_transactions` configuration
+`baggage_to_attach` configuration
 
-A list of baggage keys which are automatically attached to the transaction. When a transaction is created, the agent iterates through all baggage items currently available and stores the ones with keys that match one of the items from the configured wildcard matcher list on the newly created transaction as an item in `otel.attributes`.
-
-|                |   |
-|----------------|---|
-| Type           | `List<`[`WildcardMatcher`](../../tests/agents/json-specs/wildcard_matcher_tests.json)`>` |
-| Default        | `*`    |
-| Dynamic        | `true` |
-| Central config | `true` |
-
-`baggage_to_attach_on_spans` configuration
-
-A list of baggage keys which are automatically attached to the span. When a span is created, the agent iterates through all baggage items currently available and stores the ones with keys that match one of the items from the configured wildcard matcher list on the newly created span as an item in `otel.attributes`.
-
-|                |   |
-|----------------|---|
-| Type           | `List<`[`WildcardMatcher`](../../tests/agents/json-specs/wildcard_matcher_tests.json)`>` |
-| Default        | `*`    |
-| Dynamic        | `true` |
-| Central config | `true` |
-
-`baggage_to_attach_on_errors` configuration
-
-A list of baggage keys which are automatically attached to the error. When an error is created, the agent iterates through all baggage items currently available and stores the ones with keys that match one of the items from the configured wildcard matcher list on the newly created error  as a label.
+A list of baggage keys which are automatically attached to the current event (transaction, span, or error). When the event is created, the agent iterates through all baggage items currently available and stores the ones with keys that match one of the items from the configured wildcard matcher list on the newly created event with a prefix `baggage.`. In case of transactions and spans, the agent MUST send this data in `otel.attributes`, in case of errors the agent MUST send the data in labels.
 
 |                |   |
 |----------------|---|

--- a/specs/agents/tracing-distributed-tracing.md
+++ b/specs/agents/tracing-distributed-tracing.md
@@ -191,6 +191,63 @@ Implementation note: The `traceparent` and `tracestate` specifications only allo
 This implementation guarantees backwards compatibility with our older agents and compatibility with current OpenTelemetry instrumentations.
 We will eventually remove the `elasticapmtraceparent` entirely as soon as we can safely assume that most users have already upgraded all their agents.
 
+### Baggage
+
+To propagate distributed context, we implement the [W3C Baggage](https://www.w3.org/TR/baggage/) specification.
+
+Agents MUST parse, validate, and attach the `baggage` header according [to the W3C specification](https://www.w3.org/TR/baggage/).
+
+In addition to the W3C specification, agents also SHOULD offer users 2 ways to use the values propagated via baggage:
+- Offer an Baggage API to manually manipulate and read baggage values.
+- Offer baggage related configuration to automatically store baggage values on events.
+
+#### Baggage API
+
+Agents SHOULD offer an API with the following functionalities:
+- Adding a new baggage item
+- Changing an existing baggage item
+- Removing an existing baggage item
+- Reading a specific baggage item
+- Reading all baggage items
+
+In case the given language already offers this API as port of the standard library, the agent MUST integrate with the existing library and it MUST avoid adding a proprietary API. In case there is no such API in the standard library, the agent MUST add this API to the proprietary agent API.
+
+#### Baggage related configurations
+
+The following configurations enable users to automatically store baggage items on a given event without any code change. Baggage items with matching keys are always stored as labels.
+
+`baggage_to_attach_on_transactions` configuration
+
+A list of baggage keys which are automatically attached to the transaction. When a transaction is created, the agent iterates through all baggage items currently available and stores the ones with keys that match one of the items from the configured wildcard matcher list on the newly created transaction as a label.
+
+|                |   |
+|----------------|---|
+| Type           | `List<`[`WildcardMatcher`](../../tests/agents/json-specs/wildcard_matcher_tests.json)`>` |
+| Default        | empty list|
+| Dynamic        | `true` |
+| Central config | `true` |
+
+`baggage_to_attach_on_spans` configuration
+
+A list of baggage keys which are automatically attached to the span. When a span is created, the agent iterates through all baggage items currently available and stores the ones with keys that match one of the items from the configured wildcard matcher list on the newly created span as a label.
+
+|                |   |
+|----------------|---|
+| Type           | `List<`[`WildcardMatcher`](../../tests/agents/json-specs/wildcard_matcher_tests.json)`>` |
+| Default        | empty list|
+| Dynamic        | `true` |
+| Central config | `true` |
+
+`baggage_to_attach_on_errors` configuration
+
+A list of baggage keys which are automatically attached to the error. When an error is created, the agent iterates through all baggage items currently available and stores the ones with keys that match one of the items from the configured wildcard matcher list on the newly created error  as a label.
+
+|                |   |
+|----------------|---|
+| Type           | `List<`[`WildcardMatcher`](../../tests/agents/json-specs/wildcard_matcher_tests.json)`>` |
+| Default        | empty list|
+| Dynamic        | `true` |
+| Central config | `true` |
 
 ### Legacy HTTP Header Name
 


### PR DESCRIPTION
Add spec for [baggage](https://www.w3.org/TR/baggage/). Most of the spec if defined by W3C and we just link to it and avoid duplicating it: https://www.w3.org/TR/baggage/

Additionally the PR also covers how users can interact with baggage and use it. This is currently being implemented in Java and .NET. 

- [x] Create PR as draft
- [ ] Approval by at least one other agent
- [ ] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [ ] Merge after 2 business days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.