### PR TITLE
Replace ingest-otel-data with obs-signals-traces-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # Raising a PR against the agent spec folder will automatically request reviews from all agent teams
 # If the PR is not ready for review, create a draft PR instead
 # See also /.github/pull_request_template.md
-/specs/agents @elastic/ingest-otel-data @elastic/apm-agent-java @elastic/apm-agent-net @elastic/apm-agent-node-js @elastic/apm-agent-php @elastic/apm-agent-python @elastic/apm-agent-ruby @elastic/apm-agent-rum @elastic/apm-pm @elastic/apm-agent-ios @elastic/apm-agent-android
+/specs/agents @elastic/obs-signals-traces-team @elastic/apm-agent-java @elastic/apm-agent-net @elastic/apm-agent-node-js @elastic/apm-agent-php @elastic/apm-agent-python @elastic/apm-agent-ruby @elastic/apm-agent-rum @elastic/apm-pm @elastic/apm-agent-ios @elastic/apm-agent-android
 /specs/agents/mobile @elastic/apm-agent-ios @elastic/apm-agent-android
-/.github/pull_request_template.md @elastic/ingest-otel-data @elastic/apm-agent-java @elastic/apm-agent-net @elastic/apm-agent-node-js @elastic/apm-agent-php @elastic/apm-agent-python @elastic/apm-agent-ruby @elastic/apm-agent-rum @elastic/apm-pm
+/.github/pull_request_template.md @elastic/obs-signals-traces-team @elastic/apm-agent-java @elastic/apm-agent-net @elastic/apm-agent-node-js @elastic/apm-agent-php @elastic/apm-agent-python @elastic/apm-agent-ruby @elastic/apm-agent-rum @elastic/apm-pm


### PR DESCRIPTION
<!--
Agent spec PR checklist

Delete all of this if the PR is not changing the agent spec.
Delete sections that don't apply to this PR.
If a specific checkbox doesn't apply, ~strike through~ and check it instead of deleting it.
-->

This replaces [ingest-otel-data](https://github.com/orgs/elastic/teams/ingest-otel-data) with [obs-signals-traces-team](https://github.com/orgs/elastic/teams/obs-signals-traces-team)

cc. @sboomsma , @mariapoutachidou , @hegerchr 

<!--
Use this section if the spec requires changes in at most two agents.

Examples:
- Typos or clarifications without semantic changes
- Changes in a spec before it has been implemented
- Features that are only implemented in two agents
-->

- [x] Create PR as draft
- [x] Approval by at least one other agent
- [x] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [ ] Merge after 2 business days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.

<!--
Use this section if the spec requires changes in more than two agents.

This extended template ensures that we have a meta issue and tracking issues so that we don't forget about implementing the changes in all affected agents.
-->

- May the instrumentation collect sensitive information, such as secrets or PII (ex. in headers)?
  - [ ] Yes
    - [ ] Add a section to the spec how agents should apply sanitization (such as `sanitize_field_names`)
  - [ ] No
    - [ ] Why?
  - [ ] n/a
- [ ] Create PR as draft
- [ ] Approval by at least one other agent
- [ ] Mark as Ready for Review (automatically requests reviews from all agents and PM via [`CODEOWNERS`](https://github.com/elastic/apm/tree/main/.github/CODEOWNERS))
  - Remove PM from reviewers if impact on product is negligible
  - Remove agents from reviewers if the change is not relevant for them
- [ ] Approved by at least 2 agents + PM (if relevant)
- [ ] Merge after 7 days passed without objections \
      To auto-merge the PR, add <code>/</code>`schedule YYYY-MM-DD` to the PR description.
- [ ] [Create implementation issues through the meta issue template](https://github.com/elastic/apm/issues/new?assignees=&labels=meta%2C+apm-agents&template=apm-agents-meta.md) (this will automate issue creation for individual agents)
- [ ] If this spec adds a new dynamic config option, [add it to central config](https://github.com/elastic/apm/blob/main/specs/agents/configuration.md#adding-a-new-configuration-option).
