### PR TITLE
Made context_propagation_only dynamic

### DIFF
--- a/specs/agents/transport.md
+++ b/specs/agents/transport.md
@@ -71,6 +71,13 @@ would otherwise consider the data as being compressed (due to the `Content-Encod
 
 ### `context_propagation_only` configuration
 
+|                |   |
+|----------------|---|
+| Type           | `boolean` |
+| Default        | `false` |
+| Dynamic        | `true` |
+| Central config | `true` |
+
 Agents MAY implement this configuration option.
 `context_propagation_only` is a boolean configuration option to have an APM
 agent perform trace-context propagation and log correlation *only*; and to
@@ -82,13 +89,14 @@ Agents that implement this configuration option:
 
 - MUST continue to propagate trace headers (`traceparent`, `tracestate`, etc.)
   per normal;
+- MUST start a trace-id if no `traceparent` header is present where they would normally start a transaction and propagate it.
 - MUST continue to support [log correlation](./log-correlation.md);
-- MUST NOT attempt to communicate with APM server, including central configuration;
-- MUST NOT log warnings/errors related to failures to communicate with APM server.
+- MUST NOT send event data to the APM server
 - SHOULD attempt to reduce runtime overhead where possible. For example,
   because events will be dropped there is no need to collect stack traces,
   collect metrics, calculate breakdown metrics, or to create spans (other than
   the top-level transaction required for context propagation, similarly to non-sampled traces).
+
 
 ### `disable_send` configuration
 


### PR DESCRIPTION
<!--
Agent spec PR checklist

Delete all of this if the PR is not changing the agent spec.
Delete sections that don't apply to this PR.
If a specific checkbox doesn't apply, ~strike through~ and check it instead of deleting it.
-->

<!--
Use this section if the spec requires changes in more than two agents.

This extended template ensures that we have a meta issue and tracking issues so that we don't forget about implementing the changes in all affected agents.
-->

- May the instrumentation collect sensitive information, such as secrets or PII (ex. in headers)?
  - [ ] Yes
    - [ ] Add a section to the spec how agents should apply sanitization (such as `sanitize_field_names`)
  - [x] No
    - [ ] Why?
  - [ ] n/a
- [x] Create PR as draft
- [x] Approval by at least one other agent
- [x] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [x] Approved by at least 2 agents + PM (if relevant)
- [x] Merge after 7 days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.
- [ ] [Create implementation issues through the meta issue template](https://github.com/elastic/apm/issues/new?assignees=&labels=meta%2C+apm-agents&template=apm-agents-meta.md) (this will automate issue creation for individual agents)
- [ ] If this spec adds a new dynamic config option, [add it to central config](https://github.com/elastic/apm/blob/main/specs/agents/configuration.md#adding-a-new-configuration-option).
