### PR TITLE
Define how APM agents store and perform profiling correlation

### DIFF
--- a/specs/agents/otel-distribution.md
+++ b/specs/agents/otel-distribution.md
@@ -78,4 +78,4 @@ Implementation is currently platform specific:
 
 Supported platforms: [Java](https://github.com/elastic/elastic-otel-java/tree/main/universal-profiling-integration)
 
-Configuration to enable: `ELASTIC_OTEL_UNIVERSAL_PROFILING_INTEGRATION_ENABLED`
+For the configuration options see [this section](universal-profiling-integration.md#configuration-options).


### PR DESCRIPTION
<!--
Agent spec PR checklist

Delete all of this if the PR is not changing the agent spec.
Delete sections that don't apply to this PR.
If a specific checkbox doesn't apply, ~strike through~ and check it instead of deleting it.
-->

This PR specifies how the profiling correlation messages received from the universal profiling host agent are used and stored on spans by APM agents.

<!--
Use this section if the spec requires changes in at most two agents.

Examples:
- Typos or clarifications without semantic changes
- Changes in a spec before it has been implemented
- Features that are only implemented in two agents
-->

- [x] Create PR as draft
- [x] Approval by at least one other agent
- [x] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [ ] Merge after 2 business days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.

