### PR TITLE
Update AWC ECS container id regex

### DIFF
--- a/specs/agents/metadata.md
+++ b/specs/agents/metadata.md
@@ -110,7 +110,7 @@ On Linux, the container ID and some of the Kubernetes metadata can be extracted 
 
     - `^[[:xdigit:]]{64}$`
     - `^[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4,}$`
-    - `^[[:xdigit:]]{32}-[[:digit:]]{9,10}$` (AWS ECS/Fargate environments)
+    - `^[[:xdigit:]]{32}-[[:digit:]]{1,10}$` (AWS ECS/Fargate environments)
 
  If we match, then the basename is assumed to be a container ID.
 

--- a/specs/agents/metadata.md
+++ b/specs/agents/metadata.md
@@ -110,7 +110,7 @@ On Linux, the container ID and some of the Kubernetes metadata can be extracted 
 
     - `^[[:xdigit:]]{64}$`
     - `^[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4,}$`
-    - `^[[:xdigit:]]{32}-[[:digit:]]{10}$` (AWS ECS/Fargate environments)
+    - `^[[:xdigit:]]{32}-[[:digit:]]{9,10}$` (AWS ECS/Fargate environments)
 
  If we match, then the basename is assumed to be a container ID.
 


### PR DESCRIPTION
We have new evidence that ID part may end in 1 to 10 digits not exactly 10 digits.

- [x] Create PR as draft
- [x] Approval by at least one other agent
- [x] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [ ] Merge after 2 business days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.
