### PR TITLE
github-action: add dependabot for GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+---
+version: 2
+updates:
+	- package-ecosystem: "github-actions"
+	directories:
+		- "/"
+		- "/.github/actions/*"
+	schedule:
+		interval: "weekly"
+		day: "sunday"
+		time: "22:00"
+	groups:
+		github-actions:
+		patterns:
+			- "*"


### PR DESCRIPTION
## Details

⚠️ This PR was created by an automated tool. Please review the changes carefully. ⚠️ 

We want to enable the dependabot for GitHub actions.

## Why

We want to secure our dependencies and keep them up to date.

If there are any questions, please reach out to the @elastic/observablt-ci
