### PR TITLE
specs/agents: link to semconv host resource page for host.id reference

### DIFF
--- a/specs/agents/metadata.md
+++ b/specs/agents/metadata.md
@@ -79,7 +79,7 @@ use the new fields wherever applicable.
 #### Host.id
 
 APM agents MAY collect the `host.id` as an unique identifier for the host.
-If they collect it, it MUST be conformant to the [OpenTelemetry SemConv for `host.id`](https://opentelemetry.io/docs/specs/semconv/attributes-registry/host/).
+If they collect it, it MUST be conformant to the [OpenTelemetry SemConv for `host.id`](https://opentelemetry.io/docs/specs/semconv/resource/host/).
 
 If the APM agent performs correlation of its spans/transactions with universal profiling data, it MUST send the `host.id` (see the [profiling integration spec](universal-profiling-integration.md#profiler-registration-message)) as part of the metadata. The APM agent MAY solely rely on the `host.id` provided by the profiling host agent in that case.
 


### PR DESCRIPTION
This page contains an algorithm for filling the host.id value for non cloud environments that the current linked page is missing.