### PR TITLE
Change 'metadata.cloud.project.*' for GCP, clarify other fields

### DIFF
--- a/specs/agents/metadata.md
+++ b/specs/agents/metadata.md
@@ -247,7 +247,7 @@ From the returned metadata, the following fields are useful
 #### GCP metadata
 
 Metadata about a GCP machine instance can be retrieved from the
-metadata service, `http://metadata.google.internal`.
+metadata service, [documented here](https://cloud.google.com/compute/docs/metadata/default-metadata-values).
 
 In the case where a proxy is configured on the application, the agents SHOULD attempt to make
 the calls to the metadata endpoint directly, without using the proxy.
@@ -265,14 +265,19 @@ From the returned metadata, the following fields are useful
 
 | Cloud metadata field  | GCP Metadata field  |
 | --------------------  | ------------------- |
-| `instance.id`         | `instance.id`       |
+| `instance.id`         | `instance.id` as a string [1] |
 | `instance.name`       | `instance.name`     |
-| `project.id`          | `project.numericProjectId` as a string |
-| `project.name`        | `project.projectId` |
+| `project.id`          | `project.projectId` [2] |
 | `availability_zone`   | last part of `instance.zone`, split by `/`  |
 | `machine.type`        | last part of `instance.machineType`, split by `/` |
 | `provider`            | gcp                 |
-| `region`              | last part of `instance.zone`, split by `-`            |
+| `region`              | last part of `instance.zone` split by '/', then remove the last '-'-delimited part (e.g., `us-west1` from `projects/123456789012/zones/us-west1-b`)|
+
+[1]: Beware JSON parsing the `instance.id` field from the HTTP response body, because it is formatted as an integer that is larger [JavaScript's `Number.MAX_SAFE_INTEGER`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER). It may require native support for or explicit usage of BigInt types.
+[2]: Google cloud project identifiers are [described here](https://cloud.google.com/resource-manager/docs/creating-managing-projects#before_you_begin).
+
+(For comparison and consistency, here is the equivalent collection code for
+[beats](https://github.com/elastic/beats/blob/aa5da2847957fa62687e0b4e7777c86fe7c05f6c/libbeat/processors/add_cloud_metadata/provider_google_gce.go#L45-L153).)
 
 #### Azure metadata
 


### PR DESCRIPTION
This PR changes the spec for two `cloud.project.*` metadata fields for GCP to be consistent with how Beats collect the same metadata. It was motivated by a user that is unable to correlate documents from APM agents and Beats on `cloud.project.id`.

It also clarifies a couple things with GCP metadata collection. Finally there is an open question about adding a new field.

## details

A Google cloud project has three identifiers. The CLI lists them as:

```
% gcloud projects list
PROJECT_ID    NAME          PROJECT_NUMBER
my-project    My Project    123456789012
```

and the GCP docs describe them here: https://cloud.google.com/resource-manager/docs/creating-managing-projects#before_you_begin


## proposed changes

1. Change `cloud.project.id` to use GCE metadata `project.projectId`, instead of `project.numericProjectId` (aka "project number"). This will match what [Beats do](https://github.com/elastic/beats/blob/aa5da2847957fa62687e0b4e7777c86fe7c05f6c/libbeat/processors/add_cloud_metadata/provider_google_gce.go#L135-L139). As well, the `projectId` field is a more visible identifier for the user -- it is more prominently shown in the Google Cloud console.
2. *Stop* collecting `cloud.project.name`. What Google describes as the "Project name" is not available in the [GCE metadata response](https://cloud.google.com/compute/docs/metadata/default-metadata-values#project_metadata). The APM agents should not be attempting to make GCP API requests to get the project name.
3. Note: The `instance.id` from the GCE metadata is a *big* int. Your JSON parser could be surprised by it -- the JavaScript one gets it wrong, the Python one is fine. Please check.
    ```js
    > JSON.parse('{"id": 7774572792595385001}')
    { id: 7774572792595385000 } // oops
    ```
4. Note: The previous description for how to get the `cloud.region` was wrong. (The Python implementation linked to earlier the metadata.md doc is correct.)


## open question

(This is for discussion. I have not proposed changing this in this PR.)

Should we *also* set `cloud.account.id` to the `<GCE metadata>.project.projectId`?

[Beats do](https://github.com/elastic/beats/blob/aa5da2847957fa62687e0b4e7777c86fe7c05f6c/libbeat/processors/add_cloud_metadata/provider_google_gce.go#L140-L142).

[ECS says](https://www.elastic.co/guide/en/ecs/current/ecs-cloud.html#field-cloud-account-id):

> The cloud account or organization id used to identify different entities in a multi-tenant environment.
>
> Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.
>
> example: 666777888999

The "Examples: Google Cloud ORG Id" seems to indicate using `projectId` would be inappropriate. However, I think GCP uses the **project** (not some concept of the account) to "identify" resources.
Some examples from the GCE metadata (the globally unique identifier there is the `numericProjectId`):

```
machineType: 'projects/123456789012/machineTypes/e2-micro',
  network: 'projects/123456789012/networks/default',
  email: '123456789012-compute@developer.gserviceaccount.com',
```

For comparison the [OTel cloud semconv](https://opentelemetry.io/docs/specs/otel/resource/semantic_conventions/cloud/) do not have `cloud.project.*` (perhaps because they are concepts particular to GCP and Azure). The *do* have `cloud.account.id` and at least the OTel *JS* SDK [sets that to the GCE metadata `project-id` value](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/8802eae92d70825d4e8fea526e657ce5f16f8502/detectors/node/opentelemetry-resource-detector-gcp/src/detectors/GcpDetector.ts#L61).

I am curious if/where the ECS + OTel semconv merge lands on this.

## checklist

- ~May the instrumentation collect sensitive information, such as secrets or PII (ex. in headers)?~
- [x] Create PR as draft
- [ ] Approval by at least one other agent
- [ ] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [ ] Approved by at least 2 agents + PM (if relevant)
- [ ] Merge after 7 days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.
- [ ] [Create implementation issues through the meta issue template](https://github.com/elastic/apm/issues/new?assignees=&labels=meta%2C+apm-agents&template=apm-agents-meta.md) (this will automate issue creation for individual agents)
- [ ] If this spec adds a new dynamic config option, [add it to central config](https://github.com/elastic/apm/blob/main/specs/agents/configuration.md#adding-a-new-configuration-option).
