### PR TITLE
add extra heuristic for hostname

### DIFF
--- a/specs/agents/metadata.md
+++ b/specs/agents/metadata.md
@@ -47,6 +47,8 @@ else
     hostname = env.get("HOSTNAME")
   if (hostname == null || hostname.length == 0)
     hostname = env.get("HOST")
+  if (hostname == null || hostname.length == 0)
+    hostname = readfile("/etc/hostname")                // or any equivalent *
 
 if hostname != null
   hostname = hostname.toLowerCase().trim()              // see details below **


### PR DESCRIPTION
When using very minimal container images like the [distroless](https://github.com/GoogleContainerTools/distroless), the `hostname` command line tool that our agents use to capture the host name is missing and can't be used.

When no value is captured for host name, the most obvious symptom is missing metrics in Kibana, the traces are not impacted.

While the `HOST` and `HOSTNAME` environment variables allow to provide a fallback, adding them to very large deployments can become an extra burden.

However, reading the content of the `/etc/hostname` is still possible and we should then use it to provide a value to the host name. In this case we don't know if a simple host name or an FQDN is provided.

In containers the actual value is usually the container ID or a random string thus it's not for "human consumption" but is still relevant for correlation.

In short, this just adds an extra fallback option to existing heuristics.


------


- May the instrumentation collect sensitive information, such as secrets or PII (ex. in headers)?
  - [x] n/a
- [x] Create PR as draft
- [x] Approval by at least one other agent
- [x] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [x] Approved by at least 2 agents + PM (if relevant)
- [x] Merge after 7 days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.
- [x] [Create implementation issues through the meta issue template](https://github.com/elastic/apm/issues/new?assignees=&labels=meta%2C+apm-agents&template=apm-agents-meta.md) (this will automate issue creation for individual agents)
- [x] ~~If this spec adds a new dynamic config option, [add it to central config](https://github.com/elastic/apm/blob/main/specs/agents/configuration.md#adding-a-new-configuration-option).~~ n/a
