### PR TITLE
Update team for meta issue automation

### DIFF
--- a/.github/workflows/apm-agent-meta-issue-action.yml
+++ b/.github/workflows/apm-agent-meta-issue-action.yml
@@ -26,7 +26,7 @@ jobs:
       id: checkUserMember
       with:
         username: ${{ github.actor }}
-        team: 'apm'
+        team: 'observability'
         usernamesToExclude: |
           apmmachine
         GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}


### PR DESCRIPTION
Our GH team structure changed, some agent devs (like me) are no longer members of the `apm` team.
Per slack discussion with @AlexanderWert we therefore decided to switch to the [observability](https://github.com/orgs/elastic/teams/observability) team instead.
