### PR TITLE
Profiling integration: define required library name

### DIFF
--- a/specs/agents/universal-profiling-integration.md
+++ b/specs/agents/universal-profiling-integration.md
@@ -31,6 +31,12 @@ The `thread_local` variables must be compiled with the `TLSDESC` model in order 
  * ARM64: `-ftls-model=global-dynamic -mtls-dialect=desc`
  * x86_64: `-ftls-model=global-dynamic -mtls-dialect=gnu2`
 
+The library file name MUST match the following regular expression to be picked up by the profiler:
+
+```regexp
+.*/elastic-jvmti-linux-([\w-]*)\.so
+```
+
 ## General Memory Layout
 
 The shared memory always uses the native endianess of the current platform for multi-byte numbers.


### PR DESCRIPTION
We use name matching on the profiling correlation library as a cheap way to avoid the need to check every single executable for the APM correlation ELF exports. The profiling agent already implements this, and the correlation library shipping with the Elastic Java OTel instrumentation distribution is already conforming. This PR only serves to include this detail in the specification.

<!--
Agent spec PR checklist

Delete all of this if the PR is not changing the agent spec.
Delete sections that don't apply to this PR.
If a specific checkbox doesn't apply, ~strike through~ and check it instead of deleting it.
-->

- [x] Create PR as draft
- [x] Approval by at least one other agent
- [x] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [x] Merge after 2 business days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.

