### PR TITLE
Update powershell command for hostname detection to avoid profiles and logo that could break detection

### DIFF
--- a/specs/agents/metadata.md
+++ b/specs/agents/metadata.md
@@ -36,7 +36,7 @@ var hostname;
 if os == windows
   // https://stackoverflow.com/questions/12268885/powershell-get-fqdn-hostname
   // https://learn.microsoft.com/en-us/dotnet/api/system.net.dns.gethostentry
-  hostname = exec "powershell.exe [System.Net.Dns]::GetHostEntry($env:computerName).HostName" // or any equivalent *
+  hostname = exec "powershell.exe -NoLogo -NonInteractive -NoProfile -ExecutionPolicy Bypass -Command [System.Net.Dns]::GetHostEntry($env:computerName).HostName" // or any equivalent *
   if (hostname == null || hostname.length == 0)
     hostname = exec "cmd.exe /c hostname"               // or any equivalent *
   if (hostname == null || hostname.length == 0)


### PR DESCRIPTION
If a Windows system has a powershell profile that emits output, then it
could pollute the output used to read the hostname value. Likewise with
the powershell logo output, though I don't know if/when that logo
appears -- it does not in apm-agent-nodejs' CI tests.

Refs: https://github.com/elastic/apm-agent-nodejs/pull/3899

Powershell CLI options are documented here: https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_powershell_exe?view=powershell-5.1