### PR TITLE
universal-profiling-integration: use utf8-buf for storing the utf8 bytes array

### DIFF
--- a/specs/agents/universal-profiling-integration.md
+++ b/specs/agents/universal-profiling-integration.md
@@ -43,10 +43,10 @@ The shared memory always uses the native endianess of the current platform for m
 Strings are always UTF-8 length encoded:
 ```
 ┌─────────────────┬──────────────────────────┐
-│ length : uint32 │ utf8-str : uint8[length] │
+│ length : uint32 │ utf8-buf : uint8[length] │
 └─────────────────┴──────────────────────────┘
 ```
-`utf8-str` is not null-terminated, the length is already defined by the `length` field.
+`utf8-buf` is not null-terminated, the length is already defined by the `length` field.
 In the remainder of the document the type `utf8-str` is used to denote the encoding shown above.
 
 ## Process Storage Layout


### PR DESCRIPTION
Disambiguate utf8-str meaning and only use it to refer to a string composed by the length and the array of bytes.