### PR TITLE
Fix `outcome` definition in `error-tracking.md`

### DIFF
--- a/specs/agents/error-tracking.md
+++ b/specs/agents/error-tracking.md
@@ -24,7 +24,10 @@ Agents MUST NOT buffer errors to ensure consistency as this comes at the expense
 
 ### Impact on the `outcome`
 
-Tracking an error that's related to a transaction does not impact its `outcome`.
 A transaction might have multiple errors associated to it but still return with a 2xx status code.
-Hence, the status code is a more reliable signal for the outcome of the transaction.
-This, in turn, means that the `outcome` is always specific to the protocol.
+Hence, the status code is a more reliable signal for the outcome of the transaction. In case of well known protocols (e.g. HTTP, gRPC) the agent sets the `outcome` based on the status code.
+This, in turn, means that the `outcome` is specific to the protocol in most cases.
+
+For transactions and spans that do not represent a call in a well known protocol, the agent sets `outcome` to `failure` when at least 1 error occurred on the given transaction/span.
+
+For more details, see [transaction outcome specification](tracing-transactions.md#transaction-outcome) and [span outcome specification](tracing-spans.md#span-outcome).


### PR DESCRIPTION
In `error-tracking.md` the definition of how `outcome` is set contradicted what we define in [tracing-transactions.md](https://github.com/elastic/apm/blob/main/specs/agents/tracing-transactions.md#transaction-outcome) and in [tracing-spans.md](https://github.com/elastic/apm/blob/main/specs/agents/tracing-spans.md#span-outcome), especially the following:

> Tracking an error that's related to a transaction does not impact its `outcome`.

This PR changes `error-tracking.md` to make it match the `outcome` definition from other parts of the spec (see links above). I think most agents already do this according to  [tracing-transactions.md](https://github.com/elastic/apm/blob/main/specs/agents/tracing-transactions.md#transaction-outcome) and [tracing-spans.md](https://github.com/elastic/apm/blob/main/specs/agents/tracing-spans.md#span-outcome) - so I expect we won't need to change any implementation in a specific agent.

If that's not the case, please raise it and let's discuss.

- [x] Create PR as draft
- [ ] Approval by at least one other agent
- [ ] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [ ] Merge after 2 business days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.