### PR TITLE
use otel semconv field for stacktrace

### DIFF
--- a/specs/agents/tracing-spans.md
+++ b/specs/agents/tracing-spans.md
@@ -95,7 +95,7 @@ spans that are slower than a specified duration, using the config variable
 `span_stack_trace_min_duration`. (Previously
 `span_frames_min_duration`.)
 
-Agents based on OpenTelemetry should capture this using the semantic conventions attribute: `code.stacktrace` [added in 1.24.0](
+Agents based on OpenTelemetry should capture this using the `code.stacktrace` semantic conventions attribute [added in 1.24.0](
 https://github.com/open-telemetry/semantic-conventions/pull/435).
 
 #### `span_stack_trace_min_duration` configuration

--- a/specs/agents/tracing-spans.md
+++ b/specs/agents/tracing-spans.md
@@ -95,9 +95,8 @@ spans that are slower than a specified duration, using the config variable
 `span_stack_trace_min_duration`. (Previously
 `span_frames_min_duration`.)
 
-Agents based on OpenTelemetry should capture this in a span attribute: `elastic.span.stack_trace`.
-Stack trace should be stored in plain text using the usual text format of the platform using the same format
-as [`exception.stactkrace` attribute](https://opentelemetry.io/docs/specs/semconv/exceptions/exceptions-spans/#stacktrace-representation).
+Agents based on OpenTelemetry should capture this using the semantic conventions attribute: `code.stacktrace` [added in 1.24.0](
+https://github.com/open-telemetry/semantic-conventions/pull/435).
 
 #### `span_stack_trace_min_duration` configuration
 


### PR DESCRIPTION
Follow-up of #828, changes the otel attribute to use to `code.stacktrace` now that the semantic conventions PR has been merged: https://github.com/open-telemetry/semantic-conventions/pull/435 and will be part of the next version.

- [x] Create PR as draft
- [x] Approval by at least one other agent
- [x] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [x] Merge after 2 business days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.
