### PR TITLE
Added spec section for inferred spans

### DIFF
--- a/specs/agents/tracing-spans.md
+++ b/specs/agents/tracing-spans.md
@@ -189,7 +189,7 @@ Inferred spans can be parents of normal spans. Given the following example:
  * The span `B` is inferred to be a child of `A`, and `B` is the new parent of `C`
  * Resulting trace: `A` → `B` → `C`
 
-Agents MAY perform the span inference delayed. As a result, the spans `A` and `C` might have already been sent at the time `B` is created.
+Agents MAY perform the span inference after the transaction or child spans were ended. As a result, the spans `A` and `C` might have already been sent at the time `B` is created.
 The problem in this case is that `C` is sent with `A` as parent, whereas the actual parent will be `B`.
 
 For this reason, inferred spans can use the following mechanism to override the parent-child relationship for spans which have already been sent:


### PR DESCRIPTION

- [x] Create PR as draft
- [x] Approval by at least one other agent
- [x] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [ ] Merge after 2 business days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.
